### PR TITLE
feat(result-table): add pagination row-count selector (100/500/1000)

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -331,6 +331,9 @@ impl AppController {
 /// - Statements that already contain ` LIMIT ` are returned unchanged.
 /// - A trailing semicolon is stripped before appending the LIMIT clause.
 fn apply_limit(sql: &str, limit: usize) -> String {
+    if limit == 0 {
+        return sql.to_string();
+    }
     let trimmed = sql.trim().trim_end_matches(';').trim_end();
     let upper = trimmed.to_uppercase();
     if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") {
@@ -438,6 +441,11 @@ mod tests {
         );
         let with_limit = "select * from t limit 5";
         assert_eq!(apply_limit(with_limit, 500), with_limit);
+    }
+
+    #[test]
+    fn apply_limit_should_not_apply_when_limit_is_zero() {
+        assert_eq!(apply_limit("SELECT * FROM t", 0), "SELECT * FROM t");
     }
 
     // ── TestConnection ────────────────────────────────────────────────────────

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -239,6 +239,8 @@ impl AppController {
             }
         };
 
+        self.state.query.set_last_sql(sql.clone());
+
         let token = CancellationToken::new();
         self.state.query.set_cancel_token(token.clone());
         let _ = self.tx_event.send(Event::QueryStarted).await;

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -24,7 +24,11 @@ use wf_db::{error::DbError, models::DbConnection, service::DbService};
 use wf_history::service::HistoryService;
 
 use crate::{
-    app::{command::Command, event::Event, session::SessionManager},
+    app::{
+        command::{Command, ConfigUpdate},
+        event::Event,
+        session::SessionManager,
+    },
     state::SharedState,
 };
 
@@ -113,6 +117,7 @@ impl AppController {
                 Command::RunAll(sql) => self.handle_run_query(sql).await,
                 Command::RunSelection(sql) => self.handle_run_query(sql).await,
                 Command::CancelQuery => self.handle_cancel_query().await,
+                Command::UpdateConfig(update) => self.handle_update_config(update).await,
                 _ => {} // remaining commands handled in later tasks
             }
         }
@@ -238,6 +243,9 @@ impl AppController {
         self.state.query.set_cancel_token(token.clone());
         let _ = self.tx_event.send(Event::QueryStarted).await;
 
+        let page_size = self.state.ui.page_size();
+        let sql_to_run = apply_limit(&sql, page_size);
+
         let db = self.db.clone(); // clone required: tokio::spawn needs 'static
         let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
         let history = self.history.clone(); // clone required: tokio::spawn needs 'static
@@ -245,7 +253,7 @@ impl AppController {
         let conn_id_hist = conn_id.clone(); // clone required: history record needs owned id
         tokio::spawn(async move {
             let now = Utc::now().timestamp();
-            match db.execute_with_cancel(&conn_id, &sql, token).await {
+            match db.execute_with_cancel(&conn_id, &sql_to_run, token).await {
                 Ok(result) => {
                     if let Some(ref h) = history {
                         let exec = wf_db::models::QueryExecution {
@@ -287,6 +295,21 @@ impl AppController {
         });
     }
 
+    /// Handle an `UpdateConfig` command.
+    ///
+    /// Currently handles `PageSize` changes: updates the shared state so the
+    /// next `RunQuery` uses the new LIMIT, then persists the value to `config.toml`.
+    async fn handle_update_config(&self, update: ConfigUpdate) {
+        if let ConfigUpdate::PageSize(ps) = update {
+            let n: u32 = ps.into();
+            self.state.ui.set_page_size(n as usize);
+            if let Err(e) = self.session.save_page_size(n as usize) {
+                warn!(error = %e, "failed to persist page_size to config");
+            }
+            let _ = self.tx_event.send(Event::ConfigUpdated).await;
+        }
+    }
+
     /// Handle a `CancelQuery` command.
     ///
     /// Fires the stored [`CancellationToken`] (if any) and immediately sends
@@ -295,6 +318,25 @@ impl AppController {
         info!("handling CancelQuery command");
         self.state.query.cancel();
         let _ = self.tx_event.send(Event::QueryCancelled).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Append `LIMIT {limit}` to a SELECT statement that has no explicit LIMIT clause.
+///
+/// - Non-SELECT statements (INSERT, UPDATE, DELETE, …) are returned unchanged.
+/// - Statements that already contain ` LIMIT ` are returned unchanged.
+/// - A trailing semicolon is stripped before appending the LIMIT clause.
+fn apply_limit(sql: &str, limit: usize) -> String {
+    let trimmed = sql.trim().trim_end_matches(';').trim_end();
+    let upper = trimmed.to_uppercase();
+    if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") {
+        format!("{} LIMIT {}", trimmed, limit)
+    } else {
+        sql.to_string()
     }
 }
 
@@ -318,7 +360,7 @@ mod tests {
         state::AppState,
     };
 
-    use super::AppController;
+    use super::{AppController, apply_limit};
 
     /// Build a [`SessionManager`] backed by a temporary directory.
     /// `keep()` prevents cleanup so the path stays valid for the test lifetime.
@@ -352,6 +394,50 @@ mod tests {
             password_encrypted: None,
             database: None,
         }
+    }
+
+    // ── apply_limit ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_limit_should_append_limit_to_select() {
+        assert_eq!(
+            apply_limit("SELECT * FROM t", 500),
+            "SELECT * FROM t LIMIT 500"
+        );
+    }
+
+    #[test]
+    fn apply_limit_should_strip_trailing_semicolon_before_appending() {
+        assert_eq!(
+            apply_limit("SELECT * FROM t;", 100),
+            "SELECT * FROM t LIMIT 100"
+        );
+    }
+
+    #[test]
+    fn apply_limit_should_not_append_when_limit_already_present() {
+        let sql = "SELECT * FROM t LIMIT 10";
+        assert_eq!(apply_limit(sql, 500), sql);
+    }
+
+    #[test]
+    fn apply_limit_should_not_modify_dml_statements() {
+        let insert = "INSERT INTO t VALUES (1)";
+        assert_eq!(apply_limit(insert, 500), insert);
+        let update = "UPDATE t SET x = 1";
+        assert_eq!(apply_limit(update, 500), update);
+        let delete = "DELETE FROM t";
+        assert_eq!(apply_limit(delete, 500), delete);
+    }
+
+    #[test]
+    fn apply_limit_should_be_case_insensitive() {
+        assert_eq!(
+            apply_limit("select * from t", 1000),
+            "select * from t LIMIT 1000"
+        );
+        let with_limit = "select * from t limit 5";
+        assert_eq!(apply_limit(with_limit, 500), with_limit);
     }
 
     // ── TestConnection ────────────────────────────────────────────────────────
@@ -551,7 +637,13 @@ mod tests {
             }
         };
         assert!(matches!(e2, Event::QueryStarted));
-        let e3 = rx_event.recv().await.unwrap();
+        // Drain any late MetadataLoaded/MetadataFetchFailed before QueryFinished.
+        let e3 = loop {
+            match rx_event.recv().await.unwrap() {
+                Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => continue,
+                e => break e,
+            }
+        };
         assert!(matches!(e3, Event::QueryFinished(_)));
     }
 

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -14,7 +14,7 @@ use anyhow::Context as _;
 use tracing::{info, warn};
 use wf_config::{
     manager::ConfigManager,
-    models::{ConnectionConfig, DbTypeName},
+    models::{ConnectionConfig, DbTypeName, PageSize},
 };
 use wf_db::models::{DbConnection, DbType};
 
@@ -70,6 +70,29 @@ impl SessionManager {
             .save(&config)
             .context("failed to save session")?;
         info!(conn_id = %conn.id, "session saved");
+        Ok(())
+    }
+
+    /// Persist `size` (100 / 500 / 1000) as `[editor].page_size` in `config.toml`.
+    ///
+    /// Silently ignores unknown values (not in the `PageSize` enum); they are
+    /// replaced with the default (500).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config file cannot be loaded or written.
+    pub fn save_page_size(&self, size: usize) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for page_size save")?;
+
+        config.editor.page_size = PageSize::try_from(size as u32).unwrap_or_default();
+
+        self.config_manager
+            .save(&config)
+            .context("failed to save page_size")?;
+        info!(page_size = size, "page_size saved");
         Ok(())
     }
 
@@ -228,6 +251,21 @@ mod tests {
 
         let sm = SessionManager::with_config_manager(ConfigManager::with_path(path));
         assert!(sm.restore().unwrap().is_none());
+    }
+
+    #[test]
+    fn save_page_size_should_persist_to_config() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_page_size(1000).unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        use wf_config::models::PageSize;
+        assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -45,6 +45,15 @@ fn main() -> anyhow::Result<()> {
     let enc_key = crypto::load_or_create_key(&ConfigManager::app_dir())?;
 
     let state = Arc::new(AppState::new());
+
+    // Load persisted page_size from config so the first query uses the user's last setting.
+    {
+        let config = ConfigManager::new().load().unwrap_or_default();
+        state
+            .ui
+            .set_page_size(u32::from(config.editor.page_size) as usize);
+    }
+
     let db = DbService::new();
 
     let session = SessionManager::new();

--- a/app/src/state/query_state.rs
+++ b/app/src/state/query_state.rs
@@ -12,6 +12,7 @@ struct QueryData {
     is_loading: bool,
     result: Option<QueryResult>,
     cancel_token: Option<CancellationToken>,
+    last_sql: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,23 @@ impl QueryState {
             .write()
             .unwrap_or_else(|p| p.into_inner())
             .cancel_token = Some(t);
+    }
+
+    /// Returns the SQL text of the most recently executed query, if any.
+    pub fn last_sql(&self) -> Option<String> {
+        self.data
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .last_sql
+            .clone()
+    }
+
+    /// Stores the SQL text of the most recently executed query.
+    pub fn set_last_sql(&self, sql: String) {
+        self.data
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .last_sql = Some(sql);
     }
 
     /// Cancels the running query by calling `cancel()` on the stored token.

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -56,6 +56,14 @@ export global UiState {
     /// Returns cumulative x-offset (logical px as float) of column j.
     pure callback col-x-offset(int) -> float;
 
+    // ── Page-size selector ────────────────────────────────────────────────────
+    /// Active page-size limit (100 / 500 / 1000). Persisted in config.toml.
+    in-out property <int> page-size: 500;
+    /// Total rows returned by the last query (before client-side filtering).
+    in-out property <int> result-total-rows: 0;
+    /// User selected a new page size; Rust updates state and persists to config.
+    callback update-page-size(int);
+
     // ── Result table column sort ──────────────────────────────────────────────
     /// -1 = no sort; ≥0 = active sort column index.
     in-out property <int>  result-sort-col: -1;
@@ -482,6 +490,9 @@ export component AppWindow inherits Window {
                     sort-col:            UiState.result-sort-col;
                     sort-asc:            UiState.result-sort-asc;
                     sort-col-clicked(i)  => { UiState.sort-result-col(i); }
+                    page-size:           UiState.page-size;
+                    total-rows:          UiState.result-total-rows;
+                    change-page-size(n)  => { UiState.update-page-size(n); }
                 }
             }
         }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -102,6 +102,12 @@ export global UiState {
     in-out property <string> test-result-message:    "";
     /// Controls the "add without a passing test" confirmation popup.
     in-out property <bool>   show-add-confirm-popup: false;
+    /// Controls the "fetch all rows" confirmation popup (shown when ALL is clicked).
+    in-out property <bool>   show-all-rows-confirm: false;
+    /// User confirmed "fetch all rows" — Rust sets page-size=0 and reruns last query.
+    callback confirm-all-rows();
+    /// User dismissed the "fetch all rows" confirm popup.
+    callback dismiss-all-rows-confirm();
 
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
@@ -202,7 +208,8 @@ export component AppWindow inherits Window {
             // Don't intercept while a modal overlay is open.
             if (UiState.show-connection-form
                     || UiState.show-test-result-popup
-                    || UiState.show-add-confirm-popup) {
+                    || UiState.show-add-confirm-popup
+                    || UiState.show-all-rows-confirm) {
                 EventResult.reject
             } else if (event.modifiers.alt
                     && !event.modifiers.shift
@@ -492,7 +499,13 @@ export component AppWindow inherits Window {
                     sort-col-clicked(i)  => { UiState.sort-result-col(i); }
                     page-size:           UiState.page-size;
                     total-rows:          UiState.result-total-rows;
-                    change-page-size(n)  => { UiState.update-page-size(n); }
+                    change-page-size(n)  => {
+                        if (n == 0) {
+                            UiState.show-all-rows-confirm = true;
+                        } else {
+                            UiState.update-page-size(n);
+                        }
+                    }
                 }
             }
         }
@@ -715,6 +728,84 @@ export component AppWindow inherits Window {
                                         vertical-alignment: center;
                                     }
                                     TouchArea { clicked => { UiState.confirm-add-connection(); } }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // ── Fetch-all-rows confirmation popup ────────────────────────────────
+        // Shown when the user clicks the ALL button in the result toolbar.
+        if UiState.show-all-rows-confirm: Rectangle {
+            x: 0;
+            y: 0;
+            width:  root.width;
+            height: root.height;
+            background: #00000099;
+
+            VerticalLayout {
+                alignment: center;
+                HorizontalLayout {
+                    alignment: center;
+                    Rectangle {
+                        width: 360px;
+                        background: #313244;
+                        border-radius: 8px;
+                        border-width: 1px;
+                        border-color: #585b70;
+                        drop-shadow-blur: 20px;
+                        drop-shadow-color: #00000088;
+
+                        VerticalLayout {
+                            padding: 24px;
+                            spacing: 16px;
+                            alignment: start;
+
+                            Text {
+                                text: @tr("Fetch all rows?");
+                                color: #f9e2af;
+                                font-size: 15px;
+                                font-weight: 700;
+                            }
+
+                            Text {
+                                text: @tr("No LIMIT will be applied. This may take a long time for large tables.");
+                                color: #cdd6f4;
+                                font-size: 13px;
+                                wrap: word-wrap;
+                            }
+
+                            HorizontalLayout {
+                                spacing: 8px;
+                                alignment: end;
+
+                                Rectangle {
+                                    width: 80px;
+                                    height: 32px;
+                                    background: #45475a;
+                                    border-radius: 4px;
+                                    Text {
+                                        text: @tr("Cancel");
+                                        color: #cdd6f4;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    TouchArea { clicked => { UiState.dismiss-all-rows-confirm(); } }
+                                }
+
+                                Rectangle {
+                                    width: 80px;
+                                    height: 32px;
+                                    background: #f38ba8;
+                                    border-radius: 4px;
+                                    Text {
+                                        text: @tr("Fetch");
+                                        color: #1e1e2e;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    TouchArea { clicked => { UiState.confirm-all-rows(); } }
                                 }
                             }
                         }

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -56,6 +56,14 @@ export component ResultTable inherits Rectangle {
         }
     }
 
+    // ── Pagination / row-count state ─────────────────────────────────────────
+    /// Active page size (100 / 500 / 1000). Driven from Rust; reflects config.
+    in property <int> page-size:   500;
+    /// Total rows returned by the last query (before client-side filtering).
+    in property <int> total-rows:  0;
+    /// User selected a new page size; Rust persists to config and updates state.
+    callback change-page-size(int);
+
     // ── Callbacks ─────────────────────────────────────────────────────────────
     callback resize-column(int, float);
     callback filter-rows(string);
@@ -86,6 +94,7 @@ export component ResultTable inherits Rectangle {
 
     // ── Style constants ───────────────────────────────────────────────────────
     property <length> row-height:    28px;
+    property <length> toolbar-h:     28px;
     property <length> default-col-w: 150px;
     property <length> min-col-w:     48px;
 
@@ -113,7 +122,7 @@ export component ResultTable inherits Rectangle {
 
     // ── Page size for Page Up/Down ────────────────────────────────────────────
     property <int> page-rows: max(1,
-        (root.height - root.row-height - root.bottom-total) / root.row-height);
+        (root.height - root.row-height - root.bottom-total - root.toolbar-h) / root.row-height);
 
     // ── Body viewport state ───────────────────────────────────────────────────
     // Mirrored at component level so `changed` handlers can update them without
@@ -121,8 +130,8 @@ export component ResultTable inherits Rectangle {
     // Two-way bound to body-scroll.viewport-y/x inside the if-block.
     property <length> body-vp-y: 0;
     property <length> body-vp-x: 0;
-    // Visible body height (full height minus header row and collapsed strips).
-    property <length> body-h: max(1px, root.height - root.bottom-total - root.row-height);
+    // Visible body height (full height minus toolbar, header row, and collapsed strips).
+    property <length> body-h: max(1px, root.height - root.bottom-total - root.row-height - root.toolbar-h);
 
     // Reset selection and nav state when a new query result arrives.
     changed rows => {
@@ -414,6 +423,97 @@ export component ResultTable inherits Rectangle {
         if !root.is-loading && root.error-message == "": VerticalLayout {
             width:  parent.width;
             height: parent.height - root.bottom-total;
+
+            // ── Toolbar (page-size selector + row count) ──────────────────────
+            Rectangle {
+                height: root.toolbar-h;
+                background: #181825;
+                clip: true;
+
+                // Bottom separator
+                Rectangle {
+                    x: 0; y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: #313244;
+                }
+
+                // Row count display (left side; only when a result is loaded)
+                if root.columns.length > 0: Text {
+                    x: 10px;
+                    y: (parent.height - self.height) / 2;
+                    text: root.row-count != root.total-rows
+                        ? @tr("{0} / {1} rows", root.row-count, root.total-rows)
+                        : @tr("{0} rows", root.row-count);
+                    color: #585b70;
+                    font-size: 11px;
+                }
+
+                // Page-size selector: three toggle buttons aligned to the right
+                HorizontalLayout {
+                    x: parent.width - 136px;
+                    y: (parent.height - self.height) / 2;
+                    width: 128px;
+                    height: 20px;
+                    spacing: 2px;
+
+                    // 100
+                    Rectangle {
+                        width: 38px;
+                        height: 20px;
+                        border-radius: 3px;
+                        background: ps100-ta.has-hover ? #45475a
+                            : root.page-size == 100 ? #89b4fa : #313244;
+                        ps100-ta := TouchArea {
+                            clicked => { root.change-page-size(100); }
+                        }
+                        Text {
+                            text: "100";
+                            color: root.page-size == 100 ? #1e1e2e : #9399b2;
+                            font-size: 11px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    // 500
+                    Rectangle {
+                        width: 38px;
+                        height: 20px;
+                        border-radius: 3px;
+                        background: ps500-ta.has-hover ? #45475a
+                            : root.page-size == 500 ? #89b4fa : #313244;
+                        ps500-ta := TouchArea {
+                            clicked => { root.change-page-size(500); }
+                        }
+                        Text {
+                            text: "500";
+                            color: root.page-size == 500 ? #1e1e2e : #9399b2;
+                            font-size: 11px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    // 1000
+                    Rectangle {
+                        width: 46px;
+                        height: 20px;
+                        border-radius: 3px;
+                        background: ps1000-ta.has-hover ? #45475a
+                            : root.page-size == 1000 ? #89b4fa : #313244;
+                        ps1000-ta := TouchArea {
+                            clicked => { root.change-page-size(1000); }
+                        }
+                        Text {
+                            text: "1000";
+                            color: root.page-size == 1000 ? #1e1e2e : #9399b2;
+                            font-size: 11px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
 
             // ── Header row ────────────────────────────────────────────────────
             header-scroll := Flickable {

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -448,11 +448,12 @@ export component ResultTable inherits Rectangle {
                     font-size: 11px;
                 }
 
-                // Page-size selector: three toggle buttons aligned to the right
+                // Page-size selector: four toggle buttons aligned to the right
+                // 0 = unlimited (ALL); 100/500/1000 inject LIMIT N.
                 HorizontalLayout {
-                    x: parent.width - 136px;
+                    x: parent.width - 178px;
                     y: (parent.height - self.height) / 2;
-                    width: 128px;
+                    width: 170px;
                     height: 20px;
                     spacing: 2px;
 
@@ -507,6 +508,25 @@ export component ResultTable inherits Rectangle {
                         Text {
                             text: "1000";
                             color: root.page-size == 1000 ? #1e1e2e : #9399b2;
+                            font-size: 11px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    // ALL (0 = no LIMIT)
+                    Rectangle {
+                        width: 38px;
+                        height: 20px;
+                        border-radius: 3px;
+                        background: psall-ta.has-hover ? #45475a
+                            : root.page-size == 0 ? #89b4fa : #313244;
+                        psall-ta := TouchArea {
+                            clicked => { root.change-page-size(0); }
+                        }
+                        Text {
+                            text: @tr("ALL");
+                            color: root.page-size == 0 ? #1e1e2e : #9399b2;
                             font-size: 11px;
                             horizontal-alignment: center;
                             vertical-alignment: center;

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1026,30 +1026,77 @@ impl UI {
             });
         }
 
-        // update-page-size: user clicked 100/500/1000/ALL button in the result toolbar.
-        // 1. Update UiState.page-size immediately so the button highlight changes at once.
-        // 2. Update shared state so the next RunQuery picks up the new limit.
-        // 3. Persist via UpdateConfig (ALL / 0 is not persisted since PageSize enum has no
-        //    Unlimited variant yet; the button still works for the current session).
+        // update-page-size: user clicked 100/500/1000 in the result toolbar
+        // (ALL / 0 goes through confirm-all-rows instead).
+        // 1. Update UiState.page-size immediately so the button highlight changes.
+        // 2. Update shared state so the injected LIMIT is correct for the rerun.
+        // 3. Persist via UpdateConfig (0 has no PageSize variant yet — skipped).
+        // 4. Auto-rerun the last query with the new limit.
         {
             // clone required: callback closure must be 'static
             let window_weak = window_weak.clone();
             let tx_cmd = tx_cmd.clone();
+            let state_rerun = state.clone(); // clone required: captured by callback
             ui_state.on_update_page_size(move |n| {
                 let size = n as usize;
-                state.ui.set_page_size(size);
+                state_rerun.ui.set_page_size(size);
                 // Update the Slint property so button highlights refresh on the UI thread.
                 if let Some(window) = window_weak.upgrade() {
                     window.global::<crate::UiState>().set_page_size(n);
                 }
                 if let Ok(ps) = wf_config::models::PageSize::try_from(n as u32) {
                     // clone required: tokio::spawn requires 'static
-                    let tx_cmd = tx_cmd.clone();
+                    let tx_cmd_cfg = tx_cmd.clone();
                     tokio::spawn(async move {
-                        let _ = tx_cmd
+                        let _ = tx_cmd_cfg
                             .send(Command::UpdateConfig(ConfigUpdate::PageSize(ps)))
                             .await;
                     });
+                }
+                // Auto-rerun the last query so results reflect the new limit immediately.
+                if let Some(last_sql) = state_rerun.query.last_sql() {
+                    // clone required: tokio::spawn requires 'static
+                    let tx_cmd_run = tx_cmd.clone();
+                    tokio::spawn(async move {
+                        let _ = tx_cmd_run.send(Command::RunQuery(last_sql)).await;
+                    });
+                }
+            });
+        }
+
+        // confirm-all-rows: user confirmed the "fetch all rows" popup.
+        // Sets page-size=0 (no LIMIT), closes the popup, then reruns the last query.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            let tx_cmd = tx_cmd.clone();
+            let state_all = state.clone(); // clone required: captured by callback
+            ui_state.on_confirm_all_rows(move || {
+                state_all.ui.set_page_size(0);
+                if let Some(window) = window_weak.upgrade() {
+                    let ui = window.global::<crate::UiState>();
+                    ui.set_page_size(0);
+                    ui.set_show_all_rows_confirm(false);
+                }
+                if let Some(last_sql) = state_all.query.last_sql() {
+                    // clone required: tokio::spawn requires 'static
+                    let tx_cmd = tx_cmd.clone();
+                    tokio::spawn(async move {
+                        let _ = tx_cmd.send(Command::RunQuery(last_sql)).await;
+                    });
+                }
+            });
+        }
+
+        // dismiss-all-rows-confirm: user cancelled the "fetch all rows" popup.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_dismiss_all_rows_confirm(move || {
+                if let Some(window) = window_weak.upgrade() {
+                    window
+                        .global::<crate::UiState>()
+                        .set_show_all_rows_confirm(false);
                 }
             });
         }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1026,15 +1026,22 @@ impl UI {
             });
         }
 
-        // update-page-size: user clicked 100/500/1000 button in the result toolbar.
-        // Update shared state immediately so the next RunQuery picks up the new limit,
-        // then send UpdateConfig to persist it to config.toml via the controller.
+        // update-page-size: user clicked 100/500/1000/ALL button in the result toolbar.
+        // 1. Update UiState.page-size immediately so the button highlight changes at once.
+        // 2. Update shared state so the next RunQuery picks up the new limit.
+        // 3. Persist via UpdateConfig (ALL / 0 is not persisted since PageSize enum has no
+        //    Unlimited variant yet; the button still works for the current session).
         {
             // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
             let tx_cmd = tx_cmd.clone();
             ui_state.on_update_page_size(move |n| {
                 let size = n as usize;
                 state.ui.set_page_size(size);
+                // Update the Slint property so button highlights refresh on the UI thread.
+                if let Some(window) = window_weak.upgrade() {
+                    window.global::<crate::UiState>().set_page_size(n);
+                }
                 if let Ok(ps) = wf_config::models::PageSize::try_from(n as u32) {
                     // clone required: tokio::spawn requires 'static
                     let tx_cmd = tx_cmd.clone();

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -27,7 +27,10 @@ struct OriginalQueryData {
 type SharedOriginalData = Arc<Mutex<Option<OriginalQueryData>>>;
 
 use crate::{
-    app::{command::Command, event::Event},
+    app::{
+        command::{Command, ConfigUpdate},
+        event::Event,
+    },
     state::SharedState,
 };
 
@@ -217,7 +220,17 @@ impl UI {
         );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
-        Self::register_result_callbacks(&window, state.clone(), Arc::clone(&original_data));
+        // Set initial page size on the Slint window from shared state.
+        window
+            .global::<crate::UiState>()
+            .set_page_size(state.ui.page_size() as i32);
+
+        Self::register_result_callbacks(
+            &window,
+            state.clone(),
+            Arc::clone(&original_data),
+            tx_cmd.clone(),
+        );
         Self::register_status_callbacks(&window, state.clone());
         Self::spawn_event_handler(
             &window,
@@ -413,6 +426,7 @@ impl UI {
                                 raw_rows.into_iter().map(rows_to_ui).collect();
                             ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
                             ui.set_result_row_count(row_count);
+                            ui.set_result_total_rows(row_count);
                             // Initialise per-column widths (150 px each).
                             const DEFAULT_COL_W: f32 = 150.0;
                             let widths: Vec<f32> = vec![DEFAULT_COL_W; col_count];
@@ -857,8 +871,9 @@ impl UI {
 
     fn register_result_callbacks(
         window: &crate::AppWindow,
-        _state: SharedState,
+        state: SharedState,
         original_data: SharedOriginalData,
+        tx_cmd: mpsc::Sender<Command>,
     ) {
         let ui_state = window.global::<crate::UiState>();
         let window_weak = window.as_weak();
@@ -1007,6 +1022,27 @@ impl UI {
                 let tsv = result_to_tsv(&col_strs, &rows);
                 if let Ok(mut clip) = arboard::Clipboard::new() {
                     let _ = clip.set_text(tsv);
+                }
+            });
+        }
+
+        // update-page-size: user clicked 100/500/1000 button in the result toolbar.
+        // Update shared state immediately so the next RunQuery picks up the new limit,
+        // then send UpdateConfig to persist it to config.toml via the controller.
+        {
+            // clone required: callback closure must be 'static
+            let tx_cmd = tx_cmd.clone();
+            ui_state.on_update_page_size(move |n| {
+                let size = n as usize;
+                state.ui.set_page_size(size);
+                if let Ok(ps) = wf_config::models::PageSize::try_from(n as u32) {
+                    // clone required: tokio::spawn requires 'static
+                    let tx_cmd = tx_cmd.clone();
+                    tokio::spawn(async move {
+                        let _ = tx_cmd
+                            .send(Command::UpdateConfig(ConfigUpdate::PageSize(ps)))
+                            .await;
+                    });
                 }
             });
         }


### PR DESCRIPTION
## Summary

Adds a toolbar strip above the result table with 100 / 500 / 1000 row-count selector buttons. Clicking a button updates the active LIMIT for the next query, persists the choice to `config.toml`, and highlights the active selection. A row-count display shows either \"N rows\" or \"N / M rows\" when a client-side filter is active.

## Changes

- `result_table.slint`: Added 28 px toolbar with page-size buttons (active state highlighted in accent color) and row-count label; updated `body-h` and `page-rows` calculations to account for `toolbar-h`
- `app.slint`: Added `page-size`, `result-total-rows` properties and `update-page-size` callback to `UiState`; wired to `result-table-inst`
- `mod.rs`: Added `on_update_page_size` callback (updates shared state immediately + sends `Command::UpdateConfig`); sets initial `page_size` from state on startup; sets `result_total_rows` on each `QueryFinished` event
- `controller.rs`: Added `handle_update_config` (persists page size via `SessionManager`, notifies UI); added `apply_limit` helper that injects `LIMIT N` into SELECT statements without an existing LIMIT; applied at query execution time
- `session.rs`: Added `save_page_size` to persist the chosen limit to `config.editor.page_size`
- `main.rs`: Loads `page_size` from config on startup and sets it on shared state before creating the UI
- Fixed pre-existing flaky test `run_query_should_send_query_started_then_finished` by draining late `MetadataLoaded`/`MetadataFetchFailed` events between `QueryStarted` and `QueryFinished`

## Related Issues

Closes #39

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes