### PR TITLE
feat(completion): add CompletionService with 300ms debounce and editor wiring

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -19,7 +19,7 @@ use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use wf_completion::cache::MetadataCache;
+use wf_completion::{cache::MetadataCache, service::CompletionService};
 use wf_db::{error::DbError, models::DbConnection, service::DbService};
 use wf_history::service::HistoryService;
 
@@ -49,6 +49,8 @@ pub struct AppController {
     metadata_cache_path: PathBuf,
     /// `None` until `run()` initialises the cache.
     metadata_cache: Option<MetadataCache>,
+    /// `None` until `run()` initialises the cache (same `MetadataCache` clone).
+    completion: Option<CompletionService>,
     rx_cmd: mpsc::Receiver<Command>,
     tx_event: mpsc::Sender<Event>,
 }
@@ -78,6 +80,7 @@ impl AppController {
                 history: None,
                 metadata_cache_path,
                 metadata_cache: None,
+                completion: None,
                 rx_cmd,
                 tx_event,
             },
@@ -106,6 +109,7 @@ impl AppController {
         if let Err(e) = cache.preload_from_disk().await {
             warn!("failed to preload metadata cache: {e}");
         }
+        self.completion = Some(CompletionService::new(cache.clone()));
         self.metadata_cache = Some(cache);
 
         while let Some(cmd) = self.rx_cmd.recv().await {
@@ -118,6 +122,9 @@ impl AppController {
                 Command::RunSelection(sql) => self.handle_run_query(sql).await,
                 Command::CancelQuery => self.handle_cancel_query().await,
                 Command::UpdateConfig(update) => self.handle_update_config(update).await,
+                Command::FetchCompletion(sql, cursor_pos) => {
+                    self.handle_fetch_completion(sql, cursor_pos).await;
+                }
                 _ => {} // remaining commands handled in later tasks
             }
         }
@@ -309,6 +316,22 @@ impl AppController {
                 warn!(error = %e, "failed to persist page_size to config");
             }
             let _ = self.tx_event.send(Event::ConfigUpdated).await;
+        }
+    }
+
+    /// Handle a `FetchCompletion` command.
+    ///
+    /// Looks up the active connection, calls [`CompletionService::complete`], and
+    /// sends [`Event::CompletionReady`] with the (possibly empty) candidate list.
+    /// Silently no-ops when there is no active connection or no completion service.
+    async fn handle_fetch_completion(&self, sql: String, cursor_pos: usize) {
+        let conn_id = match self.state.conn.active() {
+            Some(c) => c.id.clone(),
+            None => return,
+        };
+        if let Some(ref completion) = self.completion {
+            let items = completion.complete(&conn_id, &sql, cursor_pos).await;
+            let _ = self.tx_event.send(Event::CompletionReady(items)).await;
         }
     }
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -109,6 +109,13 @@ export global UiState {
     /// User dismissed the "fetch all rows" confirm popup.
     callback dismiss-all-rows-confirm();
 
+    // ── Completion ────────────────────────────────────────────────────────────
+    /// Fired by the editor on every user text edit; Rust debounces 300 ms then
+    /// sends Command::FetchCompletion.
+    callback fetch-completion(string, int);
+    /// Fired by Ctrl+Space; Rust sends Command::FetchCompletion immediately.
+    callback trigger-completion(string, int);
+
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
     callback cancel-query();
@@ -316,6 +323,8 @@ export component AppWindow inherits Window {
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
                 run-query => { UiState.run-query(UiState.editor-text); }
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
+                text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
+                trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }
             }
 
             // ── Cell-value preview strip ──────────────────────────────────────

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -69,6 +69,15 @@ export component Editor inherits Rectangle {
     /// Implemented in app.slint by toggling UiState.result-panel-open.
     callback toggle-panel();
 
+    /// Fired on every user text edit (not programmatic).
+    /// Carries the new SQL text and the cursor byte offset.
+    /// Wired in app.slint to UiState.fetch-completion for 300 ms debounce.
+    callback text-edited(string, int);
+
+    /// Fired on Ctrl+Space for immediate completion.
+    /// Carries the current SQL text and cursor byte offset.
+    callback trigger-completion(string, int);
+
     // ── Out properties consumed by the external gutter in app.slint ──────────
     out property <length> gutter-scroll-y:  editor-scroll.viewport-y;
     out property <length> gutter-line-h:    root.line-h;
@@ -252,6 +261,9 @@ export component Editor inherits Rectangle {
                 } else if (event.text == "j" && event.modifiers.control) {
                     root.toggle-panel();
                     EventResult.accept
+                } else if (event.text == " " && event.modifiers.control) {
+                    root.trigger-completion(inner-input.text, inner-input.cursor-position-byte-offset);
+                    EventResult.accept
                 } else {
                     EventResult.reject
                 }
@@ -277,6 +289,12 @@ export component Editor inherits Rectangle {
                 selection-foreground-color: #cdd6f4;
                 font-family: root.font-family;
                 font-size:   root.font-size-px * 1px;
+
+                // Notify app.slint on every user keystroke so the completion
+                // debounce timer can be (re)started.
+                edited => {
+                    root.text-edited(self.text, self.cursor-position-byte-offset);
+                }
 
                 // Horizontal auto-scroll: keep cursor inside the visible area
                 // whenever the cursor position changes (typing, keyboard nav,

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -220,6 +220,7 @@ impl UI {
         );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
+        Self::register_completion_callbacks(&window, tx_cmd.clone());
         // Set initial page size on the Slint window from shared state.
         window
             .global::<crate::UiState>()
@@ -862,6 +863,57 @@ impl UI {
                 let tx_cmd = tx_cmd.clone(); // clone required: tokio::spawn requires 'static
                 tokio::spawn(async move {
                     let _ = tx_cmd.send(Command::CancelQuery).await;
+                });
+            });
+        }
+    }
+
+    // ── Completion callbacks ──────────────────────────────────────────────────
+
+    fn register_completion_callbacks(window: &crate::AppWindow, tx_cmd: mpsc::Sender<Command>) {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        use std::time::Duration;
+
+        let ui = window.global::<crate::UiState>();
+
+        // Debounced path (text-change → 300 ms → FetchCompletion).
+        // Dropping the previous timer stops it — each keystroke resets the window.
+        let debounce: Rc<RefCell<Option<slint::Timer>>> = Rc::new(RefCell::new(None));
+        {
+            let debounce = debounce.clone(); // clone required: on_fetch_completion closure
+            let tx_cmd = tx_cmd.clone(); // clone required: on_fetch_completion closure
+            ui.on_fetch_completion(move |sql, cursor_pos| {
+                *debounce.borrow_mut() = None; // drop previous timer → cancels it
+                let tx = tx_cmd.clone(); // clone required: Timer callback
+                let sql = sql.to_string();
+                let timer = slint::Timer::default();
+                timer.start(
+                    slint::TimerMode::SingleShot,
+                    Duration::from_millis(300),
+                    move || {
+                        let tx = tx.clone(); // clone required: tokio::spawn
+                        let sql = sql.clone();
+                        tokio::spawn(async move {
+                            let _ = tx
+                                .send(Command::FetchCompletion(sql, cursor_pos as usize))
+                                .await;
+                        });
+                    },
+                );
+                *debounce.borrow_mut() = Some(timer);
+            });
+        }
+
+        // Immediate path (Ctrl+Space → FetchCompletion without delay).
+        {
+            ui.on_trigger_completion(move |sql, cursor_pos| {
+                let tx = tx_cmd.clone(); // clone required: tokio::spawn
+                let sql = sql.to_string();
+                tokio::spawn(async move {
+                    let _ = tx
+                        .send(Command::FetchCompletion(sql, cursor_pos as usize))
+                        .await;
                 });
             });
         }

--- a/crates/wf-completion/src/service.rs
+++ b/crates/wf-completion/src/service.rs
@@ -1,1 +1,160 @@
-// CompletionService with 300ms debounce — implemented in T042/T063
+//! `CompletionService` — pure async compute wrapper over parser + engine + cache.
+//!
+//! The 300 ms debounce and the Slint timer logic live in `app/src/ui/mod.rs`
+//! (the only crate that depends on Slint).  This crate provides only the
+//! metadata lookup and candidate generation.
+
+use wf_db::models::DbMetadata;
+
+use crate::{
+    CompletionItem, cache::MetadataCache, engine::CompletionEngine, parser::parse_context,
+};
+
+// ---------------------------------------------------------------------------
+// CompletionService
+// ---------------------------------------------------------------------------
+
+/// Wraps [`MetadataCache`] + [`CompletionEngine`] to compute candidates for
+/// a single SQL text + cursor position.
+///
+/// The caller is responsible for debounce and for sending the result to the UI.
+#[derive(Clone)]
+pub struct CompletionService {
+    cache: MetadataCache,
+}
+
+impl CompletionService {
+    /// Create a service backed by the given metadata cache.
+    pub fn new(cache: MetadataCache) -> Self {
+        Self { cache }
+    }
+
+    /// Return completion candidates for `sql` at byte offset `cursor_pos`.
+    ///
+    /// Looks up `DbMetadata` for `conn_id` in the cache; falls back to an
+    /// empty metadata set when the connection is not yet cached.
+    pub async fn complete(
+        &self,
+        conn_id: &str,
+        sql: &str,
+        cursor_pos: usize,
+    ) -> Vec<CompletionItem> {
+        let metadata: DbMetadata = self.cache.load(conn_id).await.unwrap_or_default();
+        let prefix = extract_prefix(sql, cursor_pos);
+        let context = parse_context(sql, cursor_pos);
+        CompletionEngine::complete(context, &metadata, &prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the typed prefix at `cursor_pos`.
+///
+/// Scans backward from the cursor and returns the last run of word characters
+/// (`[A-Za-z0-9_]`).  In dot-notation (`alias.col|`), only the segment after
+/// the last `.` is returned.
+pub(crate) fn extract_prefix(sql: &str, cursor_pos: usize) -> String {
+    let pos = cursor_pos.min(sql.len());
+    let before = &sql[..pos];
+    let search_start = before.rfind('.').map(|i| i + 1).unwrap_or(0);
+    let segment = &before[search_start..];
+    segment
+        .chars()
+        .rev()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wf_db::models::{ColumnInfo, TableInfo};
+
+    fn make_meta() -> DbMetadata {
+        DbMetadata {
+            tables: vec![TableInfo {
+                name: "users".to_string(),
+                columns: vec![
+                    ColumnInfo {
+                        name: "id".to_string(),
+                        data_type: "integer".to_string(),
+                        nullable: false,
+                    },
+                    ColumnInfo {
+                        name: "email".to_string(),
+                        data_type: "varchar".to_string(),
+                        nullable: false,
+                    },
+                ],
+            }],
+            views: vec![],
+            stored_procs: vec![],
+            indexes: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_should_return_keyword_candidates_without_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let svc = CompletionService::new(cache);
+        let items = svc.complete("conn-1", "SEL", 3).await;
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"SELECT"), "expected SELECT in {labels:?}");
+    }
+
+    #[tokio::test]
+    async fn complete_should_return_table_candidates_from_cached_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        cache.store("conn-1", make_meta()).await.unwrap();
+        let svc = CompletionService::new(cache);
+        // TableName context: "SELECT * FROM "
+        let sql = "SELECT * FROM ";
+        let items = svc.complete("conn-1", sql, sql.len()).await;
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"users"), "expected 'users' in {labels:?}");
+    }
+
+    #[tokio::test]
+    async fn complete_should_return_empty_column_candidates_when_no_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let svc = CompletionService::new(cache);
+        // No metadata stored — ColumnName { Some("users") } → no columns
+        let sql = "SELECT id FROM users WHERE ";
+        let items = svc.complete("conn-x", sql, sql.len()).await;
+        assert!(
+            items.iter().all(|i| i.label != "id"),
+            "expected no column items without metadata"
+        );
+    }
+
+    #[test]
+    fn extract_prefix_should_return_typed_word_before_cursor() {
+        assert_eq!(extract_prefix("SELECT sel", 10), "sel");
+        assert_eq!(extract_prefix("FROM ord", 8), "ord");
+    }
+
+    #[test]
+    fn extract_prefix_should_return_empty_after_space() {
+        assert_eq!(extract_prefix("SELECT ", 7), "");
+        assert_eq!(extract_prefix("SELECT * FROM ", 14), "");
+    }
+
+    #[test]
+    fn extract_prefix_should_return_segment_after_dot() {
+        assert_eq!(extract_prefix("u.em", 4), "em");
+        assert_eq!(extract_prefix("u.", 2), "");
+        assert_eq!(extract_prefix("alias.col_name", 14), "col_name");
+    }
+}


### PR DESCRIPTION
## Summary

Implements `CompletionService` in `wf-completion` as a pure async compute wrapper over `MetadataCache` + `CompletionEngine`. Wires the full completion pipeline end-to-end: editor text change fires `text-edited` → `fetch-completion` callback → 300ms `slint::Timer` debounce in `app/` → `Command::FetchCompletion` → `AppController::handle_fetch_completion` → `Event::CompletionReady`. Ctrl+Space triggers immediate completion via `trigger-completion` bypassing the debounce.

## Changes

- `crates/wf-completion/src/service.rs`: implement `CompletionService::complete` (async, loads metadata from cache) and `extract_prefix` helper (handles dot-notation)
- `app/src/app/controller.rs`: add `completion: Option<CompletionService>` field, initialize it in `run()` after cache setup, handle `Command::FetchCompletion` dispatching to `handle_fetch_completion`
- `app/src/ui/app.slint`: add `fetch-completion` and `trigger-completion` callbacks to `UiState`; wire `editor-inst` to forward both
- `app/src/ui/components/editor.slint`: add `text-edited` and `trigger-completion` callbacks; wire `TextInput.edited` and Ctrl+Space in `capture-key-pressed`
- `app/src/ui/mod.rs`: add `register_completion_callbacks` with `Rc<RefCell<Option<slint::Timer>>>` debounce pattern (pattern 8 from reference-patterns.md)
- 6 new unit tests in `service.rs` (35 total in `wf-completion`)

## Related Issues

Closes #42

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes