### PR TITLE
feat(result-table): keyboard navigation with row/cell/search modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6406,6 +6426,7 @@ name = "wellfeather"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "slint",
  "slint-build",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -16,6 +16,7 @@ chrono             = { workspace = true }
 anyhow             = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+arboard             = "3.6.1"
 uuid               = { workspace = true }
 
 [dev-dependencies]

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -40,6 +40,18 @@ export global UiState {
     /// Fired by ResultTable drag handles; Rust updates the VecModel and total.
     callback resize-result-column(int, float);
 
+    // ── Result table filter / clipboard ──────────────────────────────────────
+    /// Text of the currently active client-side filter (empty = no filter).
+    in-out property <string> result-active-filter: "";
+    /// Apply a client-side filter to the current result rows.
+    callback filter-result-rows(string);
+    /// Clear the current filter and restore all rows.
+    callback clear-result-filter();
+    /// Copy a cell value to the system clipboard.
+    callback copy-result-cell(string);
+    /// Returns cumulative x-offset (logical px as float) of column j.
+    pure callback col-x-offset(int) -> float;
+
     // ── Connection list (sidebar) ─────────────────────────────────────────────
     in-out property <[ConnectionEntry]> connection-list:      [];
     in-out property <string>            active-connection-id: "";
@@ -147,8 +159,8 @@ export component AppWindow inherits Window {
         if (root._sidebar-active) { root.focused-pane = 0; }
     }
 
-    // Sync focused-pane when the result FocusScope gains focus by Alt+Down.
-    property <bool> _result-active: result-focus.has-focus;
+    // Sync focused-pane when the result table gains focus (keyboard nav or click).
+    property <bool> _result-active: result-table-inst.result-focused;
     changed _result-active => {
         if (root._result-active) { root.focused-pane = 2; }
     }
@@ -188,7 +200,7 @@ export component AppWindow inherits Window {
                 } else if (event.text == Key.DownArrow) {
                     if (root.focused-pane == 1 && UiState.result-panel-open) {
                         root.focused-pane = 2;
-                        result-focus.focus();
+                        result-table-inst.grab-focus();
                     }
                     EventResult.accept
                 } else if (event.text == Key.UpArrow) {
@@ -279,14 +291,16 @@ export component AppWindow inherits Window {
 
             // ── Result / error overlay panel ──────────────────────────────────
             // Overlays the editor from the bottom (VSCode-style).
-            // Visible only when UiState.result-panel-open is true.
-            if UiState.result-panel-open: Rectangle {
+            // Always instantiated (so result-table-inst is accessible from AppWindow
+            // scope for focus tracking and grab-focus); hidden via `visible:` when closed.
+            Rectangle {
                 x: root.gutter-col-width;
                 y: parent.height - root.panel-height;
                 width:  parent.width - root.gutter-col-width;
                 height: root.panel-height;
                 background: #1e1e2e;
                 clip: true;
+                visible: UiState.result-panel-open;
 
                 // ── Top drag handle ───────────────────────────────────────────
                 // Dragging this edge adjusts panel-height (panel grows/shrinks upward).
@@ -374,7 +388,7 @@ export component AppWindow inherits Window {
                 }
 
                 // ── Result table content ──────────────────────────────────────
-                ResultTable {
+                result-table-inst := ResultTable {
                     x: 0;
                     y: root.divider-thickness + root.panel-header-height;
                     width:  parent.width;
@@ -386,24 +400,14 @@ export component AppWindow inherits Window {
                     error-message:    UiState.error-message;
                     col-widths:       UiState.result-col-widths;
                     total-col-width:  UiState.result-total-col-width;
+                    active-filter:    UiState.result-active-filter;
                     resize-column(i, w) => { UiState.resize-result-column(i, w); }
+                    filter-rows(q)      => { UiState.filter-result-rows(q); }
+                    clear-filter        => { UiState.clear-result-filter(); }
+                    copy-cell(v)        => { UiState.copy-result-cell(v); }
+                    col-x-offset(j)     => { UiState.col-x-offset(j); }
                 }
             }
-        }
-
-        // ── Result-panel focus absorber ───────────────────────────────────────
-        // Always present (so it can be referenced by Alt+Down handler) but
-        // sized to 0 when the panel is closed.  focus-on-click: false so it
-        // does not intercept pointer events to the ResultTable below.
-        // When focused (via Alt+Down), key-pressed absorbs all keys to prevent
-        // them from leaking back to the editor's TextInput.
-        result-focus := FocusScope {
-            x: sidebar-width;
-            y: content-height - root.panel-height;
-            width:  main-width;
-            height: UiState.result-panel-open ? root.panel-height : 0;
-            focus-on-click: false;
-            key-pressed(event) => { EventResult.accept }
         }
 
         // ── Status bar ────────────────────────────────────────────────────────

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -6,8 +6,8 @@ import { RowData } from "../globals.slint";
 // Features:
 //   • Per-column widths, adjustable by dragging the right-edge divider on each header.
 //   • Overflow text is elided (…) within the cell.
-//   • Clicking a cell highlights its row and shows the full value in the cell-value
-//     strip at the bottom, pre-selected so the user can Ctrl+C to copy.
+//   • Three navigation modes: row (default), cell (Enter), search (F).
+//   • Client-side row filtering via search bar; active-filter banner shows applied filter.
 //
 // Scroll architecture:
 //   header-scroll (Flickable, interactive: false) + body-scroll (ListView, H+V).
@@ -15,10 +15,16 @@ import { RowData } from "../globals.slint";
 //   `changed viewport-x =>` in body-scroll syncs header-scroll so headers
 //   track horizontal scroll without scrolling vertically.
 //
-// Column-width architecture:
-//   col-widths      — [float] of per-column pixel widths (set by Rust on each query)
-//   total-col-width — sum of all col-widths (kept in sync via Rust resize callback)
-//   resize-column   — callback fired by the drag handle; Rust updates the VecModel
+// Keyboard navigation:
+//   Row mode:  ↑↓ Home End PgUp PgDn — move selected row
+//              Enter — enter cell mode at column 0
+//              F     — enter search mode
+//              Esc   — clear filter (if active) or deselect row
+//              Ctrl+C — copy selected cell value to clipboard
+//   Cell mode: ←→ Home End — move selected column within current row
+//              Esc  — return to row mode
+//              Ctrl+C — copy current cell value to clipboard
+//   Search:    type to build query; Enter — apply; Esc — cancel
 
 export component ResultTable inherits Rectangle {
     background: #1e1e2e;
@@ -26,219 +32,340 @@ export component ResultTable inherits Rectangle {
     preferred-height: 0;
     min-height: 0;
 
-    /// Column names from the last QueryResult.
-    in property <[string]>  columns:    [];
-    /// Row data as strings; NULL values are represented as empty strings.
-    in property <[RowData]> rows:       [];
-    /// Total row count (same as rows.length for now; kept explicit for T051).
-    in property <int>       row-count:  0;
-    /// True while a query is executing; shows the "Running…" overlay.
-    in property <bool>      is-loading: false;
-    /// Full error message from Event::QueryError. Non-empty triggers the error panel.
+    // ── In properties ─────────────────────────────────────────────────────────
+    in property <[string]>  columns:       [];
+    in property <[RowData]> rows:          [];
+    in property <int>       row-count:     0;
+    in property <bool>      is-loading:    false;
     in property <string>    error-message: "";
+    in property <[float]>   col-widths:    [];
+    in property <float>     total-col-width: 0.0;
+    /// Currently active filter text (empty = no filter). Set by Rust after filter-rows fires.
+    in property <string>    active-filter: "";
 
-    /// Per-column widths in logical pixels as floats. Length == columns.length.
-    /// Populated by Rust on QueryFinished; defaults to default-col-w while empty.
-    in property <[float]> col-widths: [];
-    /// Pre-computed sum of col-widths (maintained by Rust via resize-column).
-    /// Used for viewport-width so the horizontal scroll bar is accurate.
-    in property <float> total-col-width: 0.0;
-    /// Fired when the user drags a column divider.
-    /// i = 0-based column index; w = new width in logical pixels.
+    // ── Focus API ─────────────────────────────────────────────────────────────
+    /// True when this table (or its search / cell-value inputs) holds focus.
+    out property <bool> result-focused:
+        table-fs.has-focus
+        || (root.nav-mode == 2 && search-input.has-focus)
+        || cell-value-input.has-focus;
+
+    public function grab-focus() {
+        table-fs.focus();
+        if (root.selected-row < 0 && root.row-count > 0) {
+            root.selected-row = 0;
+        }
+    }
+
+    // ── Callbacks ─────────────────────────────────────────────────────────────
     callback resize-column(int, float);
+    callback filter-rows(string);
+    callback clear-filter();
+    callback copy-cell(string);
+    /// Returns cumulative x-offset (logical px as float) of column j.
+    /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
+    pure callback col-x-offset(int) -> float;
 
+    // ── Style constants ───────────────────────────────────────────────────────
     property <length> row-height:    28px;
     property <length> default-col-w: 150px;
     property <length> min-col-w:     48px;
 
-    // ── Cell selection state ──────────────────────────────────────────────────
-    /// 0-based index of the currently selected row (-1 = none).
+    // ── Selection / nav state ─────────────────────────────────────────────────
     property <int>    selected-row:        -1;
-    /// Full string value of the last clicked cell (shown in the value strip).
     property <string> selected-cell-value: "";
+    property <int>    selected-col:        -1;
+    /// 0 = row mode  1 = cell mode  2 = search mode
+    property <int>    nav-mode:    0;
+    property <string> search-query: "";
 
-    // When a new cell is selected: focus the value strip and select all its text
-    // so the user can immediately Ctrl+C without any extra interaction.
-    changed selected-cell-value => {
-        if (root.selected-cell-value != "") {
-            cell-value-input.focus();
-            cell-value-input.set-selection-offsets(0, 2147483647);
-        }
-    }
+    // ── Bottom strip heights ──────────────────────────────────────────────────
+    property <length> cell-strip-h:    root.selected-cell-value != "" ? 28px : 0px;
+    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
+    property <length> search-bar-h:    root.nav-mode == 2 ? 32px : 0px;
+    property <length> bottom-total:
+        root.cell-strip-h + root.filter-banner-h + root.search-bar-h;
 
-    // ── Viewport width helper (used by both Flickables and row rectangles) ────
-    // When total-col-width is available use it for accuracy; fall back to
-    // columns.length × default-col-w before the first query finishes.
+    // ── Viewport width ────────────────────────────────────────────────────────
     property <length> vp-w: root.total-col-width > 0
         ? max(root.total-col-width * 1px, root.width)
         : max(root.columns.length * root.default-col-w, root.width);
 
-    // ── Loading overlay ───────────────────────────────────────────────────────
-    if root.is-loading: Rectangle {
-        width:  parent.width;
-        height: parent.height;
-        background: #1e1e2e;
-        Text {
-            x: (parent.width  - self.width)  / 2;
-            y: (parent.height - self.height) / 2;
-            text: @tr("Running\u{2026}");
-            color: #cdd6f4;
-            font-size: 13px;
-        }
+    // ── Page size for Page Up/Down ────────────────────────────────────────────
+    property <int> page-rows: max(1,
+        (root.height - root.row-height - root.bottom-total) / root.row-height);
+
+    // ── Body viewport state ───────────────────────────────────────────────────
+    // Mirrored at component level so `changed` handlers can update them without
+    // referencing body-scroll (which lives inside a conditional if-block).
+    // Two-way bound to body-scroll.viewport-y/x inside the if-block.
+    property <length> body-vp-y: 0;
+    property <length> body-vp-x: 0;
+    // Visible body height (full height minus header row and collapsed strips).
+    property <length> body-h: max(1px, root.height - root.bottom-total - root.row-height);
+
+    // Reset selection and nav state when a new query result arrives.
+    changed rows => {
+        root.selected-row        = -1;
+        root.selected-col        = -1;
+        root.nav-mode            = 0;
+        root.selected-cell-value = "";
+        root.body-vp-y           = 0;
+        root.body-vp-x           = 0;
     }
 
-    // ── Error panel ───────────────────────────────────────────────────────────
-    if !root.is-loading && root.error-message != "": Rectangle {
-        width:  parent.width;
-        height: parent.height;
-        background: #2d1b1b;
-        VerticalLayout {
-            alignment: start;
-            padding: 16px;
-            spacing: 8px;
-            Text {
-                text: @tr("Query Error");
-                color: #f38ba8;
-                font-size: 13px;
-                font-weight: 700;
-            }
-            Text {
-                text: root.error-message;
-                color: #cdd6f4;
-                font-size: 12px;
-                wrap: word-wrap;
+    // ── Auto-scroll: keep selected row visible ────────────────────────────────
+    changed selected-row => {
+        if (root.selected-row >= 0) {
+            let row-top = root.selected-row * root.row-height;
+            let row-bot = row-top + root.row-height;
+            if (row-top < -root.body-vp-y) {
+                root.body-vp-y = -row-top;
+            } else if (row-bot > -root.body-vp-y + root.body-h) {
+                root.body-vp-y = -(row-bot - root.body-h);
             }
         }
     }
 
-    // ── Result content ────────────────────────────────────────────────────────
-    if !root.is-loading && root.error-message == "": VerticalLayout {
-        width:  parent.width;
-        // Leave room for the cell-value strip when something is selected.
-        height: parent.height - (root.selected-cell-value != "" ? 28px : 0px);
+    // ── Auto-scroll: keep selected column visible ─────────────────────────────
+    changed selected-col => {
+        if (root.selected-col >= 0) {
+            let col-left  = root.col-x-offset(root.selected-col) * 1px;
+            let col-w     = root.col-widths.length > root.selected-col
+                            && root.col-widths[root.selected-col] > 0
+                ? root.col-widths[root.selected-col] * 1px
+                : root.default-col-w;
+            let col-right = col-left + col-w;
+            if (col-left < -root.body-vp-x) {
+                root.body-vp-x = -col-left;
+            } else if (col-right > -root.body-vp-x + root.width) {
+                root.body-vp-x = -(col-right - root.width);
+            }
+        }
+    }
 
-        // ── Header row ────────────────────────────────────────────────────────
-        header-scroll := Flickable {
-            height:         root.row-height;
-            interactive:    false;
-            viewport-width: root.vp-w;
+    // ── Root FocusScope ───────────────────────────────────────────────────────
+    // capture-key-pressed fires root→focused so it intercepts keys regardless
+    // of which child (search-input, cell-value-input) currently holds focus.
+    table-fs := FocusScope {
+        x: 0; y: 0;
+        width: parent.width; height: parent.height;
+        focus-on-click: true;
 
-            HorizontalLayout {
-                spacing: 0;
-                for col[i] in root.columns: Rectangle {
-                    // Use per-column width when available; fall back to default.
-                    width: root.col-widths.length > i && root.col-widths[i] > 0
-                        ? root.col-widths[i] * 1px
-                        : root.default-col-w;
-                    height: root.row-height;
-                    background: #313244;
-                    clip: true;
-
-                    // Column label — always elides to stay within the cell.
-                    Text {
-                        x: 8px;
-                        y: (parent.height - self.height) / 2;
-                        // Leave 4px for the drag handle on the right.
-                        width: parent.width - 12px;
-                        text: col;
-                        color: #cdd6f4;
-                        font-size: 12px;
-                        overflow: elide;
+        capture-key-pressed(event) => {
+            if (root.is-loading || root.error-message != "" || root.columns.length == 0) {
+                EventResult.reject
+            } else if (root.nav-mode == 2) {
+                // Search mode: intercept Enter and Esc; reject all other keys so
+                // search-input receives them for editing.
+                if (event.text == Key.Return) {
+                    root.filter-rows(root.search-query);
+                    root.nav-mode = 0;
+                    table-fs.focus();
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    root.nav-mode = 0;
+                    table-fs.focus();
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            } else if (root.nav-mode == 1) {
+                // Cell mode
+                if (event.text == Key.LeftArrow) {
+                    if (root.selected-col > 0) { root.selected-col -= 1; }
+                    EventResult.accept
+                } else if (event.text == Key.RightArrow) {
+                    if (root.selected-col < root.columns.length - 1) {
+                        root.selected-col += 1;
                     }
-
-                    // ── Column resize drag handle (right edge) ────────────────
-                    // 4 px strip; cursor changes to ew-resize on hover.
-                    // Drag formula (same principle as the panel-height drag):
-                    //   width_new = width_current + (mouse-x - pressed-x)
-                    // After the update the handle repositions so that mouse-x
-                    // returns to pressed-x — zero drift, cursor tracks exactly.
-                    Rectangle {
-                        x: parent.width - 4px;
-                        y: 0;
-                        width:  4px;
-                        height: parent.height;
-                        background: col-resize-ta.has-hover || col-resize-ta.pressed
-                            ? #89b4fa : #45475a;
-
-                        col-resize-ta := TouchArea {
-                            mouse-cursor: ew-resize;
-                            moved => {
-                                let cw = root.col-widths.length > i && root.col-widths[i] > 0
-                                    ? root.col-widths[i] * 1px
-                                    : root.default-col-w;
-                                let new-w = max(
-                                    cw + (self.mouse-x - self.pressed-x),
-                                    root.min-col-w
-                                );
-                                root.resize-column(i, new-w / 1px);
-                            }
-                        }
+                    EventResult.accept
+                } else if (event.text == Key.Home) {
+                    root.selected-col = 0;
+                    EventResult.accept
+                } else if (event.text == Key.End) {
+                    if (root.columns.length > 0) {
+                        root.selected-col = root.columns.length - 1;
                     }
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    root.nav-mode = 0;
+                    root.selected-col = -1;
+                    EventResult.accept
+                } else if (event.text == "c" && event.modifiers.control) {
+                    if (root.selected-row >= 0 && root.selected-col >= 0
+                            && root.selected-row < root.rows.length
+                            && root.selected-col < root.rows[root.selected-row].cells.length) {
+                        root.copy-cell(root.rows[root.selected-row].cells[root.selected-col]);
+                    }
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            } else {
+                // Row mode
+                if (event.text == Key.UpArrow) {
+                    root.selected-cell-value = "";
+                    if (root.selected-row > 0) {
+                        root.selected-row -= 1;
+                    } else if (root.row-count > 0) {
+                        root.selected-row = 0;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.DownArrow) {
+                    root.selected-cell-value = "";
+                    if (root.selected-row < 0 && root.row-count > 0) {
+                        root.selected-row = 0;
+                    } else if (root.selected-row < root.row-count - 1) {
+                        root.selected-row += 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Home) {
+                    root.selected-cell-value = "";
+                    if (root.row-count > 0) { root.selected-row = 0; }
+                    EventResult.accept
+                } else if (event.text == Key.End) {
+                    root.selected-cell-value = "";
+                    if (root.row-count > 0) { root.selected-row = root.row-count - 1; }
+                    EventResult.accept
+                } else if (event.text == Key.PageUp) {
+                    root.selected-cell-value = "";
+                    if (root.selected-row > 0) {
+                        root.selected-row = max(0, root.selected-row - root.page-rows);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.PageDown) {
+                    root.selected-cell-value = "";
+                    if (root.selected-row < root.row-count - 1) {
+                        root.selected-row = min(
+                            root.row-count - 1, root.selected-row + root.page-rows);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Return) {
+                    if (root.selected-row >= 0 && root.columns.length > 0) {
+                        root.nav-mode = 1;
+                        root.selected-col = 0;
+                    }
+                    EventResult.accept
+                } else if (event.text == "f"
+                        && !event.modifiers.control
+                        && !event.modifiers.alt
+                        && !event.modifiers.shift) {
+                    root.search-query = "";
+                    root.nav-mode = 2;
+                    search-input.focus();
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    if (root.active-filter != "") {
+                        root.clear-filter();
+                    } else {
+                        root.selected-row        = -1;
+                        root.selected-cell-value = "";
+                    }
+                    EventResult.accept
+                } else if (event.text == "c" && event.modifiers.control) {
+                    if (root.selected-cell-value != "") {
+                        root.copy-cell(root.selected-cell-value);
+                    }
+                    EventResult.accept
+                } else {
+                    EventResult.reject
                 }
             }
         }
 
-        // ── Body (horizontal + vertical virtual scroll via ListView) ─────────
-        // ListView only instantiates visible rows, keeping scroll smooth with
-        // large result sets.
-        Rectangle {
-            vertical-stretch: 1;
-            clip: true;
+        // ── Loading overlay ───────────────────────────────────────────────────
+        if root.is-loading: Rectangle {
+            width:  parent.width;
+            height: parent.height;
+            background: #1e1e2e;
+            Text {
+                x: (parent.width  - self.width)  / 2;
+                y: (parent.height - self.height) / 2;
+                text: @tr("Running\u{2026}");
+                color: #cdd6f4;
+                font-size: 13px;
+            }
+        }
 
-            body-scroll := ListView {
-                width:          parent.width;
-                height:         parent.height;
+        // ── Error panel ───────────────────────────────────────────────────────
+        if !root.is-loading && root.error-message != "": Rectangle {
+            width:  parent.width;
+            height: parent.height;
+            background: #2d1b1b;
+            VerticalLayout {
+                alignment: start;
+                padding: 16px;
+                spacing: 8px;
+                Text {
+                    text: @tr("Query Error");
+                    color: #f38ba8;
+                    font-size: 13px;
+                    font-weight: 700;
+                }
+                Text {
+                    text: root.error-message;
+                    color: #cdd6f4;
+                    font-size: 12px;
+                    wrap: word-wrap;
+                }
+            }
+        }
+
+        // ── Result content ────────────────────────────────────────────────────
+        if !root.is-loading && root.error-message == "": VerticalLayout {
+            width:  parent.width;
+            height: parent.height - root.bottom-total;
+
+            // ── Header row ────────────────────────────────────────────────────
+            header-scroll := Flickable {
+                height:         root.row-height;
+                interactive:    false;
                 viewport-width: root.vp-w;
+                // One-way bind: follows body-vp-x so header tracks horizontal scroll.
+                viewport-x:     root.body-vp-x;
 
-                // Sync header horizontal position when body scrolls.
-                changed viewport-x => { header-scroll.viewport-x = self.viewport-x; }
-
-                for row[i] in root.rows: Rectangle {
-                    height: root.row-height;
-                    width:  root.vp-w;
-                    // Highlight the selected row; alternate zebra stripe otherwise.
-                    background: i == root.selected-row
-                        ? #264f78
-                        : (mod(i, 2) == 0 ? #1e1e2e : #181825);
-
-                    Rectangle {   // bottom border
-                        y: parent.height - 1px;
-                        width: parent.width;
-                        height: 1px;
+                HorizontalLayout {
+                    spacing: 0;
+                    for col[i] in root.columns: Rectangle {
+                        width: root.col-widths.length > i && root.col-widths[i] > 0
+                            ? root.col-widths[i] * 1px
+                            : root.default-col-w;
+                        height: root.row-height;
                         background: #313244;
-                    }
+                        clip: true;
 
-                    HorizontalLayout {
-                        spacing: 0;
-                        for cell[j] in row.cells: Rectangle {
-                            width: root.col-widths.length > j && root.col-widths[j] > 0
-                                ? root.col-widths[j] * 1px
-                                : root.default-col-w;
-                            height: root.row-height;
-                            clip: true;
+                        Text {
+                            x: 8px;
+                            y: (parent.height - self.height) / 2;
+                            width: parent.width - 12px;
+                            text: col;
+                            color: #cdd6f4;
+                            font-size: 12px;
+                            overflow: elide;
+                        }
 
-                            Rectangle {   // right border
-                                x: parent.width - 1px;
-                                width: 1px;
-                                height: parent.height;
-                                background: #313244;
-                            }
+                        // ── Column resize drag handle ─────────────────────────
+                        Rectangle {
+                            x: parent.width - 4px;
+                            y: 0;
+                            width:  4px;
+                            height: parent.height;
+                            background: col-resize-ta.has-hover || col-resize-ta.pressed
+                                ? #89b4fa : #45475a;
 
-                            Text {
-                                x: 8px;
-                                y: (parent.height - self.height) / 2;
-                                width: parent.width - 16px;
-                                text: cell;
-                                color: i == root.selected-row ? #ffffff : #a6adc8;
-                                font-size: 12px;
-                                overflow: elide;
-                            }
-
-                            // Click → select row and show full value in the strip.
-                            TouchArea {
-                                clicked => {
-                                    root.selected-row        = i;
-                                    root.selected-cell-value = cell;
+                            col-resize-ta := TouchArea {
+                                mouse-cursor: ew-resize;
+                                moved => {
+                                    let cw = root.col-widths.length > i
+                                             && root.col-widths[i] > 0
+                                        ? root.col-widths[i] * 1px
+                                        : root.default-col-w;
+                                    let new-w = max(
+                                        cw + (self.mouse-x - self.pressed-x),
+                                        root.min-col-w
+                                    );
+                                    root.resize-column(i, new-w / 1px);
                                 }
                             }
                         }
@@ -246,55 +373,210 @@ export component ResultTable inherits Rectangle {
                 }
             }
 
-            // Zero-row placeholder (only when a query returned no rows).
-            if root.row-count == 0 && root.columns.length > 0: Rectangle {
-                x: 0; y: 0;
-                width:  parent.width;
-                height: parent.height;
-                Text {
-                    x: (parent.width  - self.width)  / 2;
-                    y: (parent.height - self.height) / 2;
-                    text: @tr("0 rows");
-                    color: #585b70;
-                    font-size: 13px;
+            // ── Body (ListView for virtual scrolling) ─────────────────────────
+            Rectangle {
+                vertical-stretch: 1;
+                clip: true;
+
+                body-scroll := ListView {
+                    width:          parent.width;
+                    height:         parent.height;
+                    viewport-width: root.vp-w;
+                    // Two-way bindings: user scroll gestures update root.body-vp-y/x;
+                    // programmatic scroll (changed selected-row/col) flows the other way.
+                    viewport-y <=> root.body-vp-y;
+                    viewport-x <=> root.body-vp-x;
+
+                    for row[i] in root.rows: Rectangle {
+                        height: root.row-height;
+                        width:  root.vp-w;
+                        background: i == root.selected-row
+                            ? #264f78
+                            : (mod(i, 2) == 0 ? #1e1e2e : #181825);
+
+                        Rectangle {   // bottom border
+                            y: parent.height - 1px;
+                            width: parent.width;
+                            height: 1px;
+                            background: #313244;
+                        }
+
+                        HorizontalLayout {
+                            spacing: 0;
+                            for cell[j] in row.cells: Rectangle {
+                                width: root.col-widths.length > j
+                                       && root.col-widths[j] > 0
+                                    ? root.col-widths[j] * 1px
+                                    : root.default-col-w;
+                                height: root.row-height;
+                                clip: true;
+
+                                // Cell-mode highlight: distinct tint on the focused column.
+                                if i == root.selected-row && j == root.selected-col
+                                        && root.nav-mode == 1: Rectangle {
+                                    width:  parent.width;
+                                    height: parent.height;
+                                    background: #89b4fa44;
+                                }
+
+                                Rectangle {   // right border
+                                    x: parent.width - 1px;
+                                    width: 1px;
+                                    height: parent.height;
+                                    background: #313244;
+                                }
+
+                                Text {
+                                    x: 8px;
+                                    y: (parent.height - self.height) / 2;
+                                    width: parent.width - 16px;
+                                    text: cell;
+                                    color: i == root.selected-row ? #ffffff : #a6adc8;
+                                    font-size: 12px;
+                                    overflow: elide;
+                                }
+
+                                TouchArea {
+                                    clicked => {
+                                        root.selected-row        = i;
+                                        root.selected-cell-value = cell;
+                                        cell-value-input.focus();
+                                        cell-value-input.set-selection-offsets(0, 2147483647);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Zero-row placeholder
+                if root.row-count == 0 && root.columns.length > 0: Rectangle {
+                    x: 0; y: 0;
+                    width:  parent.width;
+                    height: parent.height;
+                    Text {
+                        x: (parent.width  - self.width)  / 2;
+                        y: (parent.height - self.height) / 2;
+                        text: @tr("0 rows");
+                        color: #585b70;
+                        font-size: 13px;
+                    }
                 }
             }
         }
-    }
 
-    // ── Cell value strip ──────────────────────────────────────────────────────
-    // Always instantiated (so cell-value-input is always reachable from the
-    // `changed selected-cell-value` handler above), but collapses to height 0
-    // when no cell is selected.
-    Rectangle {
-        x: 0;
-        y: root.height - (root.selected-cell-value != "" ? 28px : 0px);
-        width:  root.width;
-        height: root.selected-cell-value != "" ? 28px : 0px;
-        background: #2a2a3e;
-        clip: true;
-
-        // Top separator line.
+        // ── Search bar ────────────────────────────────────────────────────────
+        // Always in the tree (so search-input is always reachable) but
+        // clipped to height 0 when not in search mode.
         Rectangle {
-            x: 0; y: 0;
-            width: parent.width; height: 1px;
-            background: #45475a;
+            x: 0;
+            y: root.height - root.cell-strip-h - root.filter-banner-h - root.search-bar-h;
+            width:  root.width;
+            height: root.search-bar-h;
+            background: #1e1e2e;
+            clip: true;
+
+            Rectangle {   // top separator
+                x: 0; y: 0;
+                width: parent.width; height: 1px;
+                background: #45475a;
+            }
+
+            Text {
+                x: 10px;
+                y: (parent.height - self.height) / 2;
+                text: "/";
+                color: #89b4fa;
+                font-size: 13px;
+                font-weight: 700;
+            }
+
+            search-input := TextInput {
+                x: 26px;
+                y: (parent.height - self.height) / 2;
+                width: parent.width - 34px;
+                text <=> root.search-query;
+                single-line: true;
+                color: #cdd6f4;
+                selection-background-color: #264f78;
+                selection-foreground-color: #ffffff;
+                font-size: 12px;
+            }
         }
 
-        // Read-only TextInput: text is selectable and copyable (Ctrl+C) but
-        // cannot be modified.  The `changed` handler above calls focus() and
-        // set-selection-offsets(0, MAX) so everything is pre-selected on click.
-        cell-value-input := TextInput {
-            x: 8px;
-            y: (parent.height - self.height) / 2;
-            width: parent.width - 16px;
-            text: root.selected-cell-value;
-            read-only: true;
-            single-line: true;
-            color: #cdd6f4;
-            selection-background-color: #264f78;
-            selection-foreground-color: #ffffff;
-            font-size: 12px;
+        // ── Filter indicator banner ───────────────────────────────────────────
+        // Shown below the search bar when a filter is active.
+        Rectangle {
+            x: 0;
+            y: root.height - root.cell-strip-h - root.filter-banner-h;
+            width:  root.width;
+            height: root.filter-banner-h;
+            background: #1e3a5f;
+            clip: true;
+
+            Rectangle {   // top separator
+                x: 0; y: 0;
+                width: parent.width; height: 1px;
+                background: #2a5298;
+            }
+
+            HorizontalLayout {
+                padding-left: 10px;
+                padding-right: 10px;
+                spacing: 6px;
+
+                Text {
+                    text: @tr("Filter:");
+                    color: #89b4fa;
+                    font-size: 11px;
+                    font-weight: 700;
+                    vertical-alignment: center;
+                }
+                Text {
+                    text: root.active-filter;
+                    color: #cdd6f4;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                    overflow: elide;
+                    horizontal-stretch: 1;
+                }
+                Text {
+                    text: @tr("[Esc to clear]");
+                    color: #585b70;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                }
+            }
+        }
+
+        // ── Cell value strip ──────────────────────────────────────────────────
+        // Always in the tree; collapses to height 0 when no cell is selected.
+        Rectangle {
+            x: 0;
+            y: root.height - root.cell-strip-h;
+            width:  root.width;
+            height: root.cell-strip-h;
+            background: #2a2a3e;
+            clip: true;
+
+            Rectangle {   // top separator
+                x: 0; y: 0;
+                width: parent.width; height: 1px;
+                background: #45475a;
+            }
+
+            cell-value-input := TextInput {
+                x: 8px;
+                y: (parent.height - self.height) / 2;
+                width: parent.width - 16px;
+                text: root.selected-cell-value;
+                read-only: true;
+                single-line: true;
+                color: #cdd6f4;
+                selection-background-color: #264f78;
+                selection-foreground-color: #ffffff;
+                font-size: 12px;
+            }
         }
     }
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -11,6 +11,17 @@ use tokio::sync::mpsc;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, TableInfo};
 
+// ---------------------------------------------------------------------------
+// Original query result — retained for client-side filtering
+// ---------------------------------------------------------------------------
+
+struct OriginalQueryData {
+    columns: Vec<slint::SharedString>,
+    rows: Vec<Vec<slint::SharedString>>,
+}
+
+type SharedOriginalData = Arc<Mutex<Option<OriginalQueryData>>>;
+
 use crate::{
     app::{command::Command, event::Event},
     state::SharedState,
@@ -189,6 +200,10 @@ impl UI {
         let sidebar_state: Arc<Mutex<SidebarUiState>> =
             Arc::new(Mutex::new(SidebarUiState::default()));
 
+        // Shared storage for the unfiltered query result; written by the event
+        // handler on QueryFinished, read by the filter callbacks on the UI thread.
+        let original_data: SharedOriginalData = Arc::new(Mutex::new(None));
+
         Self::register_sidebar_callbacks(
             &window,
             state.clone(),
@@ -198,9 +213,15 @@ impl UI {
         );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
-        Self::register_result_callbacks(&window, state.clone());
+        Self::register_result_callbacks(&window, state.clone(), Arc::clone(&original_data));
         Self::register_status_callbacks(&window, state.clone());
-        Self::spawn_event_handler(&window, rx_event, state, Arc::clone(&sidebar_state));
+        Self::spawn_event_handler(
+            &window,
+            rx_event,
+            state,
+            Arc::clone(&sidebar_state),
+            Arc::clone(&original_data),
+        );
 
         Ok(Self { window })
     }
@@ -217,6 +238,7 @@ impl UI {
         mut rx_event: mpsc::Receiver<Event>,
         state: SharedState,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
+        original_data: SharedOriginalData,
     ) {
         let window_weak = window.as_weak();
         tokio::spawn(async move {
@@ -362,6 +384,16 @@ impl UI {
                             .collect();
                         let row_count = result.row_count as i32;
                         let exec_ms = result.execution_time_ms;
+
+                        // Store original rows for client-side filtering.
+                        {
+                            let mut orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                            *orig = Some(OriginalQueryData {
+                                columns: columns.clone(),
+                                rows: raw_rows.clone(),
+                            });
+                        }
+
                         // clone required: invoke_from_event_loop closure must be 'static
                         let window_weak = window_weak.clone();
                         let _ = slint::invoke_from_event_loop(move || {
@@ -370,6 +402,7 @@ impl UI {
                             };
                             let ui = window.global::<crate::UiState>();
                             ui.set_is_loading(false);
+                            ui.set_result_active_filter("".into()); // clear stale filter
                             // VecModel created on UI thread (Rc is not Send)
                             let col_model = Rc::new(slint::VecModel::from(columns));
                             ui.set_result_columns(col_model.into());
@@ -823,26 +856,113 @@ impl UI {
 
     // ── Result callbacks ──────────────────────────────────────────────────────
 
-    fn register_result_callbacks(window: &crate::AppWindow, _state: SharedState) {
+    fn register_result_callbacks(
+        window: &crate::AppWindow,
+        _state: SharedState,
+        original_data: SharedOriginalData,
+    ) {
         let ui_state = window.global::<crate::UiState>();
-        // clone required: callback closure must be 'static
         let window_weak = window.as_weak();
 
         // resize-result-column: update the column width VecModel in place and
         // recompute the total so viewport-width stays accurate during drag.
-        ui_state.on_resize_result_column(move |i, w| {
-            let Some(window) = window_weak.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            let model = ui.get_result_col_widths();
-            let n = model.row_count();
-            if (i as usize) < n {
-                model.set_row_data(i as usize, w);
-                let total: f32 = (0..n).filter_map(|j| model.row_data(j)).sum();
-                ui.set_result_total_col_width(total);
-            }
-        });
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_resize_result_column(move |i, w| {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let model = ui.get_result_col_widths();
+                let n = model.row_count();
+                if (i as usize) < n {
+                    model.set_row_data(i as usize, w);
+                    let total: f32 = (0..n).filter_map(|j| model.row_data(j)).sum();
+                    ui.set_result_total_col_width(total);
+                }
+            });
+        }
+
+        // filter-result-rows: apply client-side predicate and update the displayed rows.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            let original_data = Arc::clone(&original_data);
+            ui_state.on_filter_result_rows(move |query| {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                let Some(ref data) = *orig else {
+                    return;
+                };
+                let filtered = filter_rows(&data.columns, &data.rows, query.as_str());
+                let row_count = filtered.len() as i32;
+                let rows: Vec<crate::RowData> = filtered
+                    .into_iter()
+                    .map(|cells| crate::RowData {
+                        cells: Rc::new(slint::VecModel::from(cells)).into(),
+                    })
+                    .collect();
+                ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                ui.set_result_row_count(row_count);
+                ui.set_result_active_filter(query);
+            });
+        }
+
+        // clear-result-filter: restore the unfiltered original rows.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            let original_data = Arc::clone(&original_data);
+            ui_state.on_clear_result_filter(move || {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                let Some(ref data) = *orig else {
+                    return;
+                };
+                let row_count = data.rows.len() as i32;
+                let rows: Vec<crate::RowData> = data
+                    .rows
+                    .iter()
+                    .map(|cells| crate::RowData {
+                        cells: Rc::new(slint::VecModel::from(cells.clone())).into(),
+                    })
+                    .collect();
+                ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                ui.set_result_row_count(row_count);
+                ui.set_result_active_filter("".into());
+            });
+        }
+
+        // copy-result-cell: write the value to the system clipboard via arboard.
+        {
+            ui_state.on_copy_result_cell(move |value| {
+                if let Ok(mut clip) = arboard::Clipboard::new() {
+                    let _ = clip.set_text(value.as_str());
+                }
+            });
+        }
+
+        // col-x-offset (pure): cumulative x-position of column j (sum of widths 0..j).
+        // Used by result_table.slint's `changed selected-col` handler to auto-scroll.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_col_x_offset(move |j| {
+                let Some(window) = window_weak.upgrade() else {
+                    return 0.0;
+                };
+                let ui = window.global::<crate::UiState>();
+                let model = ui.get_result_col_widths();
+                (0..j as usize).filter_map(|i| model.row_data(i)).sum()
+            });
+        }
     }
 
     // ── Status callbacks (TODO) ───────────────────────────────────────────────
@@ -938,6 +1058,55 @@ fn build_conn_from_form(ui: &crate::UiState, enc_key: &[u8; 32]) -> (DbConnectio
     };
 
     (conn, password)
+}
+
+// ── Result filter helpers ─────────────────────────────────────────────────────
+
+/// Filter `rows` according to `query`:
+///
+/// * Empty query → return all rows.
+/// * `col_name = 'value'` → exact match on the named column (case-insensitive column name).
+/// * Anything else → case-insensitive substring match across all columns.
+fn filter_rows(
+    columns: &[slint::SharedString],
+    rows: &[Vec<slint::SharedString>],
+    query: &str,
+) -> Vec<Vec<slint::SharedString>> {
+    let query = query.trim();
+    if query.is_empty() {
+        return rows.to_vec();
+    }
+    if let Some((col_name, value)) = parse_col_eq(query) {
+        let col_idx = columns
+            .iter()
+            .position(|c| c.as_str().eq_ignore_ascii_case(&col_name));
+        match col_idx {
+            Some(idx) => rows
+                .iter()
+                .filter(|row| row.get(idx).is_some_and(|v| v.as_str() == value))
+                .cloned()
+                .collect(),
+            None => vec![],
+        }
+    } else {
+        let query_lower = query.to_lowercase();
+        rows.iter()
+            .filter(|row| {
+                row.iter()
+                    .any(|cell| cell.as_str().to_lowercase().contains(&query_lower))
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+/// Parse `col = 'value'` syntax.  Returns `(column_name, value_str)` on success.
+fn parse_col_eq(query: &str) -> Option<(String, &str)> {
+    let mut parts = query.splitn(2, '=');
+    let col = parts.next()?.trim();
+    let rest = parts.next()?.trim();
+    let val = rest.strip_prefix('\'')?.strip_suffix('\'')?;
+    Some((col.to_string(), val))
 }
 
 // ---------------------------------------------------------------------------
@@ -1036,6 +1205,53 @@ mod tests {
         assert!(!nodes[0].is_active);
         assert!(nodes[1].is_active);
     }
+
+    // ── filter_rows tests ─────────────────────────────────────────────────────
+
+    fn ss(s: &str) -> slint::SharedString {
+        s.into()
+    }
+
+    #[test]
+    fn filter_rows_should_return_all_when_query_empty() {
+        let cols = vec![ss("id"), ss("name")];
+        let rows = vec![vec![ss("1"), ss("Alice")], vec![ss("2"), ss("Bob")]];
+        assert_eq!(filter_rows(&cols, &rows, "").len(), 2);
+        assert_eq!(filter_rows(&cols, &rows, "   ").len(), 2);
+    }
+
+    #[test]
+    fn filter_rows_should_match_substring_across_all_columns() {
+        let cols = vec![ss("name"), ss("city")];
+        let rows = vec![
+            vec![ss("Alice"), ss("Tokyo")],
+            vec![ss("Bob"), ss("Osaka")],
+            vec![ss("Alice Smith"), ss("Kyoto")],
+        ];
+        let result = filter_rows(&cols, &rows, "alice");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0][0].as_str(), "Alice");
+        assert_eq!(result[1][0].as_str(), "Alice Smith");
+    }
+
+    #[test]
+    fn filter_rows_should_match_exact_column_value() {
+        let cols = vec![ss("name"), ss("city")];
+        let rows = vec![vec![ss("Alice"), ss("Tokyo")], vec![ss("Bob"), ss("Osaka")]];
+        let result = filter_rows(&cols, &rows, "city = 'Tokyo'");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0][1].as_str(), "Tokyo");
+    }
+
+    #[test]
+    fn filter_rows_should_return_empty_when_column_not_found() {
+        let cols = vec![ss("name")];
+        let rows = vec![vec![ss("Alice")]];
+        let result = filter_rows(&cols, &rows, "missing = 'x'");
+        assert!(result.is_empty());
+    }
+
+    // ── append_editor_text tests ──────────────────────────────────────────────
 
     #[test]
     fn append_editor_text_should_set_text_when_editor_is_empty() {

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,119 @@
+# Wellfeather — Keyboard Shortcuts Reference
+
+---
+
+## Global — Pane Focus Navigation
+
+These shortcuts work from any pane (no modal must be open).
+
+| Key | Action | Condition |
+|-----|--------|-----------|
+| `Alt+→` | Move focus: Sidebar → Editor | Focus is on Sidebar |
+| `Alt+←` | Move focus: Editor → Sidebar | Focus is on Editor |
+| `Alt+↓` | Move focus: Editor → Result panel | Focus is on Editor; result panel is open |
+| `Alt+↑` | Move focus: Result panel → Editor | Focus is on Result panel |
+
+> Pane borders are highlighted in blue (`#89b4fa`) to show which pane is active.
+
+---
+
+## Editor (SQL Editor)
+
+### Custom shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+Enter` | Run query (fires `run-query` callback) |
+| `Ctrl+J` | Toggle result panel open / closed |
+| `↑` / `↓` | Move cursor up / down one line (timer-based, no key-repeat lag) |
+
+### Standard text-editing shortcuts (via OS / TextInput)
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+C` | Copy selection |
+| `Ctrl+X` | Cut selection |
+| `Ctrl+V` | Paste |
+| `Ctrl+A` | Select all |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Y` | Redo |
+| `Shift+Arrow` | Extend selection |
+| `Ctrl+←` / `Ctrl+→` | Move by word |
+| `Home` / `End` | Move to line start / end |
+| `Ctrl+Home` / `Ctrl+End` | Move to document start / end |
+
+---
+
+## Sidebar
+
+The sidebar must be focused (`Alt+←` or click) for these keys to work.
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Move keyboard focus up / down in the tree |
+| `→` | Expand node; or move to first child if already expanded |
+| `←` | Collapse node; or jump to parent node if already collapsed |
+| `Enter` | Open table / view (leaf nodes); toggle expand (connection / category nodes) |
+
+> The focused row is highlighted in blue. The cursor is clamped when the tree model changes (e.g. after expand/collapse).
+
+---
+
+## Result Table
+
+> **Note:** Row / cell / search mode navigation is planned in Issue #138 and not yet implemented. The section below documents the intended final behaviour.
+
+The result table must be focused (`Alt+↓` or click) for these keys to work.
+
+### Row mode (default)
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Move selected row |
+| `Page Up` / `Page Down` | Move by one viewport page |
+| `Home` / `End` | First / last row |
+| `Enter` | Enter cell mode (column 0 of current row) |
+| `F` | Enter search mode |
+| `Esc` | Deselect / clear active filter |
+| `Ctrl+C` | Copy selected cell value |
+
+### Cell mode (entered with `Enter` from row mode)
+
+Navigates within a single row. `Esc` returns to row mode.
+
+| Key | Action |
+|-----|--------|
+| `←` / `→` | Move to previous / next column |
+| `Home` / `End` | First / last column |
+| `Esc` | Return to row mode |
+| `Ctrl+C` | Copy current cell value |
+
+### Search mode (entered with `F` from row mode)
+
+A search bar appears at the bottom of the panel. All keystrokes are captured by the search input.
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Apply filter → return to row mode |
+| `Esc` | Cancel → return to row mode (no filter change) |
+
+#### Search query format
+
+| Input example | Behaviour |
+|---------------|-----------|
+| `山田太郎` | Substring match across **all** columns |
+| `name = '山田太郎'` | Exact match on the **`name`** column |
+
+Filtering is client-side (current result set only). An active-filter indicator is shown above the search bar while a filter is applied.
+
+---
+
+## Connection Form (Modal)
+
+Standard form navigation — no custom shortcuts.
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift+Tab` | Move between fields |
+| `Enter` | Submit form |
+| `Esc` | Close modal (via Cancel button equivalent) |


### PR DESCRIPTION
## Summary

Implements T052: full keyboard navigation for the result table. Adds a three-mode state machine (row / cell / search), client-side row filtering with a visible filter banner, horizontal/vertical auto-scroll, and clipboard copy via `arboard`. The result panel is now always instantiated (hidden via `visible:`) so focus state can be observed from `AppWindow` scope.

## Changes

- `result_table.slint`: complete rewrite — `FocusScope` with `capture-key-pressed` intercepts keys; row mode (`↑↓ Home End PgUp PgDn Enter F Esc Ctrl+C`), cell mode (`←→ Home End Esc Ctrl+C`), search mode (type to build query, `Enter` applies, `Esc` cancels); filter indicator banner; search bar; cell value strip; auto-scroll for both axes using component-level `body-vp-y/x` properties bound two-way to `ListView.viewport-y/x` (avoids accessing a conditionally-instantiated element from `changed` handlers)
- `app.slint`: result panel Rectangle changed from `if UiState.result-panel-open:` to `visible: UiState.result-panel-open` so `result-table-inst` is always accessible; new UiState callbacks `filter-result-rows`, `clear-result-filter`, `copy-result-cell`, pure `col-x-offset` wired through
- `app/src/ui/mod.rs`: `OriginalQueryData` struct + `SharedOriginalData` type for client-side filter storage; `register_result_callbacks` updated with `on_filter_result_rows`, `on_clear_result_filter`, `on_copy_result_cell`, `on_col_x_offset`; `filter_rows` and `parse_col_eq` helpers; 4 new unit tests
- `app/Cargo.toml`: added `arboard = "3.6.1"` for clipboard access
- `docs/keybindings.md`: new file documenting all keyboard shortcuts across the application

## Related Issues

Closes #138

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes