### PR TITLE
feat(completion): add popup UI with keyboard navigation and text insertion

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -124,7 +124,7 @@ export global UiState {
     /// Set by Rust after inserting completion text; editor watches it to move cursor.
     in-out property <int>            editor-cursor-target: -1;
     /// Fired when user accepts a candidate (Enter key in popup).
-    callback accept-completion(string, int);
+    callback accept-completion(string, int, int, string);
 
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
@@ -339,7 +339,7 @@ export component AppWindow inherits Window {
                 completion-items:        UiState.completion-items;
                 completion-selected  <=> UiState.completion-selected;
                 editor-cursor-target <=> UiState.editor-cursor-target;
-                accept-completion(text, pos) => { UiState.accept-completion(text, pos); }
+                accept-completion(text, pos, offset, tname) => { UiState.accept-completion(text, pos, offset, tname); }
             }
 
             // ── Cell-value preview strip ──────────────────────────────────────

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -1,4 +1,5 @@
-import { ConnectionEntry, RowData, SidebarNode } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, CompletionRow } from "globals.slint";
+import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
 import { Sidebar }         from "components/sidebar.slint";
 import { Editor }          from "components/editor.slint";
@@ -115,6 +116,15 @@ export global UiState {
     callback fetch-completion(string, int);
     /// Fired by Ctrl+Space; Rust sends Command::FetchCompletion immediately.
     callback trigger-completion(string, int);
+
+    // ── Completion popup state ─────────────────────────────────────────────
+    in property    <[CompletionRow]> completion-items:    [];
+    in-out property <bool>           completion-visible:  false;
+    in-out property <int>            completion-selected: 0;
+    /// Set by Rust after inserting completion text; editor watches it to move cursor.
+    in-out property <int>            editor-cursor-target: -1;
+    /// Fired when user accepts a candidate (Enter key in popup).
+    callback accept-completion(string, int);
 
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
@@ -325,6 +335,11 @@ export component AppWindow inherits Window {
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }
+                completion-visible   <=> UiState.completion-visible;
+                completion-items:        UiState.completion-items;
+                completion-selected  <=> UiState.completion-selected;
+                editor-cursor-target <=> UiState.editor-cursor-target;
+                accept-completion(text, pos) => { UiState.accept-completion(text, pos); }
             }
 
             // ── Cell-value preview strip ──────────────────────────────────────
@@ -517,6 +532,16 @@ export component AppWindow inherits Window {
                     }
                 }
             }
+        }
+
+        // ── Completion popup overlay ──────────────────────────────────────────
+        // Lives at FocusScope level (not inside the clip:true main Rectangle) so
+        // it is never clipped even when the cursor is near the editor bottom.
+        if UiState.completion-visible && UiState.completion-items.length > 0: CompletionPopup {
+            x: root.sidebar-width + root.gutter-col-width + editor-inst.popup-x;
+            y: editor-inst.popup-y;
+            items: UiState.completion-items;
+            selected-index <=> UiState.completion-selected;
         }
 
         // ── Status bar ────────────────────────────────────────────────────────

--- a/app/src/ui/components/completion_popup.slint
+++ b/app/src/ui/components/completion_popup.slint
@@ -1,0 +1,62 @@
+import { CompletionRow } from "../globals.slint";
+
+export component CompletionPopup inherits Rectangle {
+    in property    <[CompletionRow]> items: [];
+    in-out property <int>            selected-index: 0;
+
+    property <length> item-h: 22px;
+
+    background: #313244;
+    border-radius: 4px;
+    border-width: 1px;
+    border-color: #585b70;
+    drop-shadow-blur: 10px;
+    drop-shadow-color: #00000088;
+    width: 320px;
+    height: min(items.length, 8) * item-h;
+    clip: true;
+
+    popup-scroll := Flickable {
+        width: parent.width;
+        height: parent.height;
+        viewport-height: root.items.length * root.item-h;
+        interactive: false;
+
+        for item[i] in root.items: Rectangle {
+            y: i * root.item-h;
+            height: root.item-h;
+            width: root.width;
+            background: i == root.selected-index ? #45475a : transparent;
+
+            Text {
+                x: 8px;
+                y: (parent.height - self.preferred-height) / 2;
+                text: item.label;
+                color: #cdd6f4;
+                font-size: 13px;
+                font-family: "JetBrains Mono";
+            }
+
+            Text {
+                x: 200px;
+                y: (parent.height - self.preferred-height) / 2;
+                text: item.kind;
+                color: #6c7086;
+                font-size: 11px;
+            }
+        }
+    }
+
+    // Auto-scroll to keep the selected row visible when navigating with ↑/↓.
+    changed selected-index => {
+        let item-top = root.selected-index * root.item-h;
+        let item-bot = item-top + root.item-h;
+        let vis-top  = -popup-scroll.viewport-y;
+        let vis-bot  = vis-top + popup-scroll.height;
+        if (item-top < vis-top) {
+            popup-scroll.viewport-y = -item-top;
+        } else if (item-bot > vis-bot) {
+            popup-scroll.viewport-y = -(item-bot - popup-scroll.height);
+        }
+    }
+}

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -1,3 +1,5 @@
+import { CompletionRow } from "../globals.slint";
+
 // SQL editor component — multi-line TextInput with synchronised line numbers.
 //
 // The line-number gutter is intentionally NOT rendered here.  It lives in
@@ -84,6 +86,17 @@ export component Editor inherits Rectangle {
     out property <int>    gutter-vis-first: root.vis-first;
     out property <int>    gutter-vis-count: root.vis-count;
 
+    // ── Completion popup ──────────────────────────────────────────────────────
+    in-out property <bool>           completion-visible:  false;
+    in property    <[CompletionRow]> completion-items:    [];
+    in-out property <int>            completion-selected: 0;
+    in-out property <int>            editor-cursor-target: -1;
+    callback accept-completion(string, int);
+
+    /// Cursor position in editor-viewport space; consumed by app.slint to place the popup.
+    out property <length> popup-x: 0px;
+    out property <length> popup-y: 0px;
+
     // ── Key-hold state for timer-based UP/DOWN navigation ────────────────────
     property <bool> up-held:   false;
     property <bool> down-held: false;
@@ -151,6 +164,15 @@ export component Editor inherits Rectangle {
             editor-scroll.viewport-y = -(root.current-line * root.line-h);
         } else if ((root.current-line + 1) * root.line-h > -editor-scroll.viewport-y + editor-scroll.height) {
             editor-scroll.viewport-y = -((root.current-line + 1) * root.line-h - editor-scroll.height);
+        }
+    }
+
+    // When Rust sets editor-cursor-target after a completion insertion, move the
+    // TextInput cursor to that byte offset then reset the target back to -1.
+    changed editor-cursor-target => {
+        if (root.editor-cursor-target >= 0) {
+            inner-input.set-selection-offsets(root.editor-cursor-target, root.editor-cursor-target);
+            root.editor-cursor-target = -1;
         }
     }
 
@@ -225,7 +247,52 @@ export component Editor inherits Rectangle {
             focus-on-click: false;
 
             capture-key-pressed(event) => {
-                if (event.text == Key.UpArrow
+                if (root.completion-visible) {
+                    // ── Popup navigation ────────────────────────────────────
+                    if (event.text == Key.UpArrow
+                            && !event.modifiers.shift
+                            && !event.modifiers.control
+                            && !event.modifiers.alt) {
+                        if (root.completion-selected > 0) {
+                            root.completion-selected -= 1;
+                        }
+                        EventResult.accept
+                    } else if (event.text == Key.DownArrow
+                            && !event.modifiers.shift
+                            && !event.modifiers.control
+                            && !event.modifiers.alt) {
+                        if (root.completion-selected < root.completion-items.length - 1) {
+                            root.completion-selected += 1;
+                        }
+                        EventResult.accept
+                    } else if (event.text == Key.Return
+                            && !event.modifiers.shift
+                            && !event.modifiers.control
+                            && !event.modifiers.alt) {
+                        if (root.completion-items.length > 0) {
+                            root.accept-completion(
+                                root.completion-items[root.completion-selected].insert-text,
+                                inner-input.cursor-position-byte-offset
+                            );
+                        }
+                        root.completion-visible = false;
+                        EventResult.accept
+                    } else if (event.text == Key.Tab) {
+                        if (root.completion-selected < root.completion-items.length - 1) {
+                            root.completion-selected += 1;
+                        } else {
+                            root.completion-selected = 0;
+                        }
+                        EventResult.accept
+                    } else if (event.text == Key.Escape) {
+                        root.completion-visible = false;
+                        EventResult.accept
+                    } else {
+                        // All other keys: let them reach TextInput; popup stays until
+                        // the debounce fires and either updates or hides it.
+                        EventResult.reject
+                    }
+                } else if (event.text == Key.UpArrow
                         && !event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
@@ -318,6 +385,9 @@ export component Editor inherits Rectangle {
                             editor-scroll.viewport-x = 0px;
                         }
                     }
+                    // Track cursor viewport position for completion popup placement.
+                    root.popup-x = pos.x + editor-scroll.viewport-x;
+                    root.popup-y = (root.current-line + 1) * root.line-h + editor-scroll.viewport-y;
                 }
             }
         }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -91,7 +91,7 @@ export component Editor inherits Rectangle {
     in property    <[CompletionRow]> completion-items:    [];
     in-out property <int>            completion-selected: 0;
     in-out property <int>            editor-cursor-target: -1;
-    callback accept-completion(string, int);
+    callback accept-completion(string, int, int, string);
 
     /// Cursor position in editor-viewport space; consumed by app.slint to place the popup.
     out property <length> popup-x: 0px;
@@ -272,7 +272,9 @@ export component Editor inherits Rectangle {
                         if (root.completion-items.length > 0) {
                             root.accept-completion(
                                 root.completion-items[root.completion-selected].insert-text,
-                                inner-input.cursor-position-byte-offset
+                                inner-input.cursor-position-byte-offset,
+                                root.completion-items[root.completion-selected].cursor-offset,
+                                root.completion-items[root.completion-selected].table-name
                             );
                         }
                         root.completion-visible = false;
@@ -288,8 +290,15 @@ export component Editor inherits Rectangle {
                         root.completion-visible = false;
                         EventResult.accept
                     } else {
-                        // All other keys: let them reach TextInput; popup stays until
-                        // the debounce fires and either updates or hides it.
+                        // Close popup immediately on characters that end a SQL token
+                        // (statement terminator, space, comma, parentheses).  This
+                        // avoids the user having to press Escape after, e.g., `;`.
+                        // The keystroke still reaches TextInput (EventResult.reject).
+                        if (event.text == ";" || event.text == " "
+                                || event.text == "," || event.text == ")"
+                                || event.text == "(") {
+                            root.completion-visible = false;
+                        }
                         EventResult.reject
                     }
                 } else if (event.text == Key.UpArrow

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -35,4 +35,6 @@ export struct CompletionRow {
     kind: string,
     detail: string,
     insert-text: string,
+    cursor-offset: int,
+    table-name: string,
 }

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -29,3 +29,10 @@ export struct SidebarNode {
     node-kind: string,    // "connection" | "category" | "table" | "view" | "proc" | "index"
     parent-index: int,    // flat-list index of parent node; -1 for root connection nodes
 }
+
+export struct CompletionRow {
+    label: string,
+    kind: string,
+    detail: string,
+    insert-text: string,
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -221,6 +221,7 @@ impl UI {
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
         Self::register_completion_callbacks(&window, tx_cmd.clone());
+        Self::register_completion_accept_callback(&window);
         // Set initial page size on the Slint window from shared state.
         window
             .global::<crate::UiState>()
@@ -546,6 +547,35 @@ impl UI {
                             let ui = window.global::<crate::UiState>();
                             let current = ui.get_editor_text().to_string();
                             ui.set_editor_text(append_editor_text(&current, &text).into());
+                        });
+                    }
+                    Event::CompletionReady(ref items) => {
+                        // Build Vec<CompletionRow> outside invoke_from_event_loop —
+                        // Vec is Send, Rc is not.
+                        let rows: Vec<crate::CompletionRow> = items
+                            .iter()
+                            .map(|item| crate::CompletionRow {
+                                label: item.label.clone().into(),
+                                kind: completion_kind_label(&item.kind).into(),
+                                detail: item.detail.clone().unwrap_or_default().into(),
+                                insert_text: item.insert_text.clone().into(),
+                            })
+                            .collect();
+                        // clone required: invoke_from_event_loop closure must be 'static
+                        let window_weak = window_weak.clone();
+                        let _ = slint::invoke_from_event_loop(move || {
+                            let Some(window) = window_weak.upgrade() else {
+                                return;
+                            };
+                            let ui = window.global::<crate::UiState>();
+                            if rows.is_empty() {
+                                ui.set_completion_visible(false);
+                            } else {
+                                let model = Rc::new(slint::VecModel::from(rows));
+                                ui.set_completion_items(model.into());
+                                ui.set_completion_selected(0);
+                                ui.set_completion_visible(true);
+                            }
                         });
                     }
                     _ => {}
@@ -919,6 +949,29 @@ impl UI {
         }
     }
 
+    fn register_completion_accept_callback(window: &crate::AppWindow) {
+        let ui = window.global::<crate::UiState>();
+        let window_weak = window.as_weak(); // clone required: on_accept_completion closure
+        ui.on_accept_completion(move |insert_text, cursor_pos| {
+            let Some(window) = window_weak.upgrade() else {
+                return;
+            };
+            let ui = window.global::<crate::UiState>();
+            let current = ui.get_editor_text().to_string();
+            let pos = (cursor_pos as usize).min(current.len());
+            let prefix_start = find_prefix_start(&current, pos);
+            let new_text = format!(
+                "{}{}{}",
+                &current[..prefix_start],
+                insert_text,
+                &current[pos..]
+            );
+            let new_cursor = (prefix_start + insert_text.len()) as i32;
+            ui.set_editor_text(new_text.into());
+            ui.set_editor_cursor_target(new_cursor);
+        });
+    }
+
     // ── Result callbacks ──────────────────────────────────────────────────────
 
     fn register_result_callbacks(
@@ -1227,6 +1280,32 @@ fn db_type_label(dt: &DbType) -> &'static str {
     }
 }
 
+fn completion_kind_label(kind: &wf_completion::CompletionKind) -> &'static str {
+    use wf_completion::CompletionKind::*;
+    match kind {
+        Table => "Table",
+        Column => "Column",
+        Keyword => "Keyword",
+        Schema => "Schema",
+        View => "View",
+    }
+}
+
+/// Returns the byte offset of the first character of the word immediately
+/// before `cursor_pos` in `text`.  Handles dot-qualified names (e.g. `u.em`)
+/// by only considering the segment after the last `.`.
+pub(crate) fn find_prefix_start(text: &str, cursor_pos: usize) -> usize {
+    let pos = cursor_pos.min(text.len());
+    let before = &text[..pos];
+    let search_start = before.rfind('.').map(|i| i + 1).unwrap_or(0);
+    let prefix_len = before[search_start..]
+        .bytes()
+        .rev()
+        .take_while(|b| b.is_ascii_alphanumeric() || *b == b'_')
+        .count();
+    pos - prefix_len
+}
+
 /// Append `text` to `current` editor content with a newline separator.
 /// If `current` is empty the text is used as-is.
 /// If `current` already ends with `\n` the text is appended directly.
@@ -1425,6 +1504,28 @@ fn parse_col_eq(query: &str) -> Option<(String, &str)> {
 mod tests {
     use super::*;
     use wf_db::models::{DbMetadata, DbType, TableInfo};
+
+    // ── find_prefix_start ────────────────────────────────────────────────────
+
+    #[test]
+    fn find_prefix_start_should_return_word_start_before_cursor() {
+        assert_eq!(find_prefix_start("SELECT sel", 10), 7);
+    }
+
+    #[test]
+    fn find_prefix_start_should_return_cursor_when_at_space() {
+        assert_eq!(find_prefix_start("SELECT ", 7), 7);
+    }
+
+    #[test]
+    fn find_prefix_start_should_return_after_dot_for_qualified_name() {
+        assert_eq!(find_prefix_start("u.em", 4), 2);
+    }
+
+    #[test]
+    fn find_prefix_start_should_return_cursor_when_no_prefix() {
+        assert_eq!(find_prefix_start("SELECT * FROM ", 14), 14);
+    }
 
     fn make_conn(id: &str, name: &str) -> DbConnection {
         DbConnection {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -559,6 +559,8 @@ impl UI {
                                 kind: completion_kind_label(&item.kind).into(),
                                 detail: item.detail.clone().unwrap_or_default().into(),
                                 insert_text: item.insert_text.clone().into(),
+                                cursor_offset: item.cursor_offset,
+                                table_name: item.table_name.clone().unwrap_or_default().into(),
                             })
                             .collect();
                         // clone required: invoke_from_event_loop closure must be 'static
@@ -952,24 +954,132 @@ impl UI {
     fn register_completion_accept_callback(window: &crate::AppWindow) {
         let ui = window.global::<crate::UiState>();
         let window_weak = window.as_weak(); // clone required: on_accept_completion closure
-        ui.on_accept_completion(move |insert_text, cursor_pos| {
-            let Some(window) = window_weak.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            let current = ui.get_editor_text().to_string();
-            let pos = (cursor_pos as usize).min(current.len());
-            let prefix_start = find_prefix_start(&current, pos);
-            let new_text = format!(
-                "{}{}{}",
-                &current[..prefix_start],
-                insert_text,
-                &current[pos..]
-            );
-            let new_cursor = (prefix_start + insert_text.len()) as i32;
-            ui.set_editor_text(new_text.into());
-            ui.set_editor_cursor_target(new_cursor);
-        });
+        ui.on_accept_completion(
+            move |insert_text, cursor_pos, cursor_offset_val, table_name| {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = window.global::<crate::UiState>();
+                let current = ui.get_editor_text().to_string();
+                let pos = (cursor_pos as usize).min(current.len());
+                let mut prefix_start = find_prefix_start(&current, pos);
+                // When accepting a disambiguated column candidate (table_name is set), the
+                // user may have typed "colname tableprefix" with a space.  Extend the
+                // replacement range backward to cover the entire "colname tableprefix" so the
+                // insertion replaces both words, not just the current word after the space.
+                let table_name_str = table_name.to_string();
+                if !table_name_str.is_empty() {
+                    let before_prefix = &current[..prefix_start];
+                    let pattern = format!("{} ", insert_text.as_str());
+                    if before_prefix.ends_with(&pattern) {
+                        let extended = prefix_start - pattern.len();
+                        let at_boundary = extended == 0
+                            || matches!(
+                                current.as_bytes().get(extended - 1),
+                                Some(b' ') | Some(b'\t') | Some(b'\n')
+                            );
+                        if at_boundary {
+                            prefix_start = extended;
+                        }
+                    }
+                }
+
+                // If the accepted text is a SQL keyword (FROM, WHERE, AND …), treat it as
+                // a plain insertion even inside a SELECT list — no comma should be added.
+                let is_keyword = wf_completion::parser::is_sql_keyword(insert_text.as_str());
+                let in_select = !is_keyword && wf_completion::parser::in_select_list(&current, pos);
+
+                let (new_text, new_cursor): (String, i32) = if in_select {
+                    // In SELECT list: auto-insert ", " between columns.
+                    let trimmed = current[..prefix_start].trim_end_matches([' ', '\t']);
+                    let last_char = trimmed.chars().last();
+                    let last_word_start = trimmed
+                        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+                        .map(|i| i + 1)
+                        .unwrap_or(0);
+                    let last_word = trimmed[last_word_start..].to_ascii_uppercase();
+                    let needs_comma = !matches!(last_char, None | Some(',') | Some('('))
+                        && !matches!(last_word.as_str(), "SELECT" | "DISTINCT");
+                    if needs_comma {
+                        let text = format!("{}, {}{}", trimmed, insert_text, &current[pos..]);
+                        let cur = (trimmed.len() + 2 + insert_text.len()) as i32;
+                        (text, cur)
+                    } else {
+                        let text = format!(
+                            "{}{}{}",
+                            &current[..prefix_start],
+                            insert_text,
+                            &current[pos..]
+                        );
+                        let cur = (prefix_start + insert_text.len()) as i32;
+                        (text, cur)
+                    }
+                } else {
+                    // Determine whether to replace the typed prefix or insert at cursor.
+                    // When the accepted text is unrelated to the prefix (e.g. user finished
+                    // typing "users" and now accepts a NextClause keyword like "WHERE"),
+                    // insert at the cursor position with a leading space rather than
+                    // overwriting the table/column name.
+                    let prefix_word = &current[prefix_start..pos];
+                    let (actual_start, add_leading_space) = if prefix_word.is_empty() {
+                        // Cursor is at whitespace or string start — plain insert.
+                        (pos, false)
+                    } else if insert_text
+                        .as_str()
+                        .to_ascii_uppercase()
+                        .starts_with(&prefix_word.to_ascii_uppercase())
+                    {
+                        // Prefix is a partial match of insert_text — replace it.
+                        (prefix_start, false)
+                    } else {
+                        // Prefix is unrelated (e.g. "users" + "WHERE") — insert at cursor.
+                        let needs_space =
+                            !current[..pos].ends_with(|c: char| c.is_ascii_whitespace());
+                        (pos, needs_space)
+                    };
+                    let leading = if add_leading_space { " " } else { "" };
+                    let text = format!(
+                        "{}{}{}{}",
+                        &current[..actual_start],
+                        leading,
+                        insert_text,
+                        &current[pos..]
+                    );
+                    let cur = if cursor_offset_val > 0 {
+                        actual_start as i32 + add_leading_space as i32 + cursor_offset_val
+                    } else {
+                        (actual_start + leading.len() + insert_text.len()) as i32
+                    };
+                    (text, cur)
+                };
+
+                // Auto-append FROM <table> when a column with a known table was accepted
+                // inside a SELECT list that has no FROM clause yet.
+                let appended_from =
+                    in_select && !table_name_str.is_empty() && !sql_has_from(&current);
+                let (final_text, final_cursor) = if appended_from {
+                    let appended = format!("{} FROM {}", new_text.trim_end(), table_name_str);
+                    let cur = appended.len() as i32;
+                    (appended, cur)
+                } else {
+                    (new_text, new_cursor)
+                };
+
+                // inserted text, e.g. between the quotes in `''`).
+                let at_end = final_cursor as usize == final_text.len();
+                ui.set_editor_text(final_text.clone().into());
+                ui.set_editor_cursor_target(final_cursor);
+                // Re-trigger only when the cursor is at end of inserted text AND the text
+                // does not end at a syntactically terminal expression (IS NULL, TRUE, FALSE,
+                // a string/numeric literal, ASC/DESC).  Terminal positions use a virtual
+                // trailing space so the parser sees the next context without polluting the
+                // editor with a stale space the user would have to delete before typing `;`.
+                if cursor_offset_val == 0 && at_end && !is_terminal_expression(&final_text) {
+                    let trigger_sql = format!("{} ", final_text);
+                    ui.invoke_trigger_completion(trigger_sql.into(), final_cursor + 1);
+                }
+            },
+        );
     }
 
     // ── Result callbacks ──────────────────────────────────────────────────────
@@ -1307,6 +1417,42 @@ pub(crate) fn find_prefix_start(text: &str, cursor_pos: usize) -> usize {
     pos - prefix_len
 }
 
+/// Returns `true` when `text` ends at a position where showing the next
+/// completion popup would be misleading — specifically after terminal SQL
+/// expressions: IS NULL, IS NOT NULL, TRUE, FALSE, ASC, DESC, string
+/// literals (ending `'`), or numeric literals.
+///
+/// This suppresses the auto-retrigger after, e.g., `IS NOT NULL` so the
+/// editor does not immediately show column candidates for the next `AND`
+/// clause; the user can still invoke Ctrl+Space explicitly if needed.
+fn is_terminal_expression(text: &str) -> bool {
+    let t = text.trim_end();
+    // Last whole-word token (alphanumeric + underscore run after final separator).
+    let last_word_start = t
+        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let last_word = t[last_word_start..].to_ascii_uppercase();
+    if matches!(
+        last_word.as_str(),
+        "NULL" | "TRUE" | "FALSE" | "ASC" | "DESC"
+    ) {
+        return true;
+    }
+    // String literal or numeric literal.
+    t.ends_with('\'') || t.ends_with('"') || t.chars().last().is_some_and(|c| c.is_ascii_digit())
+}
+
+/// Returns `true` if `sql` contains a FROM clause (case-insensitive).
+/// Used to decide whether to auto-append `FROM <table>` after a column acceptance.
+fn sql_has_from(sql: &str) -> bool {
+    let upper = sql.to_ascii_uppercase();
+    upper.contains(" FROM ")
+        || upper.contains("\nFROM ")
+        || upper.contains("\tFROM ")
+        || upper.starts_with("FROM ")
+}
+
 /// Append `text` to `current` editor content with a newline separator.
 /// If `current` is empty the text is used as-is.
 /// If `current` already ends with `\n` the text is appended directly.
@@ -1526,6 +1672,77 @@ mod tests {
     #[test]
     fn find_prefix_start_should_return_cursor_when_no_prefix() {
         assert_eq!(find_prefix_start("SELECT * FROM ", 14), 14);
+    }
+
+    // ── sql_has_from ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn sql_has_from_should_return_true_when_from_present() {
+        assert!(sql_has_from("SELECT id FROM users"));
+    }
+
+    #[test]
+    fn sql_has_from_should_return_false_when_no_from() {
+        assert!(!sql_has_from("SELECT id, name"));
+    }
+
+    #[test]
+    fn sql_has_from_should_return_true_for_multiline_from() {
+        assert!(sql_has_from("SELECT id\nFROM users"));
+    }
+
+    #[test]
+    fn sql_has_from_should_return_false_for_from_in_column_name() {
+        // "from" inside a word like "transform" should not match
+        assert!(!sql_has_from("SELECT transform_id"));
+    }
+
+    // ── is_terminal_expression ────────────────────────────────────────────────
+
+    #[test]
+    fn is_terminal_expression_should_return_true_for_is_not_null() {
+        assert!(is_terminal_expression(
+            "SELECT name FROM users WHERE deleted_at IS NOT NULL"
+        ));
+        assert!(is_terminal_expression("WHERE col IS NULL"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_return_true_for_boolean_keywords() {
+        assert!(is_terminal_expression("WHERE active = TRUE"));
+        assert!(is_terminal_expression("WHERE active = FALSE"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_return_true_for_direction_keywords() {
+        assert!(is_terminal_expression("ORDER BY id ASC"));
+        assert!(is_terminal_expression("ORDER BY id DESC"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_return_true_for_string_literal() {
+        assert!(is_terminal_expression("WHERE name = 'alice'"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_return_true_for_numeric_literal() {
+        assert!(is_terminal_expression("WHERE id = 5"));
+        assert!(is_terminal_expression("LIMIT 10"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_return_false_for_non_terminal_positions() {
+        assert!(!is_terminal_expression("FROM users WHERE"));
+        assert!(!is_terminal_expression("SELECT * FROM users"));
+        assert!(!is_terminal_expression("SELECT id"));
+    }
+
+    #[test]
+    fn is_terminal_expression_should_not_match_word_ending_with_null_suffix() {
+        // "nullify" last word is "NULLIFY" — not the keyword "NULL"
+        assert!(!is_terminal_expression("WHERE nullify"));
+        // "is_not_null_col" is a column name, not the keyword NULL
+        assert!(!is_terminal_expression("SELECT is_not_null_col"));
     }
 
     fn make_conn(id: &str, name: &str) -> DbConnection {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1286,6 +1286,7 @@ fn completion_kind_label(kind: &wf_completion::CompletionKind) -> &'static str {
         Table => "Table",
         Column => "Column",
         Keyword => "Keyword",
+        Operator => "Operator",
         Schema => "Schema",
         View => "View",
     }

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -102,9 +102,32 @@ impl CompletionEngine {
                     .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
                     .collect()
             }
-            CompletionContext::TableName => table_candidates(metadata, &prefix_upper),
+            CompletionContext::TableName => {
+                let tables = table_candidates(metadata, &prefix_upper);
+                if tables.is_empty() && !prefix_upper.is_empty() {
+                    // No table matched the prefix — the user is likely typing a
+                    // keyword (e.g. "WHERE" after "FROM users wh").  Fall back to
+                    // keyword suggestions so structure keywords always surface.
+                    keyword_candidates(&prefix_upper)
+                        .into_iter()
+                        .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
+                        .collect()
+                } else {
+                    tables
+                }
+            }
             CompletionContext::ColumnName { table } => {
-                column_candidates(metadata, table.as_deref(), &prefix_upper)
+                let cols = column_candidates(metadata, table.as_deref(), &prefix_upper);
+                if cols.is_empty() && !prefix_upper.is_empty() {
+                    // No column matched the prefix — fall back to keywords so the
+                    // user can continue structuring the query (AND, OR, ORDER BY …).
+                    keyword_candidates(&prefix_upper)
+                        .into_iter()
+                        .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
+                        .collect()
+                } else {
+                    cols
+                }
             }
             CompletionContext::None => vec![],
         }
@@ -300,6 +323,39 @@ mod tests {
         assert!(labels.contains(&"order_id"));
         assert!(labels.contains(&"total"));
         assert!(labels.contains(&"user_id"));
+    }
+
+    #[test]
+    fn complete_should_fall_back_to_keywords_when_no_table_matches_prefix() {
+        let meta = make_metadata();
+        // "wh" doesn't match any table/view name → falls back to keywords (WHERE, WITH)
+        let items = CompletionEngine::complete(CompletionContext::TableName, &meta, "wh");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"WHERE"), "expected WHERE in {labels:?}");
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Keyword));
+    }
+
+    #[test]
+    fn complete_should_fall_back_to_keywords_when_no_column_matches_prefix() {
+        let meta = make_metadata();
+        // users columns are "id" and "email"; "wh" matches neither → falls back to keywords
+        let ctx = CompletionContext::ColumnName {
+            table: Some("users".to_string()),
+        };
+        let items = CompletionEngine::complete(ctx, &meta, "wh");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"WHERE"), "expected WHERE in {labels:?}");
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Keyword));
+    }
+
+    #[test]
+    fn complete_should_prefer_table_candidates_over_keyword_fallback() {
+        let meta = make_metadata();
+        // "us" matches table "users" → table candidates returned, no keyword fallback
+        let items = CompletionEngine::complete(CompletionContext::TableName, &meta, "us");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["users"]);
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Table));
     }
 
     #[test]

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -130,6 +130,8 @@ impl CompletionEngine {
                 }
             }
             CompletionContext::NextClause => next_clause_candidates(),
+            CompletionContext::JoinOn => join_on_candidates(),
+            CompletionContext::Operator => operator_candidates(),
             CompletionContext::None => vec![],
         }
     }
@@ -160,6 +162,42 @@ fn next_clause_candidates() -> Vec<CompletionItem> {
             label: kw.to_string(),
             kind: CompletionKind::Keyword,
             insert_text: kw.to_string(),
+            detail: None,
+        })
+        .collect()
+}
+
+fn join_on_candidates() -> Vec<CompletionItem> {
+    vec![CompletionItem {
+        label: "ON".to_string(),
+        kind: CompletionKind::Keyword,
+        insert_text: "ON".to_string(),
+        detail: None,
+    }]
+}
+
+fn operator_candidates() -> Vec<CompletionItem> {
+    const OPS: &[&str] = &[
+        "=",
+        "!=",
+        "<>",
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "IS NULL",
+        "IS NOT NULL",
+        "IN",
+        "NOT IN",
+        "LIKE",
+        "ILIKE",
+        "BETWEEN",
+    ];
+    OPS.iter()
+        .map(|&op| CompletionItem {
+            label: op.to_string(),
+            kind: CompletionKind::Operator,
+            insert_text: op.to_string(),
             detail: None,
         })
         .collect()
@@ -385,6 +423,29 @@ mod tests {
         let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(labels, vec!["users"]);
         assert!(items.iter().all(|i| i.kind == CompletionKind::Table));
+    }
+
+    #[test]
+    fn complete_should_return_on_for_join_on_context() {
+        let meta = DbMetadata::default();
+        let items = CompletionEngine::complete(CompletionContext::JoinOn, &meta, "");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["ON"]);
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Keyword));
+    }
+
+    #[test]
+    fn complete_should_return_comparison_operators_for_operator_context() {
+        let meta = DbMetadata::default();
+        let items = CompletionEngine::complete(CompletionContext::Operator, &meta, "");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"="), "expected = in {labels:?}");
+        assert!(
+            labels.contains(&"IS NULL"),
+            "expected IS NULL in {labels:?}"
+        );
+        assert!(labels.contains(&"LIKE"), "expected LIKE in {labels:?}");
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Operator));
     }
 
     #[test]

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -3,10 +3,18 @@
 //! [`CompletionEngine::complete`] maps a [`CompletionContext`] + [`DbMetadata`] + prefix
 //! string to a filtered list of [`CompletionItem`] candidates.
 
-use wf_db::models::{DbMetadata, TableInfo};
+use wf_db::models::DbMetadata;
 
 use crate::parser::CompletionContext;
 use crate::{CompletionItem, CompletionKind};
+
+// Value literal candidates shown after a comparison operator (=, <, >).
+const VALUE_CANDIDATES: &[(&str, i32)] = &[
+    ("''", 1), // cursor_offset 1 → places cursor between quotes
+    ("NULL", 0),
+    ("TRUE", 0),
+    ("FALSE", 0),
+];
 
 // ── SQL keyword table ─────────────────────────────────────────────────────────
 
@@ -103,7 +111,10 @@ impl CompletionEngine {
                     .collect()
             }
             CompletionContext::TableName => {
-                let tables = table_candidates(metadata, &prefix_upper);
+                let tables: Vec<_> = table_candidates(metadata, &prefix_upper)
+                    .into_iter()
+                    .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
+                    .collect();
                 if tables.is_empty() && !prefix_upper.is_empty() {
                     // No table matched the prefix — the user is likely typing a
                     // keyword (e.g. "WHERE" after "FROM users wh").  Fall back to
@@ -117,7 +128,12 @@ impl CompletionEngine {
                 }
             }
             CompletionContext::ColumnName { table } => {
-                let cols = column_candidates(metadata, table.as_deref(), &prefix_upper);
+                // Exclude items the user has already typed in full so the popup
+                // closes automatically once a word is complete.
+                let cols: Vec<_> = column_candidates(metadata, table.as_deref(), &prefix_upper)
+                    .into_iter()
+                    .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
+                    .collect();
                 if cols.is_empty() && !prefix_upper.is_empty() {
                     // No column matched the prefix — fall back to keywords so the
                     // user can continue structuring the query (AND, OR, ORDER BY …).
@@ -132,6 +148,19 @@ impl CompletionEngine {
             CompletionContext::NextClause => next_clause_candidates(),
             CompletionContext::JoinOn => join_on_candidates(),
             CompletionContext::Operator => operator_candidates(),
+            CompletionContext::JoinConditionTable { tables } => tables
+                .iter()
+                .filter(|name| name.to_ascii_uppercase().starts_with(&prefix_upper))
+                .map(|name| CompletionItem {
+                    label: name.clone(),
+                    kind: CompletionKind::Table,
+                    insert_text: name.clone(),
+                    cursor_offset: 0,
+                    detail: None,
+                    table_name: None,
+                })
+                .collect(),
+            CompletionContext::ValueExpected => value_candidates(),
             CompletionContext::None => vec![],
         }
     }
@@ -162,7 +191,9 @@ fn next_clause_candidates() -> Vec<CompletionItem> {
             label: kw.to_string(),
             kind: CompletionKind::Keyword,
             insert_text: kw.to_string(),
+            cursor_offset: 0,
             detail: None,
+            table_name: None,
         })
         .collect()
 }
@@ -172,7 +203,9 @@ fn join_on_candidates() -> Vec<CompletionItem> {
         label: "ON".to_string(),
         kind: CompletionKind::Keyword,
         insert_text: "ON".to_string(),
+        cursor_offset: 0,
         detail: None,
+        table_name: None,
     }]
 }
 
@@ -198,7 +231,23 @@ fn operator_candidates() -> Vec<CompletionItem> {
             label: op.to_string(),
             kind: CompletionKind::Operator,
             insert_text: op.to_string(),
+            cursor_offset: 0,
             detail: None,
+            table_name: None,
+        })
+        .collect()
+}
+
+fn value_candidates() -> Vec<CompletionItem> {
+    VALUE_CANDIDATES
+        .iter()
+        .map(|&(val, offset)| CompletionItem {
+            label: val.to_string(),
+            kind: CompletionKind::Keyword,
+            insert_text: val.to_string(),
+            cursor_offset: offset,
+            detail: None,
+            table_name: None,
         })
         .collect()
 }
@@ -211,7 +260,9 @@ fn keyword_candidates(prefix_upper: &str) -> Vec<CompletionItem> {
             label: kw.to_string(),
             kind: CompletionKind::Keyword,
             insert_text: kw.to_string(),
+            cursor_offset: 0,
             detail: None,
+            table_name: None,
         })
         .collect()
 }
@@ -227,7 +278,9 @@ fn table_candidates(metadata: &DbMetadata, prefix_upper: &str) -> Vec<Completion
             label: t.name.clone(),
             kind,
             insert_text: t.name.clone(),
+            cursor_offset: 0,
             detail: None,
+            table_name: None,
         })
         .collect()
 }
@@ -237,7 +290,7 @@ fn column_candidates(
     table: Option<&str>,
     prefix_upper: &str,
 ) -> Vec<CompletionItem> {
-    let sources: Vec<&TableInfo> = match table {
+    match table {
         Some(name) => {
             let name_upper = name.to_ascii_uppercase();
             metadata
@@ -245,26 +298,92 @@ fn column_candidates(
                 .iter()
                 .chain(metadata.views.iter())
                 .filter(|t| t.name.to_ascii_uppercase() == name_upper)
+                .flat_map(|t| {
+                    let tname = t.name.clone();
+                    t.columns.iter().map(move |c| (c, tname.clone()))
+                })
+                .filter(|(c, _)| c.name.to_ascii_uppercase().starts_with(prefix_upper))
+                .map(|(c, tname)| CompletionItem {
+                    label: c.name.clone(),
+                    kind: CompletionKind::Column,
+                    insert_text: c.name.clone(),
+                    cursor_offset: 0,
+                    detail: Some(c.data_type.clone()),
+                    table_name: Some(tname),
+                })
                 .collect()
         }
-        None => metadata
-            .tables
-            .iter()
-            .chain(metadata.views.iter())
-            .collect(),
-    };
+        None => {
+            // Collect ALL (col, table) pairs to determine global ambiguity counts.
+            let all_pairs: Vec<(&wf_db::models::ColumnInfo, &str)> = metadata
+                .tables
+                .iter()
+                .chain(metadata.views.iter())
+                .flat_map(|t| t.columns.iter().map(move |c| (c, t.name.as_str())))
+                .collect();
 
-    sources
-        .into_iter()
-        .flat_map(|t| t.columns.iter())
-        .filter(|c| c.name.to_ascii_uppercase().starts_with(prefix_upper))
-        .map(|c| CompletionItem {
-            label: c.name.clone(),
-            kind: CompletionKind::Column,
-            insert_text: c.name.clone(),
-            detail: Some(c.data_type.clone()),
-        })
-        .collect()
+            // Count how many tables each column name appears in (uppercase key).
+            let mut tables_per_col: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::new();
+            for (c, _) in &all_pairs {
+                *tables_per_col
+                    .entry(c.name.to_ascii_uppercase())
+                    .or_insert(0) += 1;
+            }
+
+            // Filter and build items.
+            //
+            // Two matching modes:
+            //  1. Standard: column name starts with `prefix`  (e.g. "na" → "name")
+            //  2. Extended: for ambiguous columns only — prefix starts with the column
+            //     name and the remainder matches the table name prefix.
+            //     This lets users narrow disambiguation by continuing to type the table
+            //     name directly (e.g. "nameuse" → shows only "name (users)").
+            all_pairs
+                .into_iter()
+                .filter(|(c, tname)| {
+                    let col_upper = c.name.to_ascii_uppercase();
+                    // Standard match: column name starts with prefix.
+                    if col_upper.starts_with(prefix_upper) {
+                        return true;
+                    }
+                    // Extended match: only for ambiguous columns.
+                    // prefix must start with the column name; the trailing part of
+                    // the prefix must match the beginning of the table name.
+                    let ambiguous = *tables_per_col.get(&col_upper).unwrap_or(&0) > 1;
+                    if ambiguous
+                        && !prefix_upper.is_empty()
+                        && prefix_upper.starts_with(col_upper.as_str())
+                    {
+                        // Trim any leading whitespace so "name u" (space-separated)
+                        // matches the same way as "nameu" (no-space).
+                        let rest = prefix_upper[col_upper.len()..].trim_start_matches(' ');
+                        return tname.to_ascii_uppercase().starts_with(rest);
+                    }
+                    false
+                })
+                .map(|(c, tname)| {
+                    let ambiguous = *tables_per_col
+                        .get(&c.name.to_ascii_uppercase())
+                        .unwrap_or(&0)
+                        > 1;
+                    let label = if ambiguous {
+                        format!("{} ({})", c.name, tname)
+                    } else {
+                        c.name.clone()
+                    };
+                    CompletionItem {
+                        label,
+                        kind: CompletionKind::Column,
+                        insert_text: c.name.clone(),
+                        cursor_offset: 0,
+                        detail: Some(c.data_type.clone()),
+                        table_name: Some(tname.to_string()),
+                    }
+                })
+                .collect()
+        }
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -476,7 +595,8 @@ mod tests {
         let ctx = CompletionContext::ColumnName {
             table: Some("users".to_string()),
         };
-        let items = CompletionEngine::complete(ctx, &meta, "id");
+        // Use partial prefix so the exact-match filter does not exclude the column.
+        let items = CompletionEngine::complete(ctx, &meta, "i");
         let id_item = items
             .iter()
             .find(|i| i.label == "id")
@@ -517,5 +637,154 @@ mod tests {
         assert!(items.iter().all(|i| i.insert_text == i.label));
         let kw_items = CompletionEngine::complete(CompletionContext::Keyword, &meta, "sel");
         assert!(kw_items.iter().all(|i| i.insert_text == i.label));
+    }
+
+    #[test]
+    fn complete_should_return_value_candidates_for_value_expected_context() {
+        let meta = DbMetadata::default();
+        let items = CompletionEngine::complete(CompletionContext::ValueExpected, &meta, "");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"''"), "expected '' in {labels:?}");
+        assert!(labels.contains(&"NULL"), "expected NULL in {labels:?}");
+    }
+
+    #[test]
+    fn complete_should_set_cursor_offset_one_for_empty_string_literal() {
+        let meta = DbMetadata::default();
+        let items = CompletionEngine::complete(CompletionContext::ValueExpected, &meta, "");
+        let quote_item = items
+            .iter()
+            .find(|i| i.label == "''")
+            .expect("'' not found");
+        assert_eq!(quote_item.cursor_offset, 1);
+    }
+
+    #[test]
+    fn complete_should_disambiguate_columns_with_same_name_in_multiple_tables() {
+        // Two tables each have a "name" column — labels should carry the table qualifier.
+        let meta = DbMetadata {
+            tables: vec![
+                TableInfo {
+                    name: "users".to_string(),
+                    columns: vec![ColumnInfo {
+                        name: "name".to_string(),
+                        data_type: "varchar".to_string(),
+                        nullable: false,
+                    }],
+                },
+                TableInfo {
+                    name: "companies".to_string(),
+                    columns: vec![ColumnInfo {
+                        name: "name".to_string(),
+                        data_type: "varchar".to_string(),
+                        nullable: false,
+                    }],
+                },
+            ],
+            views: vec![],
+            stored_procs: vec![],
+            indexes: vec![],
+        };
+        let ctx = CompletionContext::ColumnName { table: None };
+        let items = CompletionEngine::complete(ctx, &meta, "na");
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.contains(&"name (users)"),
+            "expected 'name (users)' in {labels:?}"
+        );
+        assert!(
+            labels.contains(&"name (companies)"),
+            "expected 'name (companies)' in {labels:?}"
+        );
+        // insert_text should still be the plain column name
+        assert!(items.iter().all(|i| i.insert_text == "name"));
+        // table_name carries the owning table
+        let users_item = items.iter().find(|i| i.label == "name (users)").unwrap();
+        assert_eq!(users_item.table_name.as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn complete_should_narrow_disambiguated_column_by_typing_table_name_suffix() {
+        // Two tables share a "name" column.  Typing "nameuse" should narrow to
+        // only "name (users)" by matching the table-name suffix "use" → "users".
+        let meta = DbMetadata {
+            tables: vec![
+                TableInfo {
+                    name: "users".to_string(),
+                    columns: vec![ColumnInfo {
+                        name: "name".to_string(),
+                        data_type: "varchar".to_string(),
+                        nullable: false,
+                    }],
+                },
+                TableInfo {
+                    name: "companies".to_string(),
+                    columns: vec![ColumnInfo {
+                        name: "name".to_string(),
+                        data_type: "varchar".to_string(),
+                        nullable: false,
+                    }],
+                },
+            ],
+            views: vec![],
+            stored_procs: vec![],
+            indexes: vec![],
+        };
+        let ctx = CompletionContext::ColumnName { table: None };
+        // "nameuse" → col part "name" matches both; table suffix "use" only matches "users"
+        let items = CompletionEngine::complete(ctx.clone(), &meta, "nameuse");
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["name (users)"],
+            "expected only 'name (users)' in {labels:?}"
+        );
+        // insert_text is still just the column name, not the full typed prefix
+        assert_eq!(items[0].insert_text, "name");
+        // "namecomp" → matches "name (companies)"
+        let items2 = CompletionEngine::complete(ctx, &meta, "namecomp");
+        let labels2: Vec<&str> = items2.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(
+            labels2,
+            vec!["name (companies)"],
+            "expected only 'name (companies)' in {labels2:?}"
+        );
+    }
+
+    #[test]
+    fn complete_should_not_disambiguate_unique_column_names_when_table_is_none() {
+        let meta = make_metadata(); // users.id, users.email, orders.order_id, orders.total, ...
+        let ctx = CompletionContext::ColumnName { table: None };
+        let items = CompletionEngine::complete(ctx, &meta, "");
+        // "id" only exists in users → no disambiguation
+        let id_item = items.iter().find(|i| i.insert_text == "id").unwrap();
+        assert_eq!(id_item.label, "id");
+        assert_eq!(id_item.table_name.as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn complete_should_carry_table_name_on_column_candidates_with_explicit_table() {
+        let meta = make_metadata();
+        let ctx = CompletionContext::ColumnName {
+            table: Some("users".to_string()),
+        };
+        let items = CompletionEngine::complete(ctx, &meta, "");
+        assert!(
+            items
+                .iter()
+                .all(|i| i.table_name.as_deref() == Some("users"))
+        );
+    }
+
+    #[test]
+    fn complete_should_return_join_condition_tables_filtered_by_prefix() {
+        let meta = DbMetadata::default();
+        let tables = vec!["users".to_string(), "departments".to_string()];
+        let ctx = CompletionContext::JoinConditionTable { tables };
+        let items = CompletionEngine::complete(ctx.clone(), &meta, "dep");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["departments"]);
+        let all_items = CompletionEngine::complete(ctx, &meta, "");
+        assert_eq!(all_items.len(), 2);
     }
 }

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -129,12 +129,41 @@ impl CompletionEngine {
                     cols
                 }
             }
+            CompletionContext::NextClause => next_clause_candidates(),
             CompletionContext::None => vec![],
         }
     }
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn next_clause_candidates() -> Vec<CompletionItem> {
+    const NEXT_CLAUSES: &[&str] = &[
+        "WHERE",
+        "JOIN",
+        "INNER JOIN",
+        "LEFT JOIN",
+        "RIGHT JOIN",
+        "FULL OUTER JOIN",
+        "ORDER BY",
+        "GROUP BY",
+        "HAVING",
+        "LIMIT",
+        "OFFSET",
+        "ON",
+        "UNION",
+        "UNION ALL",
+    ];
+    NEXT_CLAUSES
+        .iter()
+        .map(|&kw| CompletionItem {
+            label: kw.to_string(),
+            kind: CompletionKind::Keyword,
+            insert_text: kw.to_string(),
+            detail: None,
+        })
+        .collect()
+}
 
 fn keyword_candidates(prefix_upper: &str) -> Vec<CompletionItem> {
     SQL_KEYWORDS
@@ -356,6 +385,21 @@ mod tests {
         let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(labels, vec!["users"]);
         assert!(items.iter().all(|i| i.kind == CompletionKind::Table));
+    }
+
+    #[test]
+    fn complete_should_return_next_clause_candidates_for_next_clause_context() {
+        let meta = DbMetadata::default();
+        let items = CompletionEngine::complete(CompletionContext::NextClause, &meta, "");
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"WHERE"), "expected WHERE in {labels:?}");
+        assert!(labels.contains(&"JOIN"), "expected JOIN in {labels:?}");
+        assert!(
+            labels.contains(&"ORDER BY"),
+            "expected ORDER BY in {labels:?}"
+        );
+        assert!(labels.contains(&"LIMIT"), "expected LIMIT in {labels:?}");
+        assert!(items.iter().all(|i| i.kind == CompletionKind::Keyword));
     }
 
     #[test]

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -87,7 +87,21 @@ impl CompletionEngine {
     ) -> Vec<CompletionItem> {
         let prefix_upper = prefix.to_ascii_uppercase();
         match context {
-            CompletionContext::Keyword => keyword_candidates(&prefix_upper),
+            CompletionContext::Keyword => {
+                if prefix_upper.is_empty() {
+                    // Don't flood the popup when the cursor is at an empty position
+                    // (e.g. after typing "SELECT ").  The user must type at least one
+                    // character before keyword suggestions appear.
+                    return vec![];
+                }
+                // Exclude keywords the user has already typed in full (e.g. if prefix
+                // is "SELECT", omit SELECT itself — but keep "UNION ALL" when prefix
+                // is "UNION").
+                keyword_candidates(&prefix_upper)
+                    .into_iter()
+                    .filter(|item| item.label.to_ascii_uppercase() != prefix_upper)
+                    .collect()
+            }
             CompletionContext::TableName => table_candidates(metadata, &prefix_upper),
             CompletionContext::ColumnName { table } => {
                 column_candidates(metadata, table.as_deref(), &prefix_upper)
@@ -231,16 +245,14 @@ mod tests {
     }
 
     #[test]
-    fn complete_should_return_all_keywords_for_empty_prefix() {
+    fn complete_should_return_empty_for_keyword_with_empty_prefix() {
         let meta = DbMetadata::default();
         let items = CompletionEngine::complete(CompletionContext::Keyword, &meta, "");
         assert!(
-            items.len() >= SQL_KEYWORDS.len(),
-            "expected ≥{} keywords, got {}",
-            SQL_KEYWORDS.len(),
+            items.is_empty(),
+            "expected no keyword suggestions for empty prefix, got {}",
             items.len()
         );
-        assert!(items.iter().all(|i| i.kind == CompletionKind::Keyword));
     }
 
     #[test]
@@ -342,7 +354,7 @@ mod tests {
         let meta = make_metadata();
         let items = CompletionEngine::complete(CompletionContext::TableName, &meta, "");
         assert!(items.iter().all(|i| i.insert_text == i.label));
-        let kw_items = CompletionEngine::complete(CompletionContext::Keyword, &meta, "");
+        let kw_items = CompletionEngine::complete(CompletionContext::Keyword, &meta, "sel");
         assert!(kw_items.iter().all(|i| i.insert_text == i.label));
     }
 }

--- a/crates/wf-completion/src/lib.rs
+++ b/crates/wf-completion/src/lib.rs
@@ -11,6 +11,7 @@ pub enum CompletionKind {
     Table,
     Column,
     Keyword,
+    Operator,
     Schema,
     View,
 }

--- a/crates/wf-completion/src/lib.rs
+++ b/crates/wf-completion/src/lib.rs
@@ -3,7 +3,14 @@ pub struct CompletionItem {
     pub label: String,
     pub kind: CompletionKind,
     pub insert_text: String,
+    /// Byte offset within `insert_text` where the cursor should land after insertion.
+    /// `0` means "end of inserted text" (default).  A positive value places the cursor
+    /// that many bytes from the start (e.g. `1` for `''` puts the cursor between quotes).
+    pub cursor_offset: i32,
     pub detail: Option<String>,
+    /// For column candidates, the owning table name. Used by the UI to auto-append
+    /// `FROM <table>` when a column is accepted before any FROM clause is present.
+    pub table_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/wf-completion/src/parser.rs
+++ b/crates/wf-completion/src/parser.rs
@@ -23,6 +23,12 @@ pub enum CompletionContext {
     /// Cursor is at a space after a column reference in WHERE / HAVING / ON — suggest
     /// comparison operators (`=`, `!=`, `IS NULL`, `LIKE`, …).
     Operator,
+    /// Cursor follows `ON` with nothing typed yet — suggest table names from FROM/JOIN clauses
+    /// so the user can continue with dot-notation column access.
+    JoinConditionTable { tables: Vec<String> },
+    /// Cursor follows a comparison operator (`=`, `<`, `>`) — suggest value literals
+    /// (`''`, `NULL`, `TRUE`, `FALSE`).
+    ValueExpected,
     /// Context cannot be determined (e.g. the SQL is empty).
     None,
 }
@@ -40,6 +46,11 @@ pub enum CompletionContext {
 pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
     let cursor_pos = cursor_pos.min(sql.len());
     let before = &sql[..cursor_pos];
+
+    // After a semicolon there is nothing more to complete in this statement.
+    if before.trim_end().ends_with(';') {
+        return CompletionContext::None;
+    }
 
     // Dot notation: "alias.|" → column completion scoped to that alias's table.
     if let Some(prefix) = before.trim_end().strip_suffix('.') {
@@ -76,14 +87,26 @@ pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
             CompletionContext::TableName
         }
         Some(trig @ ("WHERE" | "HAVING" | "ON")) => {
-            // Operator context: cursor at space right after a single column/qualified-column
-            // reference (e.g. "WHERE id ", "ON t.id ").  Detected when the text after the
-            // trigger is a lone identifier with no spaces or operator symbols inside it.
             if before.ends_with(|c: char| c.is_ascii_whitespace()) {
                 let trigger_end = last_kw_pos(&before_upper, trig)
                     .map(|p| p + trig.len())
                     .unwrap_or(0);
                 let after_trigger = before[trigger_end..].trim();
+
+                // ON with nothing typed yet → suggest referenced table names for dot notation
+                if trig == "ON" && after_trigger.is_empty() {
+                    let tables = extract_referenced_tables(sql);
+                    if !tables.is_empty() {
+                        return CompletionContext::JoinConditionTable { tables };
+                    }
+                }
+
+                // Cursor follows a comparison operator → suggest value literals
+                if after_trigger.ends_with(['=', '<', '>']) {
+                    return CompletionContext::ValueExpected;
+                }
+
+                // Lone column/qualified-column identifier → suggest comparison operators
                 if !after_trigger.is_empty()
                     && after_trigger
                         .chars()
@@ -97,9 +120,8 @@ pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
                 None => CompletionContext::Keyword,
             }
         }
-        Some("SELECT") | Some("SET") | Some("BY") => match extract_from_table(sql) {
-            Some(t) => CompletionContext::ColumnName { table: Some(t) },
-            None => CompletionContext::Keyword,
+        Some("SELECT") | Some("SET") | Some("BY") => CompletionContext::ColumnName {
+            table: extract_from_table(sql),
         },
         _ => CompletionContext::Keyword,
     }
@@ -226,7 +248,10 @@ fn resolve_alias(sql: &str, alias: Option<&str>) -> Option<String> {
                 if i >= 2 {
                     return Some(tokens_sql[i - 2].to_string());
                 }
-            } else if !is_join_keyword(prev) {
+            } else if is_join_keyword(prev) {
+                // "JOIN tablename" — no alias, the token itself IS the table name
+                return Some(tokens_sql[i].to_string());
+            } else {
                 // "tablename alias" pattern
                 return Some(tokens_sql[i - 1].to_string());
             }
@@ -237,12 +262,89 @@ fn resolve_alias(sql: &str, alias: Option<&str>) -> Option<String> {
     extract_from_table(sql)
 }
 
-/// True if `kw` is a SQL keyword that directly precedes a table name.
+/// True if `kw` is a SQL keyword that can directly precede a table name or alias reference.
 fn is_join_keyword(kw: &str) -> bool {
     matches!(
         kw.to_ascii_uppercase().as_str(),
-        "FROM" | "JOIN" | "LEFT" | "RIGHT" | "INNER" | "OUTER" | "CROSS" | "FULL" | "NATURAL"
+        "FROM"
+            | "JOIN"
+            | "LEFT"
+            | "RIGHT"
+            | "INNER"
+            | "OUTER"
+            | "CROSS"
+            | "FULL"
+            | "NATURAL"
+            | "ON"
     )
+}
+
+/// Returns `true` when `cursor_pos` is inside a SELECT column list.
+///
+/// Specifically: there is a `SELECT` keyword before the cursor with no `FROM`
+/// keyword between that SELECT and the cursor position.
+pub fn in_select_list(sql: &str, cursor_pos: usize) -> bool {
+    let cursor_pos = cursor_pos.min(sql.len());
+    let upper = sql.to_ascii_uppercase();
+    let before_upper = &upper[..cursor_pos];
+    let Some(select_pos) = last_kw_pos(before_upper, "SELECT") else {
+        return false;
+    };
+    first_kw_pos(&before_upper[select_pos + 6..], "FROM").is_none()
+}
+
+/// Return the distinct table names referenced after `FROM` and `JOIN` keywords in `sql`.
+///
+/// Used to build `JoinConditionTable` candidates after `ON`.
+pub fn extract_referenced_tables(sql: &str) -> Vec<String> {
+    let upper = sql.to_ascii_uppercase();
+    let mut tables = Vec::new();
+
+    for kw in ["FROM", "JOIN"] {
+        let mut start = 0;
+        while start < upper.len() {
+            let Some(rel) = upper[start..].find(kw) else {
+                break;
+            };
+            let abs = start + rel;
+            let bytes = upper.as_bytes();
+            let before_ok = abs == 0 || !is_word_char(bytes[abs - 1]);
+            let after_pos = abs + kw.len();
+            let after_ok = after_pos >= upper.len() || !is_word_char(bytes[after_pos]);
+            if before_ok && after_ok {
+                let rest = sql[after_pos..].trim_start();
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() {
+                    let name_upper = name.to_ascii_uppercase();
+                    let is_keyword = matches!(
+                        name_upper.as_str(),
+                        "ON" | "WHERE"
+                            | "HAVING"
+                            | "GROUP"
+                            | "ORDER"
+                            | "LIMIT"
+                            | "SET"
+                            | "INNER"
+                            | "LEFT"
+                            | "RIGHT"
+                            | "OUTER"
+                            | "CROSS"
+                            | "FULL"
+                            | "NATURAL"
+                    );
+                    if !is_keyword && !tables.contains(&name) {
+                        tables.push(name);
+                    }
+                }
+            }
+            start = abs + 1;
+        }
+    }
+
+    tables
 }
 
 /// Split `text` into a list of identifier tokens (runs of alphanumeric + `_`).
@@ -261,6 +363,70 @@ fn ident_tokens(text: &str) -> Vec<&str> {
         rest = &s[end..];
     }
     tokens
+}
+
+/// Returns `true` when `word` is a SQL keyword that should never be treated as
+/// a column-name prefix in compound-prefix detection.
+pub fn is_sql_keyword(word: &str) -> bool {
+    matches!(
+        word.to_ascii_uppercase().as_str(),
+        "SELECT"
+            | "FROM"
+            | "WHERE"
+            | "JOIN"
+            | "INNER"
+            | "LEFT"
+            | "RIGHT"
+            | "FULL"
+            | "OUTER"
+            | "CROSS"
+            | "NATURAL"
+            | "ON"
+            | "AS"
+            | "GROUP"
+            | "ORDER"
+            | "BY"
+            | "HAVING"
+            | "LIMIT"
+            | "OFFSET"
+            | "SET"
+            | "INSERT"
+            | "INTO"
+            | "VALUES"
+            | "UPDATE"
+            | "DELETE"
+            | "CREATE"
+            | "DROP"
+            | "ALTER"
+            | "TABLE"
+            | "INDEX"
+            | "VIEW"
+            | "WITH"
+            | "DISTINCT"
+            | "ALL"
+            | "UNION"
+            | "EXCEPT"
+            | "INTERSECT"
+            | "AND"
+            | "OR"
+            | "NOT"
+            | "IN"
+            | "EXISTS"
+            | "LIKE"
+            | "ILIKE"
+            | "BETWEEN"
+            | "IS"
+            | "NULL"
+            | "TRUE"
+            | "FALSE"
+            | "CASE"
+            | "WHEN"
+            | "THEN"
+            | "ELSE"
+            | "END"
+            | "ASC"
+            | "DESC"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -284,8 +450,8 @@ mod tests {
     // ── Four required cases from the issue ───────────────────────────────────
 
     #[test]
-    fn parse_context_should_return_keyword_when_select_has_no_from_clause() {
-        assert_eq!(p("SELECT |"), CompletionContext::Keyword);
+    fn parse_context_should_return_column_name_when_select_has_no_from_clause() {
+        assert_eq!(p("SELECT |"), CompletionContext::ColumnName { table: None });
     }
 
     #[test]
@@ -386,11 +552,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_context_should_return_column_name_after_join_on() {
+    fn parse_context_should_return_join_condition_table_after_join_on() {
         assert_eq!(
             p("SELECT * FROM t1 JOIN t2 ON |"),
-            CompletionContext::ColumnName {
-                table: Some("t1".to_string())
+            CompletionContext::JoinConditionTable {
+                tables: vec!["t1".to_string(), "t2".to_string()]
             }
         );
     }
@@ -430,12 +596,47 @@ mod tests {
     }
 
     #[test]
-    fn parse_context_should_return_column_name_after_where_operator() {
-        // After "WHERE id = " the cursor follows an operator, not a column → ColumnName
+    fn parse_context_should_return_value_expected_after_where_column_equals() {
         assert_eq!(
             p("SELECT * FROM users WHERE id = |"),
+            CompletionContext::ValueExpected
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_value_expected_after_where_column_gt() {
+        assert_eq!(
+            p("SELECT * FROM users WHERE created_at > |"),
+            CompletionContext::ValueExpected
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_none_after_semicolon() {
+        assert_eq!(
+            parse_context("SELECT * FROM users;", 20),
+            CompletionContext::None
+        );
+        assert_eq!(parse_context("SELECT 1; ", 9), CompletionContext::None);
+    }
+
+    #[test]
+    fn parse_context_should_return_join_condition_table_after_on_keyword() {
+        let ctx = p("SELECT id FROM users INNER JOIN departments ON |");
+        assert_eq!(
+            ctx,
+            CompletionContext::JoinConditionTable {
+                tables: vec!["users".to_string(), "departments".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_column_name_for_dot_notation_on_join_alias() {
+        assert_eq!(
+            p("SELECT * FROM t1 JOIN t2 ON t1.|"),
             CompletionContext::ColumnName {
-                table: Some("users".to_string())
+                table: Some("t1".to_string())
             }
         );
     }
@@ -476,5 +677,54 @@ mod tests {
             extract_from_table("select * from orders"),
             Some("orders".to_string())
         );
+    }
+
+    // ── in_select_list ────────────────────────────────────────────────────────
+
+    #[test]
+    fn in_select_list_should_return_true_between_select_and_from() {
+        assert!(in_select_list("SELECT id FROM users", 9)); // after "id"
+        assert!(in_select_list("SELECT ", 7)); // right after SELECT
+    }
+
+    #[test]
+    fn in_select_list_should_return_false_after_from() {
+        assert!(!in_select_list("SELECT id FROM users WHERE id = 1", 20)); // in WHERE
+        assert!(!in_select_list("SELECT * FROM ", 14)); // in FROM
+    }
+
+    #[test]
+    fn in_select_list_should_return_false_when_no_select() {
+        assert!(!in_select_list("FROM users", 5));
+    }
+
+    // ── extract_referenced_tables ────────────────────────────────────────────
+
+    #[test]
+    fn extract_referenced_tables_should_return_tables_from_from_and_join() {
+        let tables = extract_referenced_tables(
+            "SELECT id FROM users INNER JOIN departments ON users.id = departments.id",
+        );
+        assert!(
+            tables.contains(&"users".to_string()),
+            "expected users in {tables:?}"
+        );
+        assert!(
+            tables.contains(&"departments".to_string()),
+            "expected departments in {tables:?}"
+        );
+    }
+
+    #[test]
+    fn extract_referenced_tables_should_deduplicate() {
+        let tables =
+            extract_referenced_tables("SELECT * FROM users JOIN users ON users.id = users.id");
+        assert_eq!(tables.iter().filter(|t| t.as_str() == "users").count(), 1);
+    }
+
+    #[test]
+    fn extract_referenced_tables_should_return_empty_when_no_from() {
+        let tables = extract_referenced_tables("SELECT 1");
+        assert!(tables.is_empty());
     }
 }

--- a/crates/wf-completion/src/parser.rs
+++ b/crates/wf-completion/src/parser.rs
@@ -47,7 +47,7 @@ pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
     let before_upper = before.to_ascii_uppercase();
     match last_trigger_keyword(&before_upper) {
         Some("FROM") | Some("JOIN") | Some("INTO") => CompletionContext::TableName,
-        Some("SELECT") | Some("WHERE") | Some("SET") | Some("HAVING") => {
+        Some("SELECT") | Some("WHERE") | Some("SET") | Some("HAVING") | Some("BY") | Some("ON") => {
             match extract_from_table(sql) {
                 Some(t) => CompletionContext::ColumnName { table: Some(t) },
                 None => CompletionContext::Keyword,
@@ -114,7 +114,11 @@ fn first_kw_pos(upper_text: &str, kw: &str) -> Option<usize> {
 
 /// Among all trigger keywords, return the one with the highest (last) position in `upper_text`.
 fn last_trigger_keyword(upper_text: &str) -> Option<&'static str> {
-    const TRIGGERS: &[&str] = &["SELECT", "FROM", "JOIN", "WHERE", "SET", "HAVING", "INTO"];
+    const TRIGGERS: &[&str] = &[
+        "SELECT", "FROM", "JOIN", "WHERE", "SET", "HAVING", "INTO",
+        "BY", // ORDER BY, GROUP BY → column names
+        "ON", // JOIN ... ON → column names
+    ];
     let mut best: Option<(usize, &'static str)> = None;
     for &kw in TRIGGERS {
         if let Some(pos) = last_kw_pos(upper_text, kw)
@@ -309,6 +313,36 @@ mod tests {
             p("SELECT u.| FROM users AS u"),
             CompletionContext::ColumnName {
                 table: Some("users".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_column_name_after_order_by() {
+        assert_eq!(
+            p("SELECT * FROM users ORDER BY |"),
+            CompletionContext::ColumnName {
+                table: Some("users".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_column_name_after_group_by() {
+        assert_eq!(
+            p("SELECT * FROM users GROUP BY |"),
+            CompletionContext::ColumnName {
+                table: Some("users".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_column_name_after_join_on() {
+        assert_eq!(
+            p("SELECT * FROM t1 JOIN t2 ON |"),
+            CompletionContext::ColumnName {
+                table: Some("t1".to_string())
             }
         );
     }

--- a/crates/wf-completion/src/parser.rs
+++ b/crates/wf-completion/src/parser.rs
@@ -15,6 +15,9 @@ pub enum CompletionContext {
     /// `table` carries the first table name found in the `FROM` clause,
     /// resolved through alias lookup when the cursor is in `alias.column` notation.
     ColumnName { table: Option<String> },
+    /// Cursor is at a space after a complete table/view name — suggest next-clause keywords
+    /// (WHERE, JOIN, ORDER BY, LIMIT, etc.) ranked by frequency.
+    NextClause,
     /// Context cannot be determined (e.g. the SQL is empty).
     None,
 }
@@ -46,7 +49,25 @@ pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
 
     let before_upper = before.to_ascii_uppercase();
     match last_trigger_keyword(&before_upper) {
-        Some("FROM") | Some("JOIN") | Some("INTO") => CompletionContext::TableName,
+        Some("FROM") | Some("JOIN") | Some("INTO") => {
+            // If the cursor is at whitespace after a complete table identifier, the user
+            // is done naming the table and wants next-clause keywords (WHERE, JOIN, …).
+            if before.ends_with(|c: char| c.is_ascii_whitespace()) {
+                let trigger_end = ["FROM", "JOIN", "INTO"]
+                    .iter()
+                    .filter_map(|&kw| last_kw_pos(&before_upper, kw).map(|p| p + kw.len()))
+                    .max()
+                    .unwrap_or(0);
+                let after_trigger = before[trigger_end..].trim_start();
+                let first_token_len = after_trigger
+                    .find(|c: char| !c.is_alphanumeric() && c != '_')
+                    .unwrap_or(after_trigger.len());
+                if first_token_len > 0 {
+                    return CompletionContext::NextClause;
+                }
+            }
+            CompletionContext::TableName
+        }
         Some("SELECT") | Some("WHERE") | Some("SET") | Some("HAVING") | Some("BY") | Some("ON") => {
             match extract_from_table(sql) {
                 Some(t) => CompletionContext::ColumnName { table: Some(t) },
@@ -345,6 +366,29 @@ mod tests {
                 table: Some("t1".to_string())
             }
         );
+    }
+
+    #[test]
+    fn parse_context_should_return_next_clause_after_from_table_and_space() {
+        assert_eq!(p("SELECT * FROM users |"), CompletionContext::NextClause);
+    }
+
+    #[test]
+    fn parse_context_should_return_next_clause_after_join_table_and_space() {
+        assert_eq!(
+            p("SELECT * FROM t1 JOIN t2 |"),
+            CompletionContext::NextClause
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_table_name_immediately_after_from() {
+        assert_eq!(p("SELECT * FROM |"), CompletionContext::TableName);
+    }
+
+    #[test]
+    fn parse_context_should_return_table_name_while_typing_after_from() {
+        assert_eq!(p("SELECT * FROM use|"), CompletionContext::TableName);
     }
 
     // ── extract_from_table ────────────────────────────────────────────────────

--- a/crates/wf-completion/src/parser.rs
+++ b/crates/wf-completion/src/parser.rs
@@ -15,9 +15,14 @@ pub enum CompletionContext {
     /// `table` carries the first table name found in the `FROM` clause,
     /// resolved through alias lookup when the cursor is in `alias.column` notation.
     ColumnName { table: Option<String> },
-    /// Cursor is at a space after a complete table/view name — suggest next-clause keywords
-    /// (WHERE, JOIN, ORDER BY, LIMIT, etc.) ranked by frequency.
+    /// Cursor is at a space after a complete table/view name in a FROM clause — suggest
+    /// next-clause keywords (WHERE, JOIN, ORDER BY, LIMIT, etc.) ranked by frequency.
     NextClause,
+    /// Cursor is at a space after a complete table/view name in a JOIN clause — suggest `ON`.
+    JoinOn,
+    /// Cursor is at a space after a column reference in WHERE / HAVING / ON — suggest
+    /// comparison operators (`=`, `!=`, `IS NULL`, `LIKE`, …).
+    Operator,
     /// Context cannot be determined (e.g. the SQL is empty).
     None,
 }
@@ -49,31 +54,53 @@ pub fn parse_context(sql: &str, cursor_pos: usize) -> CompletionContext {
 
     let before_upper = before.to_ascii_uppercase();
     match last_trigger_keyword(&before_upper) {
-        Some("FROM") | Some("JOIN") | Some("INTO") => {
-            // If the cursor is at whitespace after a complete table identifier, the user
-            // is done naming the table and wants next-clause keywords (WHERE, JOIN, …).
+        Some(trig @ ("FROM" | "JOIN" | "INTO")) => {
+            // After a complete table identifier (cursor at space): distinguish FROM→NextClause
+            // from JOIN→JoinOn so the popup stays contextually minimal.
             if before.ends_with(|c: char| c.is_ascii_whitespace()) {
-                let trigger_end = ["FROM", "JOIN", "INTO"]
-                    .iter()
-                    .filter_map(|&kw| last_kw_pos(&before_upper, kw).map(|p| p + kw.len()))
-                    .max()
+                let trigger_end = last_kw_pos(&before_upper, trig)
+                    .map(|p| p + trig.len())
                     .unwrap_or(0);
                 let after_trigger = before[trigger_end..].trim_start();
                 let first_token_len = after_trigger
                     .find(|c: char| !c.is_alphanumeric() && c != '_')
                     .unwrap_or(after_trigger.len());
                 if first_token_len > 0 {
-                    return CompletionContext::NextClause;
+                    return if trig == "JOIN" {
+                        CompletionContext::JoinOn
+                    } else {
+                        CompletionContext::NextClause
+                    };
                 }
             }
             CompletionContext::TableName
         }
-        Some("SELECT") | Some("WHERE") | Some("SET") | Some("HAVING") | Some("BY") | Some("ON") => {
+        Some(trig @ ("WHERE" | "HAVING" | "ON")) => {
+            // Operator context: cursor at space right after a single column/qualified-column
+            // reference (e.g. "WHERE id ", "ON t.id ").  Detected when the text after the
+            // trigger is a lone identifier with no spaces or operator symbols inside it.
+            if before.ends_with(|c: char| c.is_ascii_whitespace()) {
+                let trigger_end = last_kw_pos(&before_upper, trig)
+                    .map(|p| p + trig.len())
+                    .unwrap_or(0);
+                let after_trigger = before[trigger_end..].trim();
+                if !after_trigger.is_empty()
+                    && after_trigger
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+                {
+                    return CompletionContext::Operator;
+                }
+            }
             match extract_from_table(sql) {
                 Some(t) => CompletionContext::ColumnName { table: Some(t) },
                 None => CompletionContext::Keyword,
             }
         }
+        Some("SELECT") | Some("SET") | Some("BY") => match extract_from_table(sql) {
+            Some(t) => CompletionContext::ColumnName { table: Some(t) },
+            None => CompletionContext::Keyword,
+        },
         _ => CompletionContext::Keyword,
     }
 }
@@ -374,10 +401,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_context_should_return_next_clause_after_join_table_and_space() {
+    fn parse_context_should_return_join_on_after_join_table_and_space() {
+        assert_eq!(p("SELECT * FROM t1 JOIN t2 |"), CompletionContext::JoinOn);
+    }
+
+    #[test]
+    fn parse_context_should_return_join_on_after_inner_join_table_and_space() {
         assert_eq!(
-            p("SELECT * FROM t1 JOIN t2 |"),
-            CompletionContext::NextClause
+            p("SELECT id FROM users INNER JOIN departments |"),
+            CompletionContext::JoinOn
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_operator_after_where_column_and_space() {
+        assert_eq!(
+            p("SELECT * FROM users WHERE id |"),
+            CompletionContext::Operator
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_operator_after_on_column_and_space() {
+        assert_eq!(
+            p("SELECT * FROM t1 JOIN t2 ON t1.id |"),
+            CompletionContext::Operator
+        );
+    }
+
+    #[test]
+    fn parse_context_should_return_column_name_after_where_operator() {
+        // After "WHERE id = " the cursor follows an operator, not a column → ColumnName
+        assert_eq!(
+            p("SELECT * FROM users WHERE id = |"),
+            CompletionContext::ColumnName {
+                table: Some("users".to_string())
+            }
         );
     }
 

--- a/crates/wf-completion/src/service.rs
+++ b/crates/wf-completion/src/service.rs
@@ -7,7 +7,10 @@
 use wf_db::models::DbMetadata;
 
 use crate::{
-    CompletionItem, cache::MetadataCache, engine::CompletionEngine, parser::parse_context,
+    CompletionItem,
+    cache::MetadataCache,
+    engine::CompletionEngine,
+    parser::{CompletionContext, is_sql_keyword, parse_context},
 };
 
 // ---------------------------------------------------------------------------
@@ -42,6 +45,70 @@ impl CompletionService {
         let metadata: DbMetadata = self.cache.load(conn_id).await.unwrap_or_default();
         let prefix = extract_prefix(sql, cursor_pos);
         let context = parse_context(sql, cursor_pos);
+
+        // When the cursor sits at the end of a name that exactly matches a known
+        // table or view, the user has finished typing the table name and is
+        // waiting to see what comes next.  Simulate a trailing space so that
+        // parse_context returns the correct "next-context" (NextClause or JoinOn)
+        // and the popup appears without requiring the user to press Space first.
+        if matches!(&context, CompletionContext::TableName) && !prefix.is_empty() {
+            let exact_match = metadata
+                .tables
+                .iter()
+                .chain(metadata.views.iter())
+                .any(|t| t.name.eq_ignore_ascii_case(&prefix));
+            if exact_match {
+                let virtual_sql = format!("{} ", &sql[..cursor_pos.min(sql.len())]);
+                let next_ctx = parse_context(&virtual_sql, virtual_sql.len());
+                if matches!(
+                    next_ctx,
+                    CompletionContext::NextClause | CompletionContext::JoinOn
+                ) {
+                    return CompletionEngine::complete(next_ctx, &metadata, "");
+                }
+            }
+        }
+
+        // Same idea for ColumnName: if the prefix exactly matches a known column name,
+        // return Operator candidates (`=`, `!=`, `IS NULL`, …) so the next popup
+        // appears without requiring a Space keypress.
+        if let CompletionContext::ColumnName { table: ref tbl } = context
+            && !prefix.is_empty()
+        {
+            let table_filter = tbl.as_deref();
+            let exact_col = metadata
+                .tables
+                .iter()
+                .chain(metadata.views.iter())
+                .filter(|t| table_filter.is_none_or(|tn| t.name.eq_ignore_ascii_case(tn)))
+                .any(|t| {
+                    t.columns
+                        .iter()
+                        .any(|c| c.name.eq_ignore_ascii_case(&prefix))
+                });
+            if exact_col {
+                let virtual_sql = format!("{} ", &sql[..cursor_pos.min(sql.len())]);
+                let next_ctx = parse_context(&virtual_sql, virtual_sql.len());
+                if matches!(next_ctx, CompletionContext::Operator) {
+                    return CompletionEngine::complete(next_ctx, &metadata, "");
+                }
+            }
+        }
+
+        // For ColumnName { table: None } with a space before the current word, try a
+        // compound prefix that spans two words (e.g. "name u" for "name (users)").
+        // This lets users narrow column disambiguation by typing part of the table name
+        // with a space separator, not just without (e.g. "nameuse").
+        // Two-pass: compound result wins if non-empty; falls back to simple prefix.
+        if matches!(&context, CompletionContext::ColumnName { table: None })
+            && let Some(compound) = extract_compound_prefix(sql, cursor_pos)
+        {
+            let compound_items = CompletionEngine::complete(context.clone(), &metadata, &compound);
+            if !compound_items.is_empty() {
+                return compound_items;
+            }
+        }
+
         CompletionEngine::complete(context, &metadata, &prefix)
     }
 }
@@ -49,6 +116,67 @@ impl CompletionService {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/// Build a compound prefix `"prev_word current_word"` when the cursor is at
+/// `"prev_word<space>current_word|"` and `prev_word` is not a SQL keyword.
+///
+/// Returns `None` when the compound prefix would be the same as the simple
+/// prefix (no previous word, previous word is a keyword, or immediately preceded
+/// by a non-space non-word character like `.`).
+fn extract_compound_prefix(sql: &str, cursor_pos: usize) -> Option<String> {
+    let pos = cursor_pos.min(sql.len());
+    let before = &sql[..pos];
+
+    // Current word (scan back past alphanumeric / underscore).
+    let current_word_len = before
+        .bytes()
+        .rev()
+        .take_while(|b| b.is_ascii_alphanumeric() || *b == b'_')
+        .count();
+    let current_word_start = pos - current_word_len;
+    let current_word = &before[current_word_start..];
+
+    // There must be at least one space immediately before the current word.
+    let before_word = &before[..current_word_start];
+    if !before_word.ends_with(' ') && !before_word.ends_with('\t') {
+        return None;
+    }
+
+    // Scan back past that whitespace to find the previous word.
+    let trimmed = before_word.trim_end_matches([' ', '\t']);
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let prev_word_len = trimmed
+        .bytes()
+        .rev()
+        .take_while(|b| b.is_ascii_alphanumeric() || *b == b'_')
+        .count();
+    if prev_word_len == 0 {
+        return None;
+    }
+
+    let prev_word_start = trimmed.len() - prev_word_len;
+
+    // Reject if the character before the previous word is `.` or alphanumeric/`_`
+    // (means the previous word is part of a qualified name like `users.name`).
+    if prev_word_start > 0 {
+        let ch = trimmed.as_bytes()[prev_word_start - 1];
+        if ch == b'.' || ch.is_ascii_alphanumeric() || ch == b'_' {
+            return None;
+        }
+    }
+
+    let prev_word = &trimmed[prev_word_start..];
+
+    // Reject if the previous word is a SQL keyword (e.g. SELECT, FROM, WHERE …).
+    if is_sql_keyword(prev_word) {
+        return None;
+    }
+
+    Some(format!("{} {}", prev_word, current_word))
+}
 
 /// Extract the typed prefix at `cursor_pos`.
 ///
@@ -156,5 +284,59 @@ mod tests {
         assert_eq!(extract_prefix("u.em", 4), "em");
         assert_eq!(extract_prefix("u.", 2), "");
         assert_eq!(extract_prefix("alias.col_name", 14), "col_name");
+    }
+
+    #[tokio::test]
+    async fn complete_should_return_next_clause_when_exact_table_name_at_cursor_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        cache.store("conn-1", make_meta()).await.unwrap();
+        let svc = CompletionService::new(cache);
+        // Cursor at end of "users" — exact table match → NextClause candidates
+        let sql = "SELECT * FROM users";
+        let items = svc.complete("conn-1", sql, sql.len()).await;
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels
+                .iter()
+                .any(|l| l.contains("WHERE") || l.contains("ORDER")),
+            "expected NextClause candidates (WHERE / ORDER BY) in {labels:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_should_return_operator_when_exact_column_name_at_cursor_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        cache.store("conn-1", make_meta()).await.unwrap();
+        let svc = CompletionService::new(cache);
+        // Cursor at end of "id" — exact column match → Operator candidates
+        let sql = "SELECT * FROM users WHERE id";
+        let items = svc.complete("conn-1", sql, sql.len()).await;
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.iter().any(|l| *l == "=" || l.contains("IS NULL")),
+            "expected Operator candidates (=, IS NULL, …) in {labels:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_should_not_promote_partial_table_name_to_next_clause() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = MetadataCache::new(dir.path().join("m.db"));
+        cache.store("conn-1", make_meta()).await.unwrap();
+        let svc = CompletionService::new(cache);
+        // "use" is a prefix of "users" but not an exact match — must stay TableName
+        let sql = "SELECT * FROM use";
+        let items = svc.complete("conn-1", sql, sql.len()).await;
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.contains(&"users"),
+            "expected TableName candidates (users) in {labels:?}"
+        );
+        assert!(
+            !labels.iter().any(|l| l.contains("WHERE")),
+            "must not contain NextClause candidates: {labels:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements the visible completion popup for SQL auto-complete (issue #43). The pipeline from #42 (text-edit → debounce → CompletionService → Event::CompletionReady) is now fully wired to a rendered overlay. The popup appears near the cursor when candidates are available, supports ↑/↓/Tab navigation, Enter to accept, and Esc to dismiss. Keyword completions are suppressed for empty prefixes to avoid flooding the popup after a completed keyword.

## Changes

- **`completion_popup.slint`** (new): scrollable 8-row overlay with label and kind badge; auto-scrolls to keep selected row visible
- **`editor.slint`**: completion-visible/items/selected/cursor-target props; popup-x/popup-y out props; Tab wraps through candidates; Enter/Esc handled in capture-key-pressed guard block
- **`app.slint`**: CompletionPopup overlay at FocusScope level (avoids clip:true clipping); all state wired to UiState via two-way bindings
- **`mod.rs`**: handles `Event::CompletionReady`; `register_completion_accept_callback` replaces the typed prefix with inserted text via `find_prefix_start`; 4 unit tests for `find_prefix_start`
- **`engine.rs`**: returns empty vec for `Keyword` context when prefix is empty; filters out exact-match keywords (typing "SELECT" no longer shows SELECT itself)

## Related Issues

Closes #43

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes