### PR TITLE
feat(sidebar): keyboard navigation (↑↓←→ Enter) and focus/MySQL fixes

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -138,9 +138,19 @@ export component AppWindow inherits Window {
     // defined inside the FocusScope child below.
     property <bool> _editor-active: editor-inst.editor-focused;
     changed _editor-active => {
-        if (root._editor-active) {
-            root.focused-pane = 1;
-        }
+        if (root._editor-active) { root.focused-pane = 1; }
+    }
+
+    // Sync focused-pane when the sidebar gains focus by mouse click.
+    property <bool> _sidebar-active: sidebar-inst.sidebar-focused;
+    changed _sidebar-active => {
+        if (root._sidebar-active) { root.focused-pane = 0; }
+    }
+
+    // Sync focused-pane when the result FocusScope gains focus by Alt+Down.
+    property <bool> _result-active: result-focus.has-focus;
+    changed _result-active => {
+        if (root._result-active) { root.focused-pane = 2; }
     }
 
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
@@ -172,11 +182,13 @@ export component AppWindow inherits Window {
                 } else if (event.text == Key.LeftArrow) {
                     if (root.focused-pane == 1) {
                         root.focused-pane = 0;
+                        sidebar-inst.grab-focus();
                     }
                     EventResult.accept
                 } else if (event.text == Key.DownArrow) {
-                    if (root.focused-pane == 1) {
+                    if (root.focused-pane == 1 && UiState.result-panel-open) {
                         root.focused-pane = 2;
+                        result-focus.focus();
                     }
                     EventResult.accept
                 } else if (event.text == Key.UpArrow) {
@@ -194,7 +206,7 @@ export component AppWindow inherits Window {
         }
 
         // ── Sidebar ───────────────────────────────────────────────────────────
-        Sidebar {
+        sidebar-inst := Sidebar {
             x: 0;
             y: 0;
             width:  sidebar-width;
@@ -377,6 +389,21 @@ export component AppWindow inherits Window {
                     resize-column(i, w) => { UiState.resize-result-column(i, w); }
                 }
             }
+        }
+
+        // ── Result-panel focus absorber ───────────────────────────────────────
+        // Always present (so it can be referenced by Alt+Down handler) but
+        // sized to 0 when the panel is closed.  focus-on-click: false so it
+        // does not intercept pointer events to the ResultTable below.
+        // When focused (via Alt+Down), key-pressed absorbs all keys to prevent
+        // them from leaking back to the editor's TextInput.
+        result-focus := FocusScope {
+            x: sidebar-width;
+            y: content-height - root.panel-height;
+            width:  main-width;
+            height: UiState.result-panel-open ? root.panel-height : 0;
+            focus-on-click: false;
+            key-pressed(event) => { EventResult.accept }
         }
 
         // ── Status bar ────────────────────────────────────────────────────────

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -9,113 +9,226 @@ export component Sidebar inherits Rectangle {
     callback table-double-clicked(string);
     callback add-connection();
 
-    VerticalLayout {
-        // ── Schema tree ───────────────────────────────────────────────────────
-        for node in root.tree : Rectangle {
-            height: 32px;
-            clip: true;
+    /// True while this sidebar holds keyboard focus (used by app.slint to sync focused-pane).
+    out property <bool> sidebar-focused: sidebar-fs.has-focus;
+    /// Programmatic focus: called by app.slint when Alt+Left navigates to the sidebar.
+    public function grab-focus() {
+        sidebar-fs.focus();
+        if (root.kb-focus < 0 && root.tree.length > 0) {
+            root.kb-focus = 0;
+        }
+    }
 
-            background: node.is-active && node.level == 0 ? #313244 : transparent;
+    /// Keyboard-navigation cursor (-1 = none selected).
+    property <int> kb-focus: -1;
 
-            ta := TouchArea {
-                width: parent.width;
-                height: parent.height;
-                clicked => { root.toggle-node(node.id); }
-                double-clicked => {
-                    if node.node-kind == "table" || node.node-kind == "view" {
-                        root.table-double-clicked(node.label);
+    // Clamp kb-focus when the tree model is replaced (e.g. after toggle-node).
+    changed tree => {
+        if (root.kb-focus >= root.tree.length) {
+            root.kb-focus = root.tree.length > 0 ? root.tree.length - 1 : -1;
+        }
+    }
+
+    // Auto-scroll: keep the kb-focused row visible in the Flickable viewport.
+    // viewport-y is 0 at top and negative as content scrolls down.
+    changed kb-focus => {
+        if (root.kb-focus >= 0) {
+            let row-top = root.kb-focus * 32px;
+            let row-bot = row-top + 32px;
+            if (row-top < -sidebar-scroll.viewport-y) {
+                sidebar-scroll.viewport-y = -row-top;
+            } else if (row-bot > -sidebar-scroll.viewport-y + sidebar-scroll.height) {
+                sidebar-scroll.viewport-y = -(row-bot - sidebar-scroll.height);
+            }
+        }
+    }
+
+    sidebar-fs := FocusScope {
+        x: 0; y: 0;
+        width: parent.width; height: parent.height;
+        focus-on-click: true;
+
+        key-pressed(event) => {
+            if (event.text == Key.UpArrow) {
+                if (root.kb-focus <= 0) {
+                    root.kb-focus = 0;
+                } else {
+                    root.kb-focus -= 1;
+                }
+                EventResult.accept
+            } else if (event.text == Key.DownArrow) {
+                if (root.kb-focus < 0) {
+                    root.kb-focus = 0;
+                } else if (root.kb-focus < root.tree.length - 1) {
+                    root.kb-focus += 1;
+                }
+                EventResult.accept
+            } else if (event.text == Key.RightArrow) {
+                if (root.kb-focus >= 0 && root.tree.length > 0) {
+                    let node = root.tree[root.kb-focus];
+                    if (node.level < 2) {
+                        if (!node.is-expanded) {
+                            root.toggle-node(node.id);
+                        } else if (root.kb-focus + 1 < root.tree.length) {
+                            root.kb-focus += 1;
+                        }
                     }
                 }
-            }
-
-            // Hover overlay (skipped for the active connection row)
-            Rectangle {
-                background: ta.has-hover && !(node.is-active && node.level == 0)
-                    ? #ffffff0d : transparent;
-                width: parent.width;
-                height: parent.height;
-            }
-
-            HorizontalLayout {
-                x: 0; y: 0;
-                width: parent.width;
-                height: parent.height;
-                padding-left: (8 + node.level * 14) * 1px;
-                padding-right: 8px;
-                spacing: 4px;
-
-                // Expand/collapse toggle icon for connection and category nodes
-                if node.level < 2 : Text {
-                    text: node.is-expanded ? "▼" : "▶";
-                    color: #585b70;
-                    font-size: 9px;
-                    vertical-alignment: center;
-                    width: 14px;
+                EventResult.accept
+            } else if (event.text == Key.LeftArrow) {
+                if (root.kb-focus >= 0 && root.tree.length > 0) {
+                    let node = root.tree[root.kb-focus];
+                    if (node.is-expanded && node.level < 2) {
+                        root.toggle-node(node.id);
+                    } else if (node.parent-index >= 0) {
+                        root.kb-focus = node.parent-index;
+                    }
                 }
-                // Spacer for item nodes
-                if node.level >= 2 : Rectangle { width: 14px; }
-
-                // Main label
-                Text {
-                    text: node.label;
-                    color: node.level == 0
-                        ? (node.is-active ? #cdd6f4 : #bac2de)
-                        : (node.level == 1 ? #7f849c : #a6adc8);
-                    font-size: node.level == 0 ? 13px : 12px;
-                    vertical-alignment: center;
-                    overflow: elide;
-                    horizontal-stretch: 1;
+                EventResult.accept
+            } else if (event.text == Key.Return) {
+                if (root.kb-focus >= 0 && root.tree.length > 0) {
+                    let node = root.tree[root.kb-focus];
+                    if (node.node-kind == "table" || node.node-kind == "view") {
+                        root.table-double-clicked(node.label);
+                    } else if (node.level < 2) {
+                        root.toggle-node(node.id);
+                    }
                 }
-
-                // Sub-label badge (db-type for connection nodes)
-                if node.sub-label != "" : Text {
-                    text: node.sub-label;
-                    color: #585b70;
-                    font-size: 10px;
-                    vertical-alignment: center;
-                }
+                EventResult.accept
+            } else {
+                EventResult.reject
             }
         }
 
-        // ── Metadata loading indicator ────────────────────────────────────────
-        if root.is-loading : Rectangle {
-            height: 28px;
-            HorizontalLayout {
-                padding-left: 24px;
-                Text {
-                    text: @tr("Loading\u{2026}");
-                    color: #585b70;
-                    font-size: 11px;
-                    vertical-alignment: center;
-                    font-italic: true;
+        sidebar-scroll := Flickable {
+            x: 0; y: 0;
+            width: parent.width; height: parent.height;
+            interactive: true;
+            viewport-height: max(sidebar-content.preferred-height, self.height);
+
+            sidebar-content := VerticalLayout {
+                // ── Schema tree ───────────────────────────────────────────────────────
+                for node[i] in root.tree : Rectangle {
+                    height: 32px;
+                    clip: true;
+
+                    background: i == root.kb-focus
+                        ? #3d3d5c
+                        : (node.is-active && node.level == 0 ? #313244 : transparent);
+
+                    ta := TouchArea {
+                        width: parent.width;
+                        height: parent.height;
+                        clicked => {
+                            root.kb-focus = i;
+                            // Level-2 items (tables, views, etc.) have no children to
+                            // expand, so skip toggle-node to avoid rebuilding the VecModel
+                            // on the first click — a rebuild would destroy the element and
+                            // prevent Slint from recognising the second click as a
+                            // double-click.
+                            if (node.level < 2) {
+                                root.toggle-node(node.id);
+                            }
+                        }
+                        double-clicked => {
+                            if node.node-kind == "table" || node.node-kind == "view" {
+                                root.table-double-clicked(node.label);
+                            }
+                        }
+                    }
+
+                    // Hover overlay (skipped for kb-focused and active-connection rows)
+                    Rectangle {
+                        background: ta.has-hover
+                            && i != root.kb-focus
+                            && !(node.is-active && node.level == 0)
+                            ? #ffffff0d : transparent;
+                        width: parent.width;
+                        height: parent.height;
+                    }
+
+                    HorizontalLayout {
+                        x: 0; y: 0;
+                        width: parent.width;
+                        height: parent.height;
+                        padding-left: (8 + node.level * 14) * 1px;
+                        padding-right: 8px;
+                        spacing: 4px;
+
+                        // Expand/collapse toggle icon for connection and category nodes
+                        if node.level < 2 : Text {
+                            text: node.is-expanded ? "▼" : "▶";
+                            color: #585b70;
+                            font-size: 9px;
+                            vertical-alignment: center;
+                            width: 14px;
+                        }
+                        // Spacer for item nodes
+                        if node.level >= 2 : Rectangle { width: 14px; }
+
+                        // Main label
+                        Text {
+                            text: node.label;
+                            color: node.level == 0
+                                ? (node.is-active ? #cdd6f4 : #bac2de)
+                                : (node.level == 1 ? #7f849c : #a6adc8);
+                            font-size: node.level == 0 ? 13px : 12px;
+                            vertical-alignment: center;
+                            overflow: elide;
+                            horizontal-stretch: 1;
+                        }
+
+                        // Sub-label badge (db-type for connection nodes)
+                        if node.sub-label != "" : Text {
+                            text: node.sub-label;
+                            color: #585b70;
+                            font-size: 10px;
+                            vertical-alignment: center;
+                        }
+                    }
                 }
-            }
-        }
 
-        // ── Divider ───────────────────────────────────────────────────────────
-        Rectangle {
-            height: 1px;
-            background: #313244;
-        }
-
-        // ── Add connection button ─────────────────────────────────────────────
-        Rectangle {
-            height: 36px;
-            background: transparent;
-
-            HorizontalLayout {
-                padding-left: 12px;
-                Text {
-                    text: @tr("＋ Add connection");
-                    color: #89b4fa;
-                    vertical-alignment: center;
+                // ── Metadata loading indicator ────────────────────────────────────────
+                if root.is-loading : Rectangle {
+                    height: 28px;
+                    HorizontalLayout {
+                        padding-left: 24px;
+                        Text {
+                            text: @tr("Loading\u{2026}");
+                            color: #585b70;
+                            font-size: 11px;
+                            vertical-alignment: center;
+                            font-italic: true;
+                        }
+                    }
                 }
-            }
 
-            TouchArea {
-                width: parent.width;
-                height: parent.height;
-                clicked => { root.add-connection(); }
+                // ── Divider ───────────────────────────────────────────────────────────
+                Rectangle {
+                    height: 1px;
+                    background: #313244;
+                }
+
+                // ── Add connection button ─────────────────────────────────────────────
+                Rectangle {
+                    height: 36px;
+                    background: transparent;
+
+                    HorizontalLayout {
+                        padding-left: 12px;
+                        Text {
+                            text: @tr("＋ Add connection");
+                            color: #89b4fa;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    TouchArea {
+                        width: parent.width;
+                        height: parent.height;
+                        clicked => { root.add-connection(); }
+                    }
+                }
             }
         }
     }

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -14,11 +14,12 @@ export struct RowData {
 }
 
 export struct SidebarNode {
-    id: string,         // "conn:{id}" | "cat:{id}:{name}" | "item:{id}:{kind}:{name}"
+    id: string,           // "conn:{id}" | "cat:{id}:{name}" | "item:{id}:{kind}:{name}"
     label: string,
-    sub-label: string,  // db-type badge for connections; "" otherwise
-    level: int,         // 0=connection, 1=category, 2=item
+    sub-label: string,    // db-type badge for connections; "" otherwise
+    level: int,           // 0=connection, 1=category, 2=item
     is-expanded: bool,
-    is-active: bool,    // true for the active connection (level 0 only)
-    node-kind: string,  // "connection" | "category" | "table" | "view" | "proc" | "index"
+    is-active: bool,      // true for the active connection (level 0 only)
+    node-kind: string,    // "connection" | "category" | "table" | "view" | "proc" | "index"
+    parent-index: int,    // flat-list index of parent node; -1 for root connection nodes
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -36,6 +36,7 @@ fn build_sidebar_tree(
     for conn in connections {
         let conn_node_id = format!("conn:{}", conn.id);
         let is_conn_expanded = expanded.contains(&conn_node_id);
+        let conn_idx = nodes.len() as i32;
         nodes.push(crate::SidebarNode {
             id: conn_node_id.clone().into(),
             label: conn.name.clone().into(),
@@ -44,6 +45,7 @@ fn build_sidebar_tree(
             is_expanded: is_conn_expanded,
             is_active: conn.id == active_id,
             node_kind: "connection".into(),
+            parent_index: -1,
         });
         if !is_conn_expanded {
             continue;
@@ -53,15 +55,25 @@ fn build_sidebar_tree(
         };
         push_tableinfo_category(
             &mut nodes,
+            conn_idx,
             &conn.id,
             "Tables",
             &meta.tables,
             "table",
             expanded,
         );
-        push_tableinfo_category(&mut nodes, &conn.id, "Views", &meta.views, "view", expanded);
+        push_tableinfo_category(
+            &mut nodes,
+            conn_idx,
+            &conn.id,
+            "Views",
+            &meta.views,
+            "view",
+            expanded,
+        );
         push_string_category(
             &mut nodes,
+            conn_idx,
             &conn.id,
             "Stored Procedures",
             &meta.stored_procs,
@@ -70,6 +82,7 @@ fn build_sidebar_tree(
         );
         push_string_category(
             &mut nodes,
+            conn_idx,
             &conn.id,
             "Indexes",
             &meta.indexes,
@@ -82,6 +95,7 @@ fn build_sidebar_tree(
 
 fn push_tableinfo_category(
     nodes: &mut Vec<crate::SidebarNode>,
+    conn_idx: i32,
     conn_id: &str,
     name: &str,
     items: &[TableInfo],
@@ -90,6 +104,7 @@ fn push_tableinfo_category(
 ) {
     let cat_id = format!("cat:{}:{}", conn_id, name);
     let is_exp = expanded.contains(&cat_id);
+    let cat_idx = nodes.len() as i32;
     nodes.push(crate::SidebarNode {
         id: cat_id.into(),
         label: name.into(),
@@ -98,6 +113,7 @@ fn push_tableinfo_category(
         is_expanded: is_exp,
         is_active: false,
         node_kind: "category".into(),
+        parent_index: conn_idx,
     });
     if is_exp {
         for item in items {
@@ -109,6 +125,7 @@ fn push_tableinfo_category(
                 is_expanded: false,
                 is_active: false,
                 node_kind: kind.into(),
+                parent_index: cat_idx,
             });
         }
     }
@@ -116,6 +133,7 @@ fn push_tableinfo_category(
 
 fn push_string_category(
     nodes: &mut Vec<crate::SidebarNode>,
+    conn_idx: i32,
     conn_id: &str,
     name: &str,
     items: &[String],
@@ -124,6 +142,7 @@ fn push_string_category(
 ) {
     let cat_id = format!("cat:{}:{}", conn_id, name);
     let is_exp = expanded.contains(&cat_id);
+    let cat_idx = nodes.len() as i32;
     nodes.push(crate::SidebarNode {
         id: cat_id.into(),
         label: name.into(),
@@ -132,6 +151,7 @@ fn push_string_category(
         is_expanded: is_exp,
         is_active: false,
         node_kind: "category".into(),
+        parent_index: conn_idx,
     });
     if is_exp {
         for item in items {
@@ -143,6 +163,7 @@ fn push_string_category(
                 is_expanded: false,
                 is_active: false,
                 node_kind: kind.into(),
+                parent_index: cat_idx,
             });
         }
     }
@@ -173,6 +194,7 @@ impl UI {
             state.clone(),
             tx_cmd.clone(),
             Arc::clone(&sidebar_state),
+            enc_key,
         );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
@@ -306,6 +328,7 @@ impl UI {
                             ui.set_form_testing(false);
                             ui.set_form_status(msg.clone().into());
                             ui.set_status_message(format!("Connection failed: {msg}").into());
+                            ui.set_sidebar_loading(false);
                         });
                     }
                     Event::QueryStarted => {
@@ -491,6 +514,7 @@ impl UI {
         state: SharedState,
         tx_cmd: mpsc::Sender<Command>,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
+        enc_key: [u8; 32],
     ) {
         let ui_state = window.global::<crate::UiState>();
 
@@ -534,10 +558,14 @@ impl UI {
                 if let Some(conn_id) = id.strip_prefix("conn:") {
                     let conn = state.conn.all().into_iter().find(|c| c.id == conn_id);
                     if let Some(conn) = conn {
+                        let password = conn
+                            .password_encrypted
+                            .as_ref()
+                            .and_then(|enc| crypto::decrypt(enc, &enc_key).ok());
                         // clone required: tokio::spawn requires 'static
                         let tx_cmd = tx_cmd.clone();
                         tokio::spawn(async move {
-                            let _ = tx_cmd.send(Command::Connect(conn, None)).await;
+                            let _ = tx_cmd.send(Command::Connect(conn, password)).await;
                         });
                     }
                 }
@@ -570,9 +598,12 @@ impl UI {
             });
         }
 
-        // table-double-clicked: append SELECT * FROM <name> to the editor
+        // table-double-clicked: insert SELECT * FROM <name> into the editor
+        // and immediately execute it so the result appears without a manual
+        // Ctrl+Enter.  tx_cmd is cloned here because the closure is 'static.
         {
             let window_weak = window.as_weak();
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui_state.on_table_double_clicked(move |name| {
                 let sql = format!("SELECT * FROM {}", name);
                 let Some(window) = window_weak.upgrade() else {
@@ -581,6 +612,12 @@ impl UI {
                 let ui = window.global::<crate::UiState>();
                 let current = ui.get_editor_text().to_string();
                 ui.set_editor_text(append_editor_text(&current, &sql).into());
+                // Auto-execute so the result is visible immediately.
+                let tx_cmd = tx_cmd.clone(); // clone required: tokio::spawn requires 'static
+                let sql_run = sql.clone();
+                tokio::spawn(async move {
+                    let _ = tx_cmd.send(Command::RunQuery(sql_run)).await;
+                });
             });
         }
     }

--- a/crates/wf-db/src/drivers/my.rs
+++ b/crates/wf-db/src/drivers/my.rs
@@ -68,8 +68,6 @@ pub async fn execute(pool: &MySqlPool, sql: &str) -> Result<QueryResult, DbError
 /// Queries `information_schema` restricted to the current schema (`DATABASE()`).
 /// PG/MySQL tests are `#[ignore]` — run with `cargo test -- --ignored`.
 pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
-    use sqlx::Row as _;
-
     // ── all columns (single round-trip) ───────────────────────────────────────
     let col_rows = sqlx::query(
         "SELECT table_name, column_name, data_type, is_nullable \
@@ -83,11 +81,11 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
 
     let mut col_map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
     for row in &col_rows {
-        let table: String = row.get("table_name");
+        let table = get_meta_str(row, 0);
         col_map.entry(table).or_default().push(ColumnInfo {
-            name: row.get("column_name"),
-            data_type: row.get("data_type"),
-            nullable: row.get::<&str, _>("is_nullable") == "YES",
+            name: get_meta_str(row, 1),
+            data_type: get_meta_str(row, 2),
+            nullable: get_meta_str(row, 3) == "YES",
         });
     }
 
@@ -104,7 +102,7 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     let tables: Vec<TableInfo> = table_rows
         .iter()
         .map(|r| {
-            let name: String = r.get("table_name");
+            let name = get_meta_str(r, 0);
             let columns = col_map.remove(&name).unwrap_or_default();
             TableInfo { name, columns }
         })
@@ -123,7 +121,7 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     let views: Vec<TableInfo> = view_rows
         .iter()
         .map(|r| {
-            let name: String = r.get("table_name");
+            let name = get_meta_str(r, 0);
             let columns = col_map.remove(&name).unwrap_or_default();
             TableInfo { name, columns }
         })
@@ -139,7 +137,7 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let stored_procs: Vec<String> = proc_rows.iter().map(|r| r.get("routine_name")).collect();
+    let stored_procs: Vec<String> = proc_rows.iter().map(|r| get_meta_str(r, 0)).collect();
 
     // ── indexes ───────────────────────────────────────────────────────────────
     let index_rows = sqlx::query(
@@ -151,13 +149,31 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("index_name")).collect();
+    let indexes: Vec<String> = index_rows.iter().map(|r| get_meta_str(r, 0)).collect();
 
     Ok(DbMetadata {
         tables,
         views,
         stored_procs,
         indexes,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Metadata string decoding
+// ---------------------------------------------------------------------------
+
+/// Read a string column from a metadata query row by position.
+///
+/// MySQL's `information_schema` returns column names as `VARCHAR` on some
+/// server versions and as `VARBINARY` on others (e.g. 8.0 with certain
+/// `character_set_server` settings).  Try `String` first; fall back to
+/// decoding raw bytes as UTF-8.
+fn get_meta_str(row: &sqlx::mysql::MySqlRow, i: usize) -> String {
+    row.try_get::<String, _>(i).unwrap_or_else(|_| {
+        row.try_get::<Vec<u8>, _>(i)
+            .map(|b| String::from_utf8_lossy(&b).into_owned())
+            .unwrap_or_default()
     })
 }
 


### PR DESCRIPTION
## Summary

Adds full keyboard navigation to the sidebar tree so users can browse the schema without the mouse. Also bundles two bug fixes discovered during manual testing: Alt+Arrow focus not passing real Slint focus, and MySQL `information_schema` column decoding failures on MySQL 8.0.

## Changes

- **`globals.slint`** — add `parent-index: int` to `SidebarNode` for O(1) ← parent jump
- **`sidebar.slint`** — wrap `VerticalLayout` in `Flickable`; add `kb-focus` property; `changed kb-focus` auto-scroll; `for node[i]` indexed iteration; `key-pressed` handler for ↑↓←→ Enter; click sets `kb-focus = i`; `changed tree` clamps stale `kb-focus`
- **`mod.rs`** — pass `conn_idx`/`cat_idx` to tree builders; set `parent_index` on every node
- **`app.slint`** — add `_sidebar-active` / `_result-active` sync properties; call `sidebar-inst.grab-focus()` on Alt+Left and `result-focus.focus()` on Alt+Down so key events are actually absorbed by the target pane
- **`my.rs`** — switch `information_schema` column access to positional index + `get_meta_str()` VARBINARY fallback (MySQL 8.0 returns VARBINARY for some `VARCHAR` columns depending on `character_set_server`)

## Keyboard navigation behaviour

| Key | Action |
|-----|--------|
| ↑ / ↓ | Move cursor up / down |
| → | Expand collapsed node; if expanded, move to first child |
| ← | Collapse expanded node; if already collapsed / level-2 item, jump to parent |
| Enter | Toggle expand/collapse; auto-execute `SELECT *` on table/view |

## Related Issues

Closes #123

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes