### PR TITLE
feat(completion): implement MetadataCache with memory and SQLite persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6427,11 +6427,15 @@ name = "wf-completion"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "serde",
+ "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
+ "wf-db",
 ]
 
 [[package]]

--- a/crates/wf-completion/Cargo.toml
+++ b/crates/wf-completion/Cargo.toml
@@ -11,9 +11,15 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-tokio     = { workspace = true }
+wf-db      = { path = "../wf-db" }
+tokio      = { workspace = true }
 tokio-util = { workspace = true }
-sqlx      = { workspace = true }
-anyhow    = { workspace = true }
-thiserror = { workspace = true }
-tracing   = { workspace = true }
+sqlx       = { workspace = true }
+serde      = { workspace = true }
+serde_json = "1.0.149"
+anyhow     = { workspace = true }
+thiserror  = { workspace = true }
+tracing    = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/wf-completion/src/cache.rs
+++ b/crates/wf-completion/src/cache.rs
@@ -1,1 +1,220 @@
-// MetadataCache (in-memory + SQLite flush) — implemented in T041/T062
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
+use wf_db::models::DbMetadata;
+
+// ---------------------------------------------------------------------------
+// MetadataCache
+// ---------------------------------------------------------------------------
+
+/// In-memory metadata cache with SQLite persistence.
+///
+/// Memory is the primary store; SQLite is used for across-session durability.
+/// `new()` is synchronous — the SQLite file is opened lazily on first use.
+pub struct MetadataCache {
+    memory: RwLock<HashMap<String, DbMetadata>>,
+    db_path: PathBuf,
+}
+
+impl MetadataCache {
+    /// Create a cache backed by the SQLite file at `db_path`.
+    /// The file is created on first write if it does not exist.
+    pub fn new(db_path: PathBuf) -> Self {
+        Self {
+            memory: RwLock::new(HashMap::new()),
+            db_path,
+        }
+    }
+
+    /// Persist `meta` for `conn_id`: write to memory then flush to SQLite.
+    pub async fn store(&self, conn_id: &str, meta: DbMetadata) -> Result<()> {
+        self.memory
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(conn_id.to_string(), meta.clone());
+
+        let pool = self.open_pool().await?;
+        let json = serde_json::to_vec(&meta)?;
+        sqlx::query("INSERT OR REPLACE INTO metadata_cache (conn_id, data) VALUES (?, ?)")
+            .bind(conn_id)
+            .bind(json.as_slice())
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Return cached metadata for `conn_id`.
+    ///
+    /// Returns the in-memory value if present; otherwise queries SQLite and
+    /// populates the memory cache before returning.
+    pub async fn load(&self, conn_id: &str) -> Option<DbMetadata> {
+        if let Some(m) = self
+            .memory
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(conn_id)
+            .cloned()
+        {
+            return Some(m);
+        }
+
+        let pool = self.open_pool().await.ok()?;
+        use sqlx::Row as _;
+        let row = sqlx::query("SELECT data FROM metadata_cache WHERE conn_id = ?")
+            .bind(conn_id)
+            .fetch_optional(&pool)
+            .await
+            .ok()??;
+
+        let data: Vec<u8> = row.get("data");
+        let meta: DbMetadata = serde_json::from_slice(&data).ok()?;
+        self.memory
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(conn_id.to_string(), meta.clone());
+        Some(meta)
+    }
+
+    /// Populate the in-memory cache from SQLite.  Call once at startup.
+    ///
+    /// Non-fatal: if the database file cannot be opened (e.g. first run), a
+    /// warning is logged and `Ok(())` is returned.
+    pub async fn preload_from_disk(&self) -> Result<()> {
+        let pool = match self.open_pool().await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("metadata cache not available: {e}");
+                return Ok(());
+            }
+        };
+
+        use sqlx::Row as _;
+        let rows = sqlx::query("SELECT conn_id, data FROM metadata_cache")
+            .fetch_all(&pool)
+            .await?;
+
+        let mut guard = self.memory.write().unwrap_or_else(|p| p.into_inner());
+        for row in &rows {
+            let conn_id: String = row.get("conn_id");
+            let data: Vec<u8> = row.get("data");
+            if let Ok(meta) = serde_json::from_slice::<DbMetadata>(&data) {
+                guard.insert(conn_id, meta);
+            }
+        }
+        Ok(())
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    async fn open_pool(&self) -> Result<SqlitePool> {
+        let opts = SqliteConnectOptions::new()
+            .filename(&self.db_path)
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS metadata_cache (
+                 conn_id TEXT PRIMARY KEY,
+                 data    BLOB NOT NULL
+             )",
+        )
+        .execute(&pool)
+        .await?;
+        Ok(pool)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wf_db::models::{ColumnInfo, TableInfo};
+
+    fn make_meta(table: &str) -> DbMetadata {
+        DbMetadata {
+            tables: vec![TableInfo {
+                name: table.to_string(),
+                columns: vec![
+                    ColumnInfo {
+                        name: "id".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                    },
+                    ColumnInfo {
+                        name: "name".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: true,
+                    },
+                ],
+            }],
+            views: vec![],
+            stored_procs: vec![],
+            indexes: vec!["idx_id".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn store_and_load_should_roundtrip_via_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("metadata.db"));
+        let meta = make_meta("users");
+
+        cache.store("conn-1", meta.clone()).await.unwrap();
+        let loaded = cache.load("conn-1").await.unwrap();
+
+        assert_eq!(loaded.tables.len(), 1);
+        assert_eq!(loaded.tables[0].name, "users");
+        assert_eq!(loaded.tables[0].columns.len(), 2);
+        assert_eq!(loaded.indexes[0], "idx_id");
+    }
+
+    #[tokio::test]
+    async fn load_should_fall_back_to_sqlite_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metadata.db");
+
+        // Instance A — store
+        let cache_a = MetadataCache::new(path.clone());
+        cache_a.store("conn-1", make_meta("orders")).await.unwrap();
+
+        // Instance B — fresh memory, same file
+        let cache_b = MetadataCache::new(path);
+        let loaded = cache_b.load("conn-1").await.unwrap();
+
+        assert_eq!(loaded.tables[0].name, "orders");
+    }
+
+    #[tokio::test]
+    async fn preload_from_disk_should_populate_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metadata.db");
+
+        let cache_a = MetadataCache::new(path.clone());
+        cache_a
+            .store("conn-1", make_meta("products"))
+            .await
+            .unwrap();
+
+        let cache_b = MetadataCache::new(path);
+        cache_b.preload_from_disk().await.unwrap();
+
+        // After preload, memory should have the entry — verify by checking
+        // that a subsequent load returns without hitting SQLite (same result).
+        let loaded = cache_b.load("conn-1").await.unwrap();
+        assert_eq!(loaded.tables[0].name, "products");
+    }
+
+    #[tokio::test]
+    async fn load_should_return_none_for_unknown_conn_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("metadata.db"));
+        let result = cache.load("does-not-exist").await;
+        assert!(result.is_none());
+    }
+}

--- a/crates/wf-db/src/models.rs
+++ b/crates/wf-db/src/models.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 // ---------------------------------------------------------------------------
 // DbType / DbKind
 // ---------------------------------------------------------------------------
@@ -86,7 +88,7 @@ pub struct QueryExecution {
 // ---------------------------------------------------------------------------
 
 /// Schema metadata for a single column.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ColumnInfo {
     pub name: String,
     pub data_type: String,
@@ -94,7 +96,7 @@ pub struct ColumnInfo {
 }
 
 /// Schema metadata for a table or view.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableInfo {
     pub name: String,
     pub columns: Vec<ColumnInfo>,
@@ -102,7 +104,7 @@ pub struct TableInfo {
 
 /// All schema objects retrieved from a connected database.
 /// Populated by `DbService::fetch_metadata` and cached in `MetadataCache`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DbMetadata {
     pub tables: Vec<TableInfo>,
     pub views: Vec<TableInfo>,


### PR DESCRIPTION
## Summary

Implements `MetadataCache` in `crates/wf-completion/src/cache.rs` as specified in T042. The cache stores `DbMetadata` in memory keyed by connection ID, flushes to a `metadata.db` SQLite file for across-session durability, and supports bulk preloading at startup. This is the foundation the completion engine will build on.

## Changes

- `wf-db/src/models.rs`: added `Serialize + Deserialize` derives to `ColumnInfo`, `TableInfo`, and `DbMetadata` (required for serde_json persistence)
- `wf-completion/Cargo.toml`: added `wf-db`, `serde`, `serde_json` dependencies and `tempfile` dev-dependency
- `wf-completion/src/cache.rs`: full `MetadataCache` implementation
  - `new(db_path)`: sync constructor, lazy SQLite open
  - `store(conn_id, meta)`: writes to memory, flushes to SQLite via `INSERT OR REPLACE`
  - `load(conn_id)`: memory-first, SQLite fallback with automatic memory population
  - `preload_from_disk()`: bulk-loads all SQLite rows into memory at startup; non-fatal on missing file
  - 4 unit tests covering roundtrip, restart-fallback, preload, and missing-key cases

## Related Issues

Closes #29

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes