### PR TITLE
feat(sidebar): collapsible three-level schema tree (T044)

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -157,7 +157,7 @@ impl AppController {
                             {
                                 warn!(conn_id = %fetch_id, error = %e, "failed to store metadata");
                             }
-                            let _ = tx.send(Event::MetadataLoaded(meta)).await;
+                            let _ = tx.send(Event::MetadataLoaded(fetch_id.clone(), meta)).await;
                         }
                         Err(e) => {
                             warn!(conn_id = %fetch_id, error = %e, "metadata fetch failed");
@@ -507,7 +507,7 @@ mod tests {
         // Drain any MetadataLoaded/MetadataFetchFailed from the background fetch.
         let e2 = loop {
             match rx_event.recv().await.unwrap() {
-                Event::MetadataLoaded(_) | Event::MetadataFetchFailed(_) => continue,
+                Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => continue,
                 e => break e,
             }
         };
@@ -546,7 +546,7 @@ mod tests {
         // Drain any MetadataLoaded/MetadataFetchFailed before QueryStarted.
         let e2 = loop {
             match rx_event.recv().await.unwrap() {
-                Event::MetadataLoaded(_) | Event::MetadataFetchFailed(_) => continue,
+                Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => continue,
                 e => break e,
             }
         };
@@ -624,7 +624,10 @@ mod tests {
         assert!(matches!(e1, Event::Connected(_)));
         let e2 = rx_event.recv().await.unwrap();
         assert!(
-            matches!(e2, Event::MetadataLoaded(_) | Event::MetadataFetchFailed(_)),
+            matches!(
+                e2,
+                Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_)
+            ),
             "expected MetadataLoaded or MetadataFetchFailed, got {e2:?}"
         );
     }
@@ -658,7 +661,7 @@ mod tests {
         while connected_count < 2 {
             match rx_event.recv().await.unwrap() {
                 Event::Connected(_) => connected_count += 1,
-                Event::MetadataLoaded(_) | Event::MetadataFetchFailed(_) => {}
+                Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => {}
                 _ => {}
             }
         }

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -29,7 +29,7 @@ pub enum Event {
     /// Fired when `Command::TestConnection` fails; carries the error message.
     TestConnectionFailed(String),
     CompletionReady(Vec<CompletionItem>),
-    MetadataLoaded(DbMetadata),
+    MetadataLoaded(String, DbMetadata), // conn_id, metadata
     MetadataFetchFailed(String),
     ConfigUpdated,
     StateChanged(StateEvent),

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -1,4 +1,4 @@
-import { ConnectionEntry, RowData } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode } from "globals.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
 import { Sidebar }         from "components/sidebar.slint";
 import { Editor }          from "components/editor.slint";
@@ -43,6 +43,7 @@ export global UiState {
     // ── Connection list (sidebar) ─────────────────────────────────────────────
     in-out property <[ConnectionEntry]> connection-list:      [];
     in-out property <string>            active-connection-id: "";
+    in-out property <[SidebarNode]>     sidebar-tree:         [];
 
     // ── Connection form state ─────────────────────────────────────────────────
     in-out property <bool>   show-connection-form: false;
@@ -86,8 +87,10 @@ export global UiState {
     callback close-connection-form();
     /// Sends Command::TestConnection — verifies the connection without saving it.
     callback test-connection();
-    /// Re-connects an existing saved connection by id.
-    callback switch-connection(string);
+    /// Sidebar node click: expand/collapse + switch active connection for level-0 nodes.
+    callback toggle-sidebar-node(string);
+    /// Table/view item double-click; carries the item name (T045).
+    callback table-double-clicked(string);
     /// "Add" button: persists the connection if test passed, else shows confirm popup.
     callback add-connection();
     /// "Yes" in the add-without-test confirm popup.
@@ -132,8 +135,10 @@ export component AppWindow inherits Window {
         y: 0;
         width:  sidebar-width;
         height: content-height;
-        connections: UiState.connection-list;
-        switch-connection(id) => { UiState.switch-connection(id); }
+        tree:       UiState.sidebar-tree;
+        is-loading: UiState.sidebar-loading;
+        toggle-node(id) => { UiState.toggle-sidebar-node(id); }
+        table-double-clicked(name) => { UiState.table-double-clicked(name); }
         add-connection => { UiState.open-connection-form(); }
     }
 

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -1,42 +1,94 @@
-import { ConnectionEntry } from "../globals.slint";
+import { SidebarNode } from "../globals.slint";
 
 export component Sidebar inherits Rectangle {
     background: #1e1e2e;
 
-    in property <[ConnectionEntry]> connections: [];
-    callback switch-connection(string);
+    in property <[SidebarNode]> tree: [];
+    in property <bool> is-loading: false;
+    callback toggle-node(string);
+    callback table-double-clicked(string);
     callback add-connection();
 
     VerticalLayout {
-        // ── Connection list ───────────────────────────────────────────────────
-        for conn in root.connections: Rectangle {
-            height: 36px;
-            background: conn.is-active ? #313244 : transparent;
+        // ── Schema tree ───────────────────────────────────────────────────────
+        for node in root.tree : Rectangle {
+            height: 32px;
+            clip: true;
+
+            background: node.is-active && node.level == 0 ? #313244 : transparent;
+
+            ta := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                clicked => { root.toggle-node(node.id); }
+                double-clicked => {
+                    if node.node-kind == "table" || node.node-kind == "view" {
+                        root.table-double-clicked(node.label);
+                    }
+                }
+            }
+
+            // Hover overlay (skipped for the active connection row)
+            Rectangle {
+                background: ta.has-hover && !(node.is-active && node.level == 0)
+                    ? #ffffff0d : transparent;
+                width: parent.width;
+                height: parent.height;
+            }
 
             HorizontalLayout {
-                padding-left: 12px;
+                x: 0; y: 0;
+                width: parent.width;
+                height: parent.height;
+                padding-left: (8 + node.level * 14) * 1px;
                 padding-right: 8px;
-                spacing: 6px;
+                spacing: 4px;
+
+                // Expand/collapse toggle icon for connection and category nodes
+                if node.level < 2 : Text {
+                    text: node.is-expanded ? "▼" : "▶";
+                    color: #585b70;
+                    font-size: 9px;
+                    vertical-alignment: center;
+                    width: 14px;
+                }
+                // Spacer for item nodes
+                if node.level >= 2 : Rectangle { width: 14px; }
+
+                // Main label
                 Text {
-                    text: conn.name;
-                    color: conn.is-active ? #cdd6f4 : #a6adc8;
+                    text: node.label;
+                    color: node.level == 0
+                        ? (node.is-active ? #cdd6f4 : #bac2de)
+                        : (node.level == 1 ? #7f849c : #a6adc8);
+                    font-size: node.level == 0 ? 13px : 12px;
                     vertical-alignment: center;
                     overflow: elide;
                     horizontal-stretch: 1;
                 }
-                Text {
-                    text: conn.db-type;
+
+                // Sub-label badge (db-type for connection nodes)
+                if node.sub-label != "" : Text {
+                    text: node.sub-label;
                     color: #585b70;
-                    font-size: 11px;
+                    font-size: 10px;
                     vertical-alignment: center;
                 }
             }
+        }
 
-            // Click area on top to intercept pointer events
-            TouchArea {
-                width: parent.width;
-                height: parent.height;
-                clicked => { root.switch-connection(conn.id); }
+        // ── Metadata loading indicator ────────────────────────────────────────
+        if root.is-loading : Rectangle {
+            height: 28px;
+            HorizontalLayout {
+                padding-left: 24px;
+                Text {
+                    text: @tr("Loading\u{2026}");
+                    color: #585b70;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                    font-italic: true;
+                }
             }
         }
 

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -12,3 +12,13 @@ export struct ConnectionEntry {
 export struct RowData {
     cells: [string],
 }
+
+export struct SidebarNode {
+    id: string,         // "conn:{id}" | "cat:{id}:{name}" | "item:{id}:{kind}:{name}"
+    label: string,
+    sub-label: string,  // db-type badge for connections; "" otherwise
+    level: int,         // 0=connection, 1=category, 2=item
+    is-expanded: bool,
+    is-active: bool,    // true for the active connection (level 0 only)
+    node-kind: string,  // "connection" | "category" | "table" | "view" | "proc" | "index"
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1,18 +1,156 @@
 #![allow(dead_code)]
 
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use slint::ComponentHandle;
 use slint::Model as _;
 use tokio::sync::mpsc;
 use wf_config::crypto;
-use wf_db::models::{DbConnection, DbType};
+use wf_db::models::{DbConnection, DbMetadata, DbType, TableInfo};
 
 use crate::{
     app::{command::Command, event::Event},
     state::SharedState,
 };
+
+// ---------------------------------------------------------------------------
+// Sidebar tree state
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct SidebarUiState {
+    metadata: HashMap<String, DbMetadata>,
+    expanded: HashSet<String>,
+}
+
+fn build_sidebar_tree(
+    connections: &[DbConnection],
+    active_id: &str,
+    metadata: &HashMap<String, DbMetadata>,
+    expanded: &HashSet<String>,
+) -> Vec<crate::SidebarNode> {
+    let mut nodes = vec![];
+    for conn in connections {
+        let conn_node_id = format!("conn:{}", conn.id);
+        let is_conn_expanded = expanded.contains(&conn_node_id);
+        nodes.push(crate::SidebarNode {
+            id: conn_node_id.clone().into(),
+            label: conn.name.clone().into(),
+            sub_label: db_type_label(&conn.db_type).into(),
+            level: 0,
+            is_expanded: is_conn_expanded,
+            is_active: conn.id == active_id,
+            node_kind: "connection".into(),
+        });
+        if !is_conn_expanded {
+            continue;
+        }
+        let Some(meta) = metadata.get(&conn.id) else {
+            continue;
+        };
+        push_tableinfo_category(
+            &mut nodes,
+            &conn.id,
+            "Tables",
+            &meta.tables,
+            "table",
+            expanded,
+        );
+        push_tableinfo_category(&mut nodes, &conn.id, "Views", &meta.views, "view", expanded);
+        push_string_category(
+            &mut nodes,
+            &conn.id,
+            "Stored Procedures",
+            &meta.stored_procs,
+            "proc",
+            expanded,
+        );
+        push_string_category(
+            &mut nodes,
+            &conn.id,
+            "Indexes",
+            &meta.indexes,
+            "index",
+            expanded,
+        );
+    }
+    nodes
+}
+
+fn push_tableinfo_category(
+    nodes: &mut Vec<crate::SidebarNode>,
+    conn_id: &str,
+    name: &str,
+    items: &[TableInfo],
+    kind: &str,
+    expanded: &HashSet<String>,
+) {
+    let cat_id = format!("cat:{}:{}", conn_id, name);
+    let is_exp = expanded.contains(&cat_id);
+    nodes.push(crate::SidebarNode {
+        id: cat_id.into(),
+        label: name.into(),
+        sub_label: "".into(),
+        level: 1,
+        is_expanded: is_exp,
+        is_active: false,
+        node_kind: "category".into(),
+    });
+    if is_exp {
+        for item in items {
+            nodes.push(crate::SidebarNode {
+                id: format!("item:{}:{}:{}", conn_id, kind, item.name).into(),
+                label: item.name.clone().into(),
+                sub_label: "".into(),
+                level: 2,
+                is_expanded: false,
+                is_active: false,
+                node_kind: kind.into(),
+            });
+        }
+    }
+}
+
+fn push_string_category(
+    nodes: &mut Vec<crate::SidebarNode>,
+    conn_id: &str,
+    name: &str,
+    items: &[String],
+    kind: &str,
+    expanded: &HashSet<String>,
+) {
+    let cat_id = format!("cat:{}:{}", conn_id, name);
+    let is_exp = expanded.contains(&cat_id);
+    nodes.push(crate::SidebarNode {
+        id: cat_id.into(),
+        label: name.into(),
+        sub_label: "".into(),
+        level: 1,
+        is_expanded: is_exp,
+        is_active: false,
+        node_kind: "category".into(),
+    });
+    if is_exp {
+        for item in items {
+            nodes.push(crate::SidebarNode {
+                id: format!("item:{}:{}:{}", conn_id, kind, item).into(),
+                label: item.clone().into(),
+                sub_label: "".into(),
+                level: 2,
+                is_expanded: false,
+                is_active: false,
+                node_kind: kind.into(),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UI
+// ---------------------------------------------------------------------------
 
 pub struct UI {
     window: crate::AppWindow,
@@ -27,12 +165,20 @@ impl UI {
     ) -> Result<Self> {
         let window = crate::AppWindow::new()?;
 
-        Self::register_sidebar_callbacks(&window, state.clone(), tx_cmd.clone());
+        let sidebar_state: Arc<Mutex<SidebarUiState>> =
+            Arc::new(Mutex::new(SidebarUiState::default()));
+
+        Self::register_sidebar_callbacks(
+            &window,
+            state.clone(),
+            tx_cmd.clone(),
+            Arc::clone(&sidebar_state),
+        );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
         Self::register_result_callbacks(&window, state.clone());
         Self::register_status_callbacks(&window, state.clone());
-        Self::spawn_event_handler(&window, rx_event, state);
+        Self::spawn_event_handler(&window, rx_event, state, Arc::clone(&sidebar_state));
 
         Ok(Self { window })
     }
@@ -48,6 +194,7 @@ impl UI {
         window: &crate::AppWindow,
         mut rx_event: mpsc::Receiver<Event>,
         state: SharedState,
+        sidebar_state: Arc<Mutex<SidebarUiState>>,
     ) {
         let window_weak = window.as_weak();
         tokio::spawn(async move {
@@ -81,6 +228,18 @@ impl UI {
                             })
                             .unwrap_or_else(|| active_id.clone());
 
+                        // Auto-expand the newly connected node
+                        {
+                            let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            sb.expanded.insert(format!("conn:{}", active_id));
+                        }
+                        // Build sidebar tree (Vec<SidebarNode> is Send)
+                        let sidebar_nodes = {
+                            let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            let connections = state.conn.all();
+                            build_sidebar_tree(&connections, &active_id, &sb.metadata, &sb.expanded)
+                        };
+
                         // clone required: invoke_from_event_loop closure must be 'static
                         let window_weak = window_weak.clone();
                         let active_id = active_id.clone();
@@ -98,6 +257,9 @@ impl UI {
                             ui.set_form_status("".into());
                             ui.set_error_message("".into());
                             ui.set_status_connection(status_conn.into());
+                            ui.set_sidebar_tree(
+                                Rc::new(slint::VecModel::from(sidebar_nodes)).into(),
+                            );
                             ui.set_sidebar_loading(true);
                         });
                     }
@@ -260,14 +422,34 @@ impl UI {
                             ui.set_status_connection("Not connected".into());
                         });
                     }
-                    Event::MetadataLoaded(_) => {
+                    Event::MetadataLoaded(ref conn_id, ref meta) => {
+                        let conn_id = conn_id.clone();
+                        let meta = meta.clone(); // clone required: moved into sidebar_state
+                        // Store metadata in shared state
+                        {
+                            let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            sb.metadata.insert(conn_id.clone(), meta);
+                        }
+                        // Build updated tree outside invoke_from_event_loop (Vec is Send)
+                        let nodes = {
+                            let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            let connections = state.conn.all();
+                            let active_id = state
+                                .conn
+                                .active()
+                                .map(|c| c.id.clone())
+                                .unwrap_or_default();
+                            build_sidebar_tree(&connections, &active_id, &sb.metadata, &sb.expanded)
+                        };
                         // clone required: invoke_from_event_loop closure must be 'static
                         let window_weak = window_weak.clone();
                         let _ = slint::invoke_from_event_loop(move || {
                             let Some(window) = window_weak.upgrade() else {
                                 return;
                             };
-                            window.global::<crate::UiState>().set_sidebar_loading(false);
+                            let ui = window.global::<crate::UiState>();
+                            ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                            ui.set_sidebar_loading(false);
                         });
                     }
                     Event::MetadataFetchFailed(ref msg) => {
@@ -295,6 +477,7 @@ impl UI {
         window: &crate::AppWindow,
         state: SharedState,
         tx_cmd: mpsc::Sender<Command>,
+        sidebar_state: Arc<Mutex<SidebarUiState>>,
     ) {
         let ui_state = window.global::<crate::UiState>();
 
@@ -324,22 +507,60 @@ impl UI {
             });
         }
 
-        // switch-connection: look up the saved conn by id and re-connect
+        // toggle-sidebar-node: expand/collapse a tree node; also switches active
+        // connection when a level-0 (connection) node is clicked.
         {
-            // clone required: callback closure needs owned tx_cmd
+            // clone required: callback closure needs owned captures
             let tx_cmd = tx_cmd.clone();
-            // clone required: callback closure needs owned state
             let state = state.clone();
-            ui_state.on_switch_connection(move |id| {
+            let sidebar_state = Arc::clone(&sidebar_state);
+            let window_weak = window.as_weak();
+            ui_state.on_toggle_sidebar_node(move |id| {
                 let id = id.to_string();
-                let conn = state.conn.all().into_iter().find(|c| c.id == id);
-                if let Some(conn) = conn {
-                    // clone required: tokio::spawn requires 'static
-                    let tx_cmd = tx_cmd.clone();
-                    tokio::spawn(async move {
-                        let _ = tx_cmd.send(Command::Connect(conn, None)).await;
-                    });
+                // If this is a connection node, send a Connect command.
+                if let Some(conn_id) = id.strip_prefix("conn:") {
+                    let conn = state.conn.all().into_iter().find(|c| c.id == conn_id);
+                    if let Some(conn) = conn {
+                        // clone required: tokio::spawn requires 'static
+                        let tx_cmd = tx_cmd.clone();
+                        tokio::spawn(async move {
+                            let _ = tx_cmd.send(Command::Connect(conn, None)).await;
+                        });
+                    }
                 }
+                // Toggle expanded state
+                {
+                    let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    if sb.expanded.contains(&id) {
+                        sb.expanded.remove(&id);
+                    } else {
+                        sb.expanded.insert(id.clone());
+                    }
+                }
+                // Rebuild and push the updated tree (already on UI thread)
+                let nodes = {
+                    let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    let connections = state.conn.all();
+                    let active_id = state
+                        .conn
+                        .active()
+                        .map(|c| c.id.clone())
+                        .unwrap_or_default();
+                    build_sidebar_tree(&connections, &active_id, &sb.metadata, &sb.expanded)
+                };
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                window
+                    .global::<crate::UiState>()
+                    .set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+            });
+        }
+
+        // table-double-clicked: stub for T045 (insert SELECT * FROM {name})
+        {
+            ui_state.on_table_double_clicked(move |_name| {
+                // T045: insert SELECT * FROM {name} into editor
             });
         }
     }
@@ -647,4 +868,102 @@ fn build_conn_from_form(ui: &crate::UiState, enc_key: &[u8; 32]) -> (DbConnectio
     };
 
     (conn, password)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wf_db::models::{DbMetadata, DbType, TableInfo};
+
+    fn make_conn(id: &str, name: &str) -> DbConnection {
+        DbConnection {
+            id: id.to_string(),
+            name: name.to_string(),
+            db_type: DbType::SQLite,
+            connection_string: None,
+            host: None,
+            port: None,
+            user: None,
+            password_encrypted: None,
+            database: None,
+        }
+    }
+
+    fn make_meta(tables: &[&str]) -> DbMetadata {
+        DbMetadata {
+            tables: tables
+                .iter()
+                .map(|n| TableInfo {
+                    name: n.to_string(),
+                    columns: vec![],
+                })
+                .collect(),
+            views: vec![],
+            stored_procs: vec![],
+            indexes: vec![],
+        }
+    }
+
+    #[test]
+    fn build_sidebar_tree_should_render_connection_nodes() {
+        let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
+        let nodes = build_sidebar_tree(&conns, "", &HashMap::new(), &HashSet::new());
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].label.as_str(), "Alpha");
+        assert_eq!(nodes[0].level, 0);
+        assert_eq!(nodes[0].node_kind.as_str(), "connection");
+        assert_eq!(nodes[1].label.as_str(), "Beta");
+    }
+
+    #[test]
+    fn build_sidebar_tree_should_show_categories_when_connection_expanded() {
+        let conns = vec![make_conn("a", "Alpha")];
+        let mut expanded = HashSet::new();
+        expanded.insert("conn:a".to_string());
+        let mut metadata = HashMap::new();
+        metadata.insert("a".to_string(), make_meta(&["users"]));
+        let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
+        // conn + Tables + Views + Stored Procedures + Indexes = 5 nodes
+        assert_eq!(nodes.len(), 5);
+        assert_eq!(nodes[1].label.as_str(), "Tables");
+        assert_eq!(nodes[1].level, 1);
+        assert_eq!(nodes[1].node_kind.as_str(), "category");
+    }
+
+    #[test]
+    fn build_sidebar_tree_should_show_items_when_category_expanded() {
+        let conns = vec![make_conn("a", "Alpha")];
+        let mut expanded = HashSet::new();
+        expanded.insert("conn:a".to_string());
+        expanded.insert("cat:a:Tables".to_string());
+        let mut metadata = HashMap::new();
+        metadata.insert("a".to_string(), make_meta(&["users", "orders"]));
+        let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
+        // conn + Tables + users + orders + Views + Stored Procedures + Indexes = 7
+        assert_eq!(nodes.len(), 7);
+        assert_eq!(nodes[2].label.as_str(), "users");
+        assert_eq!(nodes[2].level, 2);
+        assert_eq!(nodes[2].node_kind.as_str(), "table");
+        assert_eq!(nodes[3].label.as_str(), "orders");
+    }
+
+    #[test]
+    fn build_sidebar_tree_should_hide_children_when_collapsed() {
+        let conns = vec![make_conn("a", "Alpha")];
+        let nodes = build_sidebar_tree(&conns, "a", &HashMap::new(), &HashSet::new());
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].level, 0);
+    }
+
+    #[test]
+    fn build_sidebar_tree_should_mark_active_connection() {
+        let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
+        let nodes = build_sidebar_tree(&conns, "b", &HashMap::new(), &HashSet::new());
+        assert!(!nodes[0].is_active);
+        assert!(nodes[1].is_active);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the flat connection list in the sidebar with a three-level collapsible tree: connection → category (Tables / Views / Stored Procedures / Indexes) → item. The tree is backed by a flat `VecModel<SidebarNode>` with a `level` field (0/1/2); expand/collapse state and metadata are managed in Rust via `Arc<Mutex<SidebarUiState>>` and rebuilt on each toggle or metadata load.

## Changes

- `event.rs`: `MetadataLoaded(DbMetadata)` → `MetadataLoaded(String, DbMetadata)` to carry `conn_id`
- `controller.rs`: pass `fetch_id.clone()` when sending `MetadataLoaded`; update all match patterns
- `globals.slint`: add `SidebarNode` struct (id, label, sub-label, level, is-expanded, is-active, node-kind)
- `app.slint`: replace `switch-connection` callback with `toggle-sidebar-node` + `table-double-clicked`; add `sidebar-tree` property; rewire `Sidebar` bindings
- `sidebar.slint`: complete rewrite — renders `[SidebarNode]` flat tree with indent, expand icons (▼/▶), hover overlay, loading indicator, and double-click for table/view
- `mod.rs`: add `SidebarUiState`, `build_sidebar_tree`, `push_tableinfo_category`, `push_string_category`; wire `on_toggle_sidebar_node` (expand/collapse + connection switch) and `on_table_double_clicked` (T045 stub); update `Event::Connected` handler to auto-expand the new connection and push initial tree; update `Event::MetadataLoaded` handler to store metadata and rebuild tree
- 5 unit tests for `build_sidebar_tree` covering node rendering, category/item visibility, collapse, and active-connection flag

## Related Issues

Closes #31

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes