### PR TITLE
feat(history): implement HistoryService with SQLite persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6406,6 +6406,7 @@ name = "wellfeather"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "slint",
  "slint-build",
  "tempfile",
@@ -6474,6 +6475,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "wf-db",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -12,6 +12,7 @@ wf-completion      = { path = "../crates/wf-completion" }
 wf-history         = { path = "../crates/wf-history" }
 tokio              = { workspace = true }
 tokio-util         = { workspace = true }
+chrono             = { workspace = true }
 anyhow             = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -13,10 +13,14 @@
 //! Both channels are bounded (`capacity = 64`). The controller task exits cleanly
 //! when all `Sender<Command>` clones are dropped (i.e. when the UI window closes).
 
+use std::path::PathBuf;
+
+use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use wf_db::{error::DbError, models::DbConnection, service::DbService};
+use wf_history::service::HistoryService;
 
 use crate::{
     app::{command::Command, event::Event, session::SessionManager},
@@ -32,6 +36,10 @@ pub struct AppController {
     state: SharedState,
     db: DbService,
     session: SessionManager,
+    /// Path to `history.db`; opened asynchronously at the start of `run()`.
+    history_path: PathBuf,
+    /// `None` until `run()` opens the database; failures are non-fatal (logged).
+    history: Option<HistoryService>,
     rx_cmd: mpsc::Receiver<Command>,
     tx_event: mpsc::Sender<Event>,
 }
@@ -39,10 +47,14 @@ pub struct AppController {
 impl AppController {
     /// Create the controller and return it together with the two channel endpoints
     /// that `main.rs` distributes: `Sender<Command>` → UI, `Receiver<Event>` → UI.
+    ///
+    /// `history_path` is the filesystem path for `history.db`; the database is
+    /// opened (and the schema migrated) asynchronously at the start of [`Self::run`].
     pub fn new(
         state: SharedState,
         db: DbService,
         session: SessionManager,
+        history_path: PathBuf,
     ) -> (Self, mpsc::Sender<Command>, mpsc::Receiver<Event>) {
         let (tx_cmd, rx_cmd) = mpsc::channel(64);
         let (tx_event, rx_event) = mpsc::channel(64);
@@ -51,6 +63,8 @@ impl AppController {
                 state,
                 db,
                 session,
+                history_path,
+                history: None,
                 rx_cmd,
                 tx_event,
             },
@@ -62,6 +76,18 @@ impl AppController {
     /// Run the command loop as a tokio task (spawn with `tokio::spawn(controller.run())`).
     /// Exits when all `Sender<Command>` clones are dropped.
     pub async fn run(mut self) {
+        // Open history.db at startup — failure is non-fatal (queries still work).
+        self.history = match HistoryService::open(&self.history_path).await {
+            Ok(h) => {
+                info!("history.db opened at {:?}", self.history_path);
+                Some(h)
+            }
+            Err(e) => {
+                warn!("failed to open history.db: {e}");
+                None
+            }
+        };
+
         while let Some(cmd) = self.rx_cmd.recv().await {
             match cmd {
                 Command::Connect(conn, pw) => self.handle_connect(conn, pw).await,
@@ -177,15 +203,47 @@ impl AppController {
 
         let db = self.db.clone(); // clone required: tokio::spawn needs 'static
         let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
+        let history = self.history.clone(); // clone required: tokio::spawn needs 'static
+        let sql_hist = sql.clone(); // clone required: history record needs owned sql
+        let conn_id_hist = conn_id.clone(); // clone required: history record needs owned id
         tokio::spawn(async move {
+            let now = Utc::now().timestamp();
             match db.execute_with_cancel(&conn_id, &sql, token).await {
                 Ok(result) => {
+                    if let Some(ref h) = history {
+                        let exec = wf_db::models::QueryExecution {
+                            id: 0,
+                            sql: sql_hist,
+                            duration_ms: result.execution_time_ms,
+                            success: true,
+                            error_message: None,
+                            timestamp: now,
+                            connection_id: conn_id_hist,
+                        };
+                        if let Err(e) = h.insert(&exec).await {
+                            warn!("failed to save history: {e}");
+                        }
+                    }
                     let _ = tx.send(Event::QueryFinished(result)).await;
                 }
                 Err(DbError::Cancelled) => {
                     let _ = tx.send(Event::QueryCancelled).await;
                 }
                 Err(e) => {
+                    if let Some(ref h) = history {
+                        let exec = wf_db::models::QueryExecution {
+                            id: 0,
+                            sql: sql_hist,
+                            duration_ms: 0,
+                            success: false,
+                            error_message: Some(e.to_string()),
+                            timestamp: now,
+                            connection_id: conn_id_hist,
+                        };
+                        if let Err(he) = h.insert(&exec).await {
+                            warn!("failed to save history: {he}");
+                        }
+                    }
                     let _ = tx.send(Event::QueryError(e.to_string())).await;
                 }
             }
@@ -209,7 +267,7 @@ impl AppController {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{path::PathBuf, sync::Arc};
 
     use tempfile::tempdir;
     use wf_config::manager::ConfigManager;
@@ -233,6 +291,12 @@ mod tests {
         SessionManager::with_config_manager(ConfigManager::with_path(path))
     }
 
+    /// Return a path to a temporary `history.db` (file created lazily by the controller).
+    fn test_history_path() -> PathBuf {
+        let dir = tempdir().unwrap();
+        dir.keep().join("history.db")
+    }
+
     fn sqlite_conn(id: &str) -> DbConnection {
         DbConnection {
             id: id.to_string(),
@@ -254,7 +318,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd
             .send(Command::TestConnection(sqlite_conn("t1"), None))
@@ -275,7 +339,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         let bad = DbConnection {
             id: "tbad".to_string(),
@@ -309,7 +373,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd
             .send(Command::Connect(sqlite_conn("c1"), None))
@@ -329,7 +393,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         let bad = DbConnection {
             id: "bad".to_string(),
@@ -356,7 +420,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd
             .send(Command::Connect(sqlite_conn("c2"), None))
@@ -383,7 +447,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         // Connect first so there is an active connection.
         tx_cmd
@@ -411,7 +475,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd
             .send(Command::RunQuery("SELECT 1".to_string()))
@@ -430,7 +494,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd.send(Command::CancelQuery).await.unwrap();
         drop(tx_cmd);
@@ -446,7 +510,7 @@ mod tests {
         let state = Arc::new(AppState::new());
         let db = DbService::new();
         let (controller, tx_cmd, mut rx_event) =
-            AppController::new(state.clone(), db, test_session());
+            AppController::new(state.clone(), db, test_session(), test_history_path());
 
         tx_cmd
             .send(Command::Connect(sqlite_conn("c3"), None))

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -58,7 +58,12 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let (controller, tx_cmd, rx_event) = AppController::new(state.clone(), db, session);
+    let (controller, tx_cmd, rx_event) = AppController::new(
+        state.clone(),
+        db,
+        session,
+        ConfigManager::app_dir().join("history.db"),
+    );
     tokio::spawn(controller.run());
 
     // Send auto-connect before entering the event loop.

--- a/crates/wf-history/Cargo.toml
+++ b/crates/wf-history/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+wf-db     = { path = "../wf-db" }
 sqlx      = { workspace = true }
 tokio     = { workspace = true }
 anyhow    = { workspace = true }

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -1,1 +1,168 @@
-// HistoryService (SQLite persistence of QueryExecution) — implemented in T016
+use std::path::Path;
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
+use wf_db::models::QueryExecution;
+
+// ---------------------------------------------------------------------------
+// HistoryService
+// ---------------------------------------------------------------------------
+
+/// Persists [`QueryExecution`] records to a SQLite `history.db` file.
+///
+/// Cheap to clone — all clones share the same underlying connection pool.
+#[derive(Clone)]
+pub struct HistoryService {
+    pool: SqlitePool,
+}
+
+const CREATE_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS query_executions (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        sql           TEXT    NOT NULL,
+        duration_ms   INTEGER NOT NULL,
+        success       INTEGER NOT NULL,
+        error_message TEXT,
+        timestamp     INTEGER NOT NULL,
+        connection_id TEXT    NOT NULL
+    )";
+
+impl HistoryService {
+    /// Open (or create) the history database at `db_path` and run schema migrations.
+    ///
+    /// Creates the file if it does not exist.  Returns an error if the path is
+    /// not writable or if the migration query fails.
+    pub async fn open(db_path: &Path) -> Result<Self> {
+        let opts = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await?;
+        Self::migrate(&pool).await?;
+        Ok(Self { pool })
+    }
+
+    async fn migrate(pool: &SqlitePool) -> Result<()> {
+        sqlx::query(CREATE_TABLE).execute(pool).await?;
+        Ok(())
+    }
+
+    /// Persist one [`QueryExecution`] record.
+    ///
+    /// The `id` field is ignored — SQLite assigns the ROWID automatically.
+    pub async fn insert(&self, execution: &QueryExecution) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO query_executions
+             (sql, duration_ms, success, error_message, timestamp, connection_id)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&execution.sql)
+        .bind(execution.duration_ms as i64)
+        .bind(execution.success as i32)
+        .bind(&execution.error_message)
+        .bind(execution.timestamp)
+        .bind(&execution.connection_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return up to `limit` most recent executions, newest first (DESC timestamp).
+    pub async fn recent(&self, limit: usize) -> Result<Vec<QueryExecution>> {
+        let rows = sqlx::query(
+            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id
+             FROM query_executions
+             ORDER BY timestamp DESC
+             LIMIT ?",
+        )
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        use sqlx::Row as _;
+        let executions = rows
+            .iter()
+            .map(|row| QueryExecution {
+                id: row.get("id"),
+                sql: row.get("sql"),
+                duration_ms: row.get::<i64, _>("duration_ms") as u128,
+                success: row.get::<i32, _>("success") != 0,
+                error_message: row.get("error_message"),
+                timestamp: row.get("timestamp"),
+                connection_id: row.get("connection_id"),
+            })
+            .collect();
+
+        Ok(executions)
+    }
+
+    /// In-memory database variant for unit tests only.
+    #[cfg(test)]
+    async fn open_memory() -> Result<Self> {
+        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        Self::migrate(&pool).await?;
+        Ok(Self { pool })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_exec(sql: &str, ts: i64, success: bool, err: Option<&str>) -> QueryExecution {
+        QueryExecution {
+            id: 0,
+            sql: sql.to_string(),
+            duration_ms: 5,
+            success,
+            error_message: err.map(|s| s.to_string()),
+            timestamp: ts,
+            connection_id: "c1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_and_recent_should_roundtrip() {
+        let svc = HistoryService::open_memory().await.unwrap();
+
+        svc.insert(&make_exec("SELECT 1", 1000, true, None))
+            .await
+            .unwrap();
+        svc.insert(&make_exec("SELECT 2", 2000, false, Some("err")))
+            .await
+            .unwrap();
+
+        let rows = svc.recent(10).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        // DESC by timestamp → newest first
+        assert_eq!(rows[0].sql, "SELECT 2");
+        assert!(!rows[0].success);
+        assert_eq!(rows[0].error_message.as_deref(), Some("err"));
+        assert_eq!(rows[1].sql, "SELECT 1");
+        assert!(rows[1].success);
+        assert!(rows[1].error_message.is_none());
+    }
+
+    #[tokio::test]
+    async fn recent_should_respect_limit() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        for i in 0..5_i64 {
+            svc.insert(&make_exec(&format!("SELECT {i}"), i, true, None))
+                .await
+                .unwrap();
+        }
+        let rows = svc.recent(3).await.unwrap();
+        assert_eq!(rows.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn recent_should_return_empty_when_no_rows() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        let rows = svc.recent(10).await.unwrap();
+        assert!(rows.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements `HistoryService` in `crates/wf-history`, backed by a SQLite `history.db` file. Every query execution — both successful and failed — is persisted automatically after each run. The schema is created on first launch. This provides the data foundation for the planned query history UI in Phase 2.

## Changes

- `crates/wf-history/Cargo.toml`: added `wf-db` dependency to access `QueryExecution`
- `crates/wf-history/src/service.rs`: implemented `HistoryService` with `open` (file-backed, creates schema if missing), `insert`, and `recent` (returns N most recent rows DESC by timestamp); 3 unit tests using in-memory SQLite
- `app/Cargo.toml`: added `chrono` dependency for UTC timestamp generation
- `app/src/app/controller.rs`: added `history_path: PathBuf` and `history: Option<HistoryService>` fields; DB opened at start of `run()` (non-fatal on failure); `handle_run_query` spawned task records `QueryFinished` (success=true) and `QueryError` (success=false); `QueryCancelled` is not recorded
- `app/src/main.rs`: passes `ConfigManager::app_dir().join("history.db")` to `AppController::new`

## Related Issues

Closes #27

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes