### PR TITLE
feat(result-table): virtual scroll via Slint ListView

### DIFF
--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -1,3 +1,4 @@
+import { ListView } from "std-widgets.slint";
 import { RowData } from "../globals.slint";
 
 // Result table — column headers + scrollable data rows.
@@ -9,7 +10,8 @@ import { RowData } from "../globals.slint";
 //     strip at the bottom, pre-selected so the user can Ctrl+C to copy.
 //
 // Scroll architecture:
-//   header-scroll (Flickable, interactive: false) + body-scroll (Flickable, H+V).
+//   header-scroll (Flickable, interactive: false) + body-scroll (ListView, H+V).
+//   ListView only renders visible rows for smooth scrolling with large result sets.
 //   `changed viewport-x =>` in body-scroll syncs header-scroll so headers
 //   track horizontal scroll without scrolling vertically.
 //
@@ -176,32 +178,21 @@ export component ResultTable inherits Rectangle {
             }
         }
 
-        // ── Body (horizontal + vertical scroll) ──────────────────────────────
-        body-scroll := Flickable {
-            vertical-stretch:  1;
-            viewport-width:    root.vp-w;
-            viewport-height:   max(root.row-count * root.row-height, 1px);
+        // ── Body (horizontal + vertical virtual scroll via ListView) ─────────
+        // ListView only instantiates visible rows, keeping scroll smooth with
+        // large result sets.
+        Rectangle {
+            vertical-stretch: 1;
+            clip: true;
 
-            // Sync header horizontal position when body scrolls.
-            changed viewport-x => { header-scroll.viewport-x = self.viewport-x; }
+            body-scroll := ListView {
+                width:          parent.width;
+                height:         parent.height;
+                viewport-width: root.vp-w;
 
-            VerticalLayout {
-                spacing: 0;
+                // Sync header horizontal position when body scrolls.
+                changed viewport-x => { header-scroll.viewport-x = self.viewport-x; }
 
-                // Zero-row placeholder (only when a query returned no rows).
-                if root.row-count == 0 && root.columns.length > 0: Rectangle {
-                    height: 40px;
-                    width:  root.width;
-                    Text {
-                        x: (parent.width  - self.width)  / 2;
-                        y: (parent.height - self.height) / 2;
-                        text: @tr("0 rows");
-                        color: #585b70;
-                        font-size: 13px;
-                    }
-                }
-
-                // Data rows.
                 for row[i] in root.rows: Rectangle {
                     height: root.row-height;
                     width:  root.vp-w;
@@ -252,6 +243,20 @@ export component ResultTable inherits Rectangle {
                             }
                         }
                     }
+                }
+            }
+
+            // Zero-row placeholder (only when a query returned no rows).
+            if root.row-count == 0 && root.columns.length > 0: Rectangle {
+                x: 0; y: 0;
+                width:  parent.width;
+                height: parent.height;
+                Text {
+                    x: (parent.width  - self.width)  / 2;
+                    y: (parent.height - self.height) / 2;
+                    text: @tr("0 rows");
+                    color: #585b70;
+                    font-size: 13px;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Replaces the `Flickable` + `VerticalLayout` + full `for` loop in the result table body with Slint's `ListView`, which only instantiates rows within the visible viewport. This keeps scrolling smooth regardless of result set size (e.g. 100k+ rows).

## Changes

- `result_table.slint`: import `ListView` from `std-widgets.slint`
- Replace `body-scroll := Flickable { viewport-height: ...; VerticalLayout { for row ... } }` with `Rectangle { body-scroll := ListView { for row ... } }` pattern
- Move the zero-row placeholder to a sibling overlay inside the outer `Rectangle` (ListView cannot contain mixed conditional + repeated items)
- Remove manual `viewport-height` — ListView auto-computes it from row count × `row-height`
- Retain `changed viewport-x` sync with `header-scroll` for horizontal scroll alignment

## Related Issues

Closes #34

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes