### PR TITLE
feat(query): SQL formatter with Ctrl+Shift+F keybinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,6 +5190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0705994df478b895f05b8e290e0d46e53187b26f8d889d37b2a0881234922d94"
+dependencies = [
+ "unicode_categories",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,6 +6011,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6509,6 +6525,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
+ "sqlformat",
  "thiserror 2.0.18",
 ]
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -116,6 +116,8 @@ export global UiState {
     callback fetch-completion(string, int);
     /// Fired by Ctrl+Space; Rust sends Command::FetchCompletion immediately.
     callback trigger-completion(string, int);
+    /// Fired by Ctrl+Shift+F; Rust reformats editor-text in place.
+    callback format-sql();
 
     // ── Completion popup state ─────────────────────────────────────────────
     in property    <[CompletionRow]> completion-items:    [];
@@ -335,6 +337,7 @@ export component AppWindow inherits Window {
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }
+                format-sql => { UiState.format-sql(); }
                 completion-visible   <=> UiState.completion-visible;
                 completion-items:        UiState.completion-items;
                 completion-selected  <=> UiState.completion-selected;

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -80,6 +80,9 @@ export component Editor inherits Rectangle {
     /// Carries the current SQL text and cursor byte offset.
     callback trigger-completion(string, int);
 
+    /// Fired when the user presses Ctrl+Shift+F to reformat the SQL.
+    callback format-sql();
+
     // ── Out properties consumed by the external gutter in app.slint ──────────
     out property <length> gutter-scroll-y:  editor-scroll.viewport-y;
     out property <length> gutter-line-h:    root.line-h;
@@ -339,6 +342,12 @@ export component Editor inherits Rectangle {
                     EventResult.accept
                 } else if (event.text == " " && event.modifiers.control) {
                     root.trigger-completion(inner-input.text, inner-input.cursor-position-byte-offset);
+                    EventResult.accept
+                } else if (event.text == "F"
+                        && event.modifiers.control
+                        && event.modifiers.shift
+                        && !event.modifiers.alt) {
+                    root.format-sql();
                     EventResult.accept
                 } else {
                     EventResult.reject

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -222,6 +222,7 @@ impl UI {
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
         Self::register_completion_callbacks(&window, tx_cmd.clone());
         Self::register_completion_accept_callback(&window);
+        Self::register_formatter_callback(&window);
         // Set initial page size on the Slint window from shared state.
         window
             .global::<crate::UiState>()
@@ -1080,6 +1081,20 @@ impl UI {
                 }
             },
         );
+    }
+
+    fn register_formatter_callback(window: &crate::AppWindow) {
+        let ui = window.global::<crate::UiState>();
+        let window_weak = window.as_weak(); // clone required: on_format_sql closure
+        ui.on_format_sql(move || {
+            let Some(window) = window_weak.upgrade() else {
+                return;
+            };
+            let ui = window.global::<crate::UiState>();
+            let text = ui.get_editor_text().to_string();
+            let formatted = wf_query::formatter::format_sql(&text);
+            ui.set_editor_text(formatted.into());
+        });
     }
 
     // ── Result callbacks ──────────────────────────────────────────────────────

--- a/crates/wf-query/Cargo.toml
+++ b/crates/wf-query/Cargo.toml
@@ -14,3 +14,4 @@ authors.workspace = true
 serde     = { workspace = true }
 anyhow    = { workspace = true }
 thiserror = { workspace = true }
+sqlformat = "0.5.0"

--- a/crates/wf-query/src/formatter.rs
+++ b/crates/wf-query/src/formatter.rs
@@ -1,1 +1,45 @@
-// SQL formatter (Ctrl+Shift+F) — implemented in T044/T065
+use sqlformat::{FormatOptions, QueryParams, format};
+
+pub fn format_sql(sql: &str) -> String {
+    let opts = FormatOptions {
+        uppercase: Some(true),
+        ..FormatOptions::default()
+    };
+    format(sql, &QueryParams::None, &opts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_sql_should_uppercase_keywords_and_indent() {
+        let input = "select * from users where id = 1";
+        let output = format_sql(input);
+        assert!(
+            output.contains("SELECT"),
+            "expected SELECT uppercase in:\n{output}"
+        );
+        assert!(
+            output.contains("FROM"),
+            "expected FROM uppercase in:\n{output}"
+        );
+        assert!(
+            output.contains("WHERE"),
+            "expected WHERE uppercase in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn format_sql_should_return_empty_for_empty_input() {
+        assert_eq!(format_sql(""), "");
+    }
+
+    #[test]
+    fn format_sql_should_handle_already_uppercase() {
+        let input = "SELECT id FROM users";
+        let output = format_sql(input);
+        assert!(output.contains("SELECT"));
+        assert!(output.contains("FROM"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements `format_sql` in the `wf-query` crate using the `sqlformat` crate, and wires it to `Ctrl+Shift+F` in the SQL editor. Pressing the shortcut reformats the entire editor content with uppercase keywords and proper indentation in place, with no async round-trip needed since formatting completes well under 100 ms.

## Changes

- `crates/wf-query/Cargo.toml`: added `sqlformat = "0.5"` dependency
- `crates/wf-query/src/formatter.rs`: implemented `pub fn format_sql(sql: &str) -> String` with `uppercase: Some(true)` option; 3 unit tests
- `app/src/ui/components/editor.slint`: added `callback format-sql()` declaration and `Ctrl+Shift+F` handler in `capture-key-pressed`
- `app/src/ui/app.slint`: added `callback format-sql()` to `UiState`; wired `editor-inst.format-sql => { UiState.format-sql(); }`
- `app/src/ui/mod.rs`: added `register_formatter_callback` — calls `wf_query::formatter::format_sql` and updates `editor_text` synchronously on the UI thread

## Related Issues

Closes #44

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes