### PR TITLE
feat(result-table): add right-click context menu for copy operations

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -49,6 +49,10 @@ export global UiState {
     callback clear-result-filter();
     /// Copy a cell value to the system clipboard.
     callback copy-result-cell(string);
+    /// Copy row i cells to clipboard (tab-separated, NULL → empty string).
+    callback copy-result-row(int);
+    /// Copy all visible rows as TSV with column headers.
+    callback copy-result-tsv();
     /// Returns cumulative x-offset (logical px as float) of column j.
     pure callback col-x-offset(int) -> float;
 
@@ -472,6 +476,8 @@ export component AppWindow inherits Window {
                     filter-rows(q)       => { UiState.filter-result-rows(q); }
                     clear-filter         => { UiState.clear-result-filter(); }
                     copy-cell(v)         => { UiState.copy-result-cell(v); }
+                    copy-row(i)          => { UiState.copy-result-row(i); }
+                    copy-all-tsv         => { UiState.copy-result-tsv(); }
                     col-x-offset(j)      => { UiState.col-x-offset(j); }
                     sort-col:            UiState.result-sort-col;
                     sort-asc:            UiState.result-sort-asc;

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -61,6 +61,10 @@ export component ResultTable inherits Rectangle {
     callback filter-rows(string);
     callback clear-filter();
     callback copy-cell(string);
+    /// Copy row i cells to clipboard (tab-separated, NULL → empty string).
+    callback copy-row(int);
+    /// Copy all visible rows as TSV with column headers.
+    callback copy-all-tsv();
     /// Returns cumulative x-offset (logical px as float) of column j.
     /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
     pure callback col-x-offset(int) -> float;
@@ -72,6 +76,13 @@ export component ResultTable inherits Rectangle {
     in property <int>  sort-col: -1;
     /// true = ascending (▲), false = descending (▼).
     in property <bool> sort-asc: true;
+
+    // ── Context menu state ────────────────────────────────────────────────────
+    property <length> ctx-menu-x:       0;
+    property <length> ctx-menu-y:       0;
+    property <int>    ctx-row:          -1;
+    property <string> ctx-cell-value:   "";
+    property <bool>   ctx-cell-is-null: false;
 
     // ── Style constants ───────────────────────────────────────────────────────
     property <length> row-height:    28px;
@@ -291,6 +302,76 @@ export component ResultTable inherits Rectangle {
             }
         }
 
+        // ── Right-click context menu ──────────────────────────────────────────
+        ctx-popup := PopupWindow {
+            x: root.ctx-menu-x;
+            y: root.ctx-menu-y;
+            width: 204px;
+            height: 90px;
+            close-policy: PopupClosePolicy.close-on-click;
+
+            Rectangle {
+                width: 204px;
+                height: 90px;
+                background: #313244;
+                border-radius: 4px;
+                border-width: 1px;
+                border-color: #585b70;
+                drop-shadow-blur: 8px;
+                drop-shadow-color: #00000088;
+                clip: true;
+
+                VerticalLayout {
+                    spacing: 0;
+
+                    Rectangle {
+                        height: 30px;
+                        background: mi1.has-hover ? #45475a : transparent;
+                        mi1 := TouchArea {
+                            clicked => { root.copy-cell(root.ctx-cell-value); }
+                        }
+                        Text {
+                            x: 12px;
+                            y: (parent.height - self.height) / 2;
+                            text: @tr("Copy cell value");
+                            color: #cdd6f4;
+                            font-size: 12px;
+                        }
+                    }
+
+                    Rectangle {
+                        height: 30px;
+                        background: mi2.has-hover ? #45475a : transparent;
+                        mi2 := TouchArea {
+                            clicked => { root.copy-row(root.ctx-row); }
+                        }
+                        Text {
+                            x: 12px;
+                            y: (parent.height - self.height) / 2;
+                            text: @tr("Copy row (tab-separated)");
+                            color: #cdd6f4;
+                            font-size: 12px;
+                        }
+                    }
+
+                    Rectangle {
+                        height: 30px;
+                        background: mi3.has-hover ? #45475a : transparent;
+                        mi3 := TouchArea {
+                            clicked => { root.copy-all-tsv(); }
+                        }
+                        Text {
+                            x: 12px;
+                            y: (parent.height - self.height) / 2;
+                            text: @tr("Copy as TSV (with headers)");
+                            color: #cdd6f4;
+                            font-size: 12px;
+                        }
+                    }
+                }
+            }
+        }
+
         // ── Loading overlay ───────────────────────────────────────────────────
         if root.is-loading: Rectangle {
             width:  parent.width;
@@ -499,6 +580,29 @@ export component ResultTable inherits Rectangle {
                                         root.selected-cell-value   = cell.value;
                                         root.selected-cell-is-null = cell.is-null;
                                         table-fs.focus();
+                                    }
+                                    pointer-event(event) => {
+                                        if (event.button == PointerEventButton.right
+                                                && event.kind == PointerEventKind.down) {
+                                            root.selected-row          = i;
+                                            root.ctx-row               = i;
+                                            root.ctx-cell-value        = cell.value;
+                                            root.ctx-cell-is-null      = cell.is-null;
+                                            root.selected-cell-value   = cell.value;
+                                            root.selected-cell-is-null = cell.is-null;
+                                            root.ctx-menu-x = clamp(
+                                                root.col-x-offset(j) * 1px + root.body-vp-x + self.mouse-x,
+                                                0,
+                                                root.width - 208px
+                                            );
+                                            root.ctx-menu-y = clamp(
+                                                root.row-height + i * root.row-height + root.body-vp-y + self.mouse-y,
+                                                0,
+                                                root.height - 96px
+                                            );
+                                            ctx-popup.show();
+                                            table-fs.focus();
+                                        }
                                     }
                                 }
                             }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -944,6 +944,73 @@ impl UI {
             });
         }
 
+        // copy-result-row: join visible row i cells with tabs, NULL → empty string.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_copy_result_row(move |row_i| {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let rows_model = ui.get_result_rows();
+                if let Some(row) = rows_model.row_data(row_i as usize) {
+                    let cells: Vec<Option<String>> = (0..row.cells.row_count())
+                        .filter_map(|j| row.cells.row_data(j))
+                        .map(|c| {
+                            if c.is_null {
+                                None
+                            } else {
+                                Some(c.value.to_string())
+                            }
+                        })
+                        .collect();
+                    let tsv = cells_to_tsv(&cells);
+                    if let Ok(mut clip) = arboard::Clipboard::new() {
+                        let _ = clip.set_text(tsv);
+                    }
+                }
+            });
+        }
+
+        // copy-result-tsv: export all visible rows as TSV with column headers.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_copy_result_tsv(move || {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let cols_model = ui.get_result_columns();
+                let rows_model = ui.get_result_rows();
+                let columns: Vec<String> = (0..cols_model.row_count())
+                    .filter_map(|i| cols_model.row_data(i))
+                    .map(|s| s.to_string())
+                    .collect();
+                let rows: Vec<Vec<Option<String>>> = (0..rows_model.row_count())
+                    .filter_map(|i| rows_model.row_data(i))
+                    .map(|row| {
+                        (0..row.cells.row_count())
+                            .filter_map(|j| row.cells.row_data(j))
+                            .map(|c| {
+                                if c.is_null {
+                                    None
+                                } else {
+                                    Some(c.value.to_string())
+                                }
+                            })
+                            .collect()
+                    })
+                    .collect();
+                let col_strs: Vec<&str> = columns.iter().map(String::as_str).collect();
+                let tsv = result_to_tsv(&col_strs, &rows);
+                if let Ok(mut clip) = arboard::Clipboard::new() {
+                    let _ = clip.set_text(tsv);
+                }
+            });
+        }
+
         // col-x-offset (pure): cumulative x-position of column j (sum of widths 0..j).
         // Used by result_table.slint's `changed selected-col` handler to auto-scroll.
         {
@@ -1111,6 +1178,25 @@ fn rows_to_ui(cells: Vec<Option<String>>) -> crate::RowData {
     crate::RowData {
         cells: Rc::new(slint::VecModel::from(cell_data)).into(),
     }
+}
+
+/// Join one row's cells as a TSV line. `None` (NULL) → empty string.
+fn cells_to_tsv(cells: &[Option<String>]) -> String {
+    cells
+        .iter()
+        .map(|c| c.as_deref().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\t")
+}
+
+/// Format `columns` + `rows` as a TSV string with a header line.
+fn result_to_tsv(columns: &[&str], rows: &[Vec<Option<String>>]) -> String {
+    let mut lines = Vec::with_capacity(rows.len() + 1);
+    lines.push(columns.join("\t"));
+    for row in rows {
+        lines.push(cells_to_tsv(row));
+    }
+    lines.join("\n")
 }
 
 /// Sort `rows` in-place by column `col`.
@@ -1401,6 +1487,50 @@ mod tests {
         assert_eq!(rows[0][0].as_deref(), Some("b"));
         assert_eq!(rows[1][0].as_deref(), Some("a"));
         assert!(rows[2][0].is_none());
+    }
+
+    // ── cells_to_tsv / result_to_tsv tests ───────────────────────────────────
+
+    #[test]
+    fn cells_to_tsv_should_join_values_with_tabs() {
+        let cells = vec![sv("a"), sv("b"), sv("c")];
+        assert_eq!(cells_to_tsv(&cells), "a\tb\tc");
+    }
+
+    #[test]
+    fn cells_to_tsv_should_render_null_as_empty_string() {
+        let cells = vec![sv("a"), None, sv("c")];
+        assert_eq!(cells_to_tsv(&cells), "a\t\tc");
+    }
+
+    #[test]
+    fn cells_to_tsv_should_handle_empty_row() {
+        let cells: Vec<Option<String>> = vec![];
+        assert_eq!(cells_to_tsv(&cells), "");
+    }
+
+    #[test]
+    fn result_to_tsv_should_include_header_and_rows() {
+        let cols = vec!["id", "name"];
+        let rows = vec![vec![sv("1"), sv("Alice")], vec![sv("2"), sv("Bob")]];
+        let tsv = result_to_tsv(&cols, &rows);
+        assert_eq!(tsv, "id\tname\n1\tAlice\n2\tBob");
+    }
+
+    #[test]
+    fn result_to_tsv_should_render_null_cells_as_empty_string() {
+        let cols = vec!["id", "name"];
+        let rows = vec![vec![sv("1"), None]];
+        let tsv = result_to_tsv(&cols, &rows);
+        assert_eq!(tsv, "id\tname\n1\t");
+    }
+
+    #[test]
+    fn result_to_tsv_should_produce_header_only_when_no_rows() {
+        let cols = vec!["id", "name"];
+        let rows: Vec<Vec<Option<String>>> = vec![];
+        let tsv = result_to_tsv(&cols, &rows);
+        assert_eq!(tsv, "id\tname");
     }
 
     // ── append_editor_text tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a right-click context menu to result table cells with three copy options: copy cell value, copy row as tab-separated, and copy all visible rows as TSV with headers. Ctrl+C was already working; this PR adds the right-click surface and the row/TSV copy operations.

## Changes

- `result_table.slint`: added `copy-row(int)` and `copy-all-tsv()` callbacks; added context menu state properties; added `PopupWindow` with three menu items (dark-themed, hover highlight); added `pointer-event` handler on cell `TouchArea` to detect right-click, compute popup position from scroll offsets, clamp to component bounds, and call `ctx-popup.show()`
- `app.slint`: added `copy-result-row(int)` and `copy-result-tsv()` callbacks to `UiState`; wired `copy-row` and `copy-all-tsv` in `result-table-inst`
- `mod.rs`: added `cells_to_tsv` and `result_to_tsv` pure helper functions; registered `on_copy_result_row` and `on_copy_result_tsv` callbacks that read from the visible VecModel and write to the system clipboard via arboard; added 6 unit tests covering the TSV helpers

## Related Issues

Closes #38

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes