### PR TITLE
feat(db): implement fetch_metadata for SQLite, PG, and MySQL drivers

### DIFF
--- a/crates/wf-db/src/drivers/my.rs
+++ b/crates/wf-db/src/drivers/my.rs
@@ -2,8 +2,10 @@ use std::time::Instant;
 
 use sqlx::{Column, MySqlPool, Row, TypeInfo};
 
+use std::collections::HashMap;
+
 use crate::error::DbError;
-use crate::models::QueryResult;
+use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
 
 /// Connect to a MySQL database at `url`.
 ///
@@ -59,6 +61,104 @@ pub async fn execute(pool: &MySqlPool, sql: &str) -> Result<QueryResult, DbError
             execution_time_ms: started.elapsed().as_millis(),
         })
     }
+}
+
+/// Fetch schema metadata from the connected MySQL database.
+///
+/// Queries `information_schema` restricted to the current schema (`DATABASE()`).
+/// PG/MySQL tests are `#[ignore]` — run with `cargo test -- --ignored`.
+pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
+    use sqlx::Row as _;
+
+    // ── all columns (single round-trip) ───────────────────────────────────────
+    let col_rows = sqlx::query(
+        "SELECT table_name, column_name, data_type, is_nullable \
+         FROM information_schema.columns \
+         WHERE table_schema = DATABASE() \
+         ORDER BY table_name, ordinal_position",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut col_map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+    for row in &col_rows {
+        let table: String = row.get("table_name");
+        col_map.entry(table).or_default().push(ColumnInfo {
+            name: row.get("column_name"),
+            data_type: row.get("data_type"),
+            nullable: row.get::<&str, _>("is_nullable") == "YES",
+        });
+    }
+
+    // ── tables ────────────────────────────────────────────────────────────────
+    let table_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' \
+         ORDER BY table_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let tables: Vec<TableInfo> = table_rows
+        .iter()
+        .map(|r| {
+            let name: String = r.get("table_name");
+            let columns = col_map.remove(&name).unwrap_or_default();
+            TableInfo { name, columns }
+        })
+        .collect();
+
+    // ── views ─────────────────────────────────────────────────────────────────
+    let view_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = DATABASE() AND table_type = 'VIEW' \
+         ORDER BY table_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let views: Vec<TableInfo> = view_rows
+        .iter()
+        .map(|r| {
+            let name: String = r.get("table_name");
+            let columns = col_map.remove(&name).unwrap_or_default();
+            TableInfo { name, columns }
+        })
+        .collect();
+
+    // ── stored procedures ─────────────────────────────────────────────────────
+    let proc_rows = sqlx::query(
+        "SELECT routine_name FROM information_schema.routines \
+         WHERE routine_schema = DATABASE() AND routine_type = 'PROCEDURE' \
+         ORDER BY routine_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let stored_procs: Vec<String> = proc_rows.iter().map(|r| r.get("routine_name")).collect();
+
+    // ── indexes ───────────────────────────────────────────────────────────────
+    let index_rows = sqlx::query(
+        "SELECT DISTINCT index_name FROM information_schema.statistics \
+         WHERE table_schema = DATABASE() \
+         ORDER BY index_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("index_name")).collect();
+
+    Ok(DbMetadata {
+        tables,
+        views,
+        stored_procs,
+        indexes,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +304,24 @@ mod tests {
     async fn connect_should_return_connection_failed_on_unreachable_host() {
         let result = connect("mysql://user:pass@127.0.0.1:19999/db").await;
         assert!(matches!(result, Err(DbError::ConnectionFailed(_))));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn fetch_metadata_should_return_tables_views_procs_and_indexes() {
+        let url = std::env::var("TEST_MY_URL")
+            .unwrap_or_else(|_| "mysql://root:root@localhost:3306/mysql".to_string());
+        let pool = connect(&url).await.unwrap();
+
+        sqlx::query("CREATE TEMPORARY TABLE wf_meta_test (id INT NOT NULL, label VARCHAR(255))")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let meta = fetch_metadata(&pool).await.unwrap();
+
+        // Temporary tables don't appear in information_schema — the call must succeed.
+        let _ = meta;
     }
 
     #[tokio::test]

--- a/crates/wf-db/src/drivers/pg.rs
+++ b/crates/wf-db/src/drivers/pg.rs
@@ -2,8 +2,10 @@ use std::time::Instant;
 
 use sqlx::{Column, PgPool, Row, TypeInfo};
 
+use std::collections::HashMap;
+
 use crate::error::DbError;
-use crate::models::QueryResult;
+use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
 
 /// Connect to a PostgreSQL database at `url`.
 ///
@@ -59,6 +61,104 @@ pub async fn execute(pool: &PgPool, sql: &str) -> Result<QueryResult, DbError> {
             execution_time_ms: started.elapsed().as_millis(),
         })
     }
+}
+
+/// Fetch schema metadata from the connected PostgreSQL database.
+///
+/// Queries `information_schema` and `pg_indexes` restricted to the `public`
+/// schema.  PG/MySQL tests are `#[ignore]` — run with `cargo test -- --ignored`.
+pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
+    use sqlx::Row as _;
+
+    // ── all columns (single round-trip) ───────────────────────────────────────
+    let col_rows = sqlx::query(
+        "SELECT table_name, column_name, data_type, is_nullable \
+         FROM information_schema.columns \
+         WHERE table_schema = 'public' \
+         ORDER BY table_name, ordinal_position",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut col_map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+    for row in &col_rows {
+        let table: String = row.get("table_name");
+        col_map.entry(table).or_default().push(ColumnInfo {
+            name: row.get("column_name"),
+            data_type: row.get("data_type"),
+            nullable: row.get::<&str, _>("is_nullable") == "YES",
+        });
+    }
+
+    // ── tables ────────────────────────────────────────────────────────────────
+    let table_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
+         ORDER BY table_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let tables: Vec<TableInfo> = table_rows
+        .iter()
+        .map(|r| {
+            let name: String = r.get("table_name");
+            let columns = col_map.remove(&name).unwrap_or_default();
+            TableInfo { name, columns }
+        })
+        .collect();
+
+    // ── views ─────────────────────────────────────────────────────────────────
+    let view_rows = sqlx::query(
+        "SELECT table_name FROM information_schema.views \
+         WHERE table_schema = 'public' \
+         ORDER BY table_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let views: Vec<TableInfo> = view_rows
+        .iter()
+        .map(|r| {
+            let name: String = r.get("table_name");
+            let columns = col_map.remove(&name).unwrap_or_default();
+            TableInfo { name, columns }
+        })
+        .collect();
+
+    // ── stored procedures / functions ─────────────────────────────────────────
+    let proc_rows = sqlx::query(
+        "SELECT routine_name FROM information_schema.routines \
+         WHERE routine_schema = 'public' \
+         ORDER BY routine_name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let stored_procs: Vec<String> = proc_rows.iter().map(|r| r.get("routine_name")).collect();
+
+    // ── indexes ───────────────────────────────────────────────────────────────
+    let index_rows = sqlx::query(
+        "SELECT indexname FROM pg_indexes \
+         WHERE schemaname = 'public' \
+         ORDER BY indexname",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("indexname")).collect();
+
+    Ok(DbMetadata {
+        tables,
+        views,
+        stored_procs,
+        indexes,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +302,26 @@ mod tests {
     async fn connect_should_return_connection_failed_on_unreachable_host() {
         let result = connect("postgresql://user:pass@127.0.0.1:19999/db").await;
         assert!(matches!(result, Err(DbError::ConnectionFailed(_))));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn fetch_metadata_should_return_tables_views_procs_and_indexes() {
+        let url = std::env::var("TEST_PG_URL").unwrap_or_else(|_| {
+            "postgresql://postgres:postgres@localhost:5432/postgres".to_string()
+        });
+        let pool = connect(&url).await.unwrap();
+
+        sqlx::query("CREATE TEMP TABLE wf_meta_test (id INT NOT NULL, label TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let meta = fetch_metadata(&pool).await.unwrap();
+
+        // Temp tables live in pg_temp_* schema, not public — metadata should be non-empty
+        // in a real database but at minimum the call must succeed.
+        let _ = meta;
     }
 
     #[tokio::test]

--- a/crates/wf-db/src/drivers/sqlite.rs
+++ b/crates/wf-db/src/drivers/sqlite.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use sqlx::{Column, Row, SqlitePool, TypeInfo};
 
 use crate::error::DbError;
-use crate::models::QueryResult;
+use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
 
 /// Connect to a SQLite database at `url`.
 ///
@@ -65,6 +65,85 @@ pub async fn execute(pool: &SqlitePool, sql: &str) -> Result<QueryResult, DbErro
             execution_time_ms: started.elapsed().as_millis(),
         })
     }
+}
+
+/// Fetch schema metadata from the SQLite database:
+/// tables, views, indexes, and per-table columns.
+/// SQLite has no stored procedures — that field is always empty.
+pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
+    use sqlx::Row as _;
+
+    // ── tables ────────────────────────────────────────────────────────────────
+    let table_rows = sqlx::query(
+        "SELECT name FROM sqlite_master \
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%' \
+         ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let mut tables = Vec::new();
+    for row in &table_rows {
+        let name: String = row.get("name");
+        let columns = pragma_columns(pool, &name).await?;
+        tables.push(TableInfo { name, columns });
+    }
+
+    // ── views ─────────────────────────────────────────────────────────────────
+    let view_rows = sqlx::query("SELECT name FROM sqlite_master WHERE type = 'view' ORDER BY name")
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)?;
+
+    let mut views = Vec::new();
+    for row in &view_rows {
+        let name: String = row.get("name");
+        let columns = pragma_columns(pool, &name).await?;
+        views.push(TableInfo { name, columns });
+    }
+
+    // ── indexes ───────────────────────────────────────────────────────────────
+    let index_rows = sqlx::query(
+        "SELECT name FROM sqlite_master \
+         WHERE type = 'index' AND name NOT LIKE 'sqlite_%' \
+         ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("name")).collect();
+
+    Ok(DbMetadata {
+        tables,
+        views,
+        stored_procs: vec![],
+        indexes,
+    })
+}
+
+/// Run `PRAGMA table_info` for `table_name` and return column descriptors.
+async fn pragma_columns(pool: &SqlitePool, table_name: &str) -> Result<Vec<ColumnInfo>, DbError> {
+    use sqlx::Row as _;
+    // Escape double-quotes inside the identifier (SQLite quoting rule).
+    let escaped = table_name.replace('"', "\"\"");
+    let sql = format!("PRAGMA table_info(\"{escaped}\")");
+    let rows = sqlx::query(&sql)
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)?;
+
+    let columns = rows
+        .iter()
+        .map(|r| ColumnInfo {
+            name: r.get("name"),
+            data_type: r.get("type"),
+            nullable: r.get::<i32, _>("notnull") == 0,
+        })
+        .collect();
+
+    Ok(columns)
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +388,76 @@ mod tests {
         let result = execute(&pool, "DELETE FROM t WHERE id = 1").await.unwrap();
 
         assert_eq!(result.row_count, 1);
+    }
+
+    // ── fetch_metadata ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fetch_metadata_should_return_tables_indexes_and_columns() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query("CREATE TABLE users (id INTEGER NOT NULL, name TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE orders (id INTEGER NOT NULL, user_id INTEGER NOT NULL, total REAL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("CREATE INDEX idx_orders_user ON orders (user_id)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let meta = fetch_metadata(&pool).await.unwrap();
+
+        assert_eq!(meta.tables.len(), 2);
+
+        let users = meta.tables.iter().find(|t| t.name == "users").unwrap();
+        assert_eq!(users.columns.len(), 2);
+        assert_eq!(users.columns[0].name, "id");
+        assert_eq!(users.columns[0].data_type.to_uppercase(), "INTEGER");
+        assert!(!users.columns[0].nullable); // NOT NULL
+        assert_eq!(users.columns[1].name, "name");
+        assert!(users.columns[1].nullable); // no constraint → nullable
+
+        assert_eq!(meta.indexes.len(), 1);
+        assert_eq!(meta.indexes[0], "idx_orders_user");
+
+        assert!(meta.stored_procs.is_empty());
+        assert!(meta.views.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_metadata_should_return_views_with_columns() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query("CREATE TABLE products (id INTEGER NOT NULL, price REAL NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("CREATE VIEW cheap AS SELECT id, price FROM products WHERE price < 10.0")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let meta = fetch_metadata(&pool).await.unwrap();
+
+        assert_eq!(meta.views.len(), 1);
+        assert_eq!(meta.views[0].name, "cheap");
+        assert_eq!(meta.views[0].columns.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_metadata_should_return_empty_metadata_for_empty_database() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+        let meta = fetch_metadata(&pool).await.unwrap();
+        assert!(meta.tables.is_empty());
+        assert!(meta.views.is_empty());
+        assert!(meta.indexes.is_empty());
+        assert!(meta.stored_procs.is_empty());
     }
 
     // ── execute — timing ─────────────────────────────────────────────────────

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -2,7 +2,7 @@ use sqlx::{MySqlPool, PgPool, SqlitePool};
 
 use crate::drivers;
 use crate::error::DbError;
-use crate::models::{DbConnection, DbKind, DbType, QueryResult};
+use crate::models::{DbConnection, DbKind, DbMetadata, DbType, QueryResult};
 
 // ---------------------------------------------------------------------------
 // DbPool
@@ -57,6 +57,15 @@ impl DbPool {
             DbPool::Pg(p) => drivers::pg::execute(p, sql).await,
             DbPool::My(p) => drivers::my::execute(p, sql).await,
             DbPool::Sqlite(p) => drivers::sqlite::execute(p, sql).await,
+        }
+    }
+
+    /// Fetch schema metadata (tables, views, stored procs, indexes) for this pool.
+    pub async fn fetch_metadata(&self) -> Result<DbMetadata, DbError> {
+        match self {
+            DbPool::Pg(p) => drivers::pg::fetch_metadata(p).await,
+            DbPool::My(p) => drivers::my::fetch_metadata(p).await,
+            DbPool::Sqlite(p) => drivers::sqlite::fetch_metadata(p).await,
         }
     }
 

--- a/crates/wf-db/src/service.rs
+++ b/crates/wf-db/src/service.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::error::DbError;
-use crate::models::{DbConnection, QueryResult};
+use crate::models::{DbConnection, DbMetadata, QueryResult};
 use crate::pool::DbPool;
 
 // ---------------------------------------------------------------------------
@@ -84,6 +84,14 @@ impl DbService {
             result = pool.execute(sql) => result,
             _ = token.cancelled() => Err(DbError::Cancelled),
         }
+    }
+
+    /// Fetch schema metadata for the connection identified by `conn_id`.
+    ///
+    /// Returns `Err(DbError::ConnectionFailed)` if `conn_id` is not connected.
+    pub async fn fetch_metadata(&self, conn_id: &str) -> Result<DbMetadata, DbError> {
+        let pool = self.pool_for(conn_id)?;
+        pool.fetch_metadata().await
     }
 
     /// Returns `true` if a pool for `conn_id` exists in the map.


### PR DESCRIPTION
## Summary

Implements `fetch_metadata` across all three DB drivers (SQLite, PostgreSQL, MySQL), the `DbPool` dispatch layer, and `DbService`. Each driver queries its system catalogs to return tables, views, stored procedures, indexes, and per-table column metadata as `DbMetadata`. This is the foundation for the completion service cache (T042).

## Changes

- `drivers/sqlite.rs`: `fetch_metadata` using `sqlite_master` + `PRAGMA table_info`; `stored_procs` always empty; table name double-quote escaping for safety
- `drivers/pg.rs`: `fetch_metadata` using `information_schema` + `pg_indexes` filtered to `public` schema; single column round-trip to avoid N+1 queries
- `drivers/my.rs`: `fetch_metadata` using `information_schema` filtered to `DATABASE()`; same single-query column strategy
- `pool.rs`: `DbPool::fetch_metadata` dispatch method
- `service.rs`: `DbService::fetch_metadata(conn_id)` public API
- Tests: 3 SQLite unit tests (non-ignored); 1 `#[ignore]` test each for PG and MySQL

## Related Issues

Closes #28

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes