### PR TITLE
feat(query): add CSV export of query results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +421,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +458,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1292,6 +1337,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1475,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -4089,6 +4157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +4606,30 @@ dependencies = [
  "tiny-skia",
  "usvg",
  "zune-jpeg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5687,6 +5785,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6042,7 +6141,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -6444,6 +6550,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "chrono",
+ "rfd",
  "slint",
  "slint-build",
  "tempfile",
@@ -6524,6 +6631,7 @@ name = "wf-query"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "csv",
  "serde",
  "sqlformat",
  "thiserror 2.0.18",
@@ -7399,6 +7507,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -7597,6 +7706,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,6 +17,7 @@ anyhow             = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 arboard             = "3.6.1"
+rfd                 = { version = "0.15", features = ["tokio"] }
 uuid               = { workspace = true }
 
 [dev-dependencies]

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -54,6 +54,8 @@ export global UiState {
     callback copy-result-row(int);
     /// Copy all visible rows as TSV with column headers.
     callback copy-result-tsv();
+    /// Fired by the Export CSV button; Rust opens a save dialog and writes the file.
+    callback export-csv();
     /// Returns cumulative x-offset (logical px as float) of column j.
     pure callback col-x-offset(int) -> float;
 
@@ -520,6 +522,7 @@ export component AppWindow inherits Window {
                     copy-cell(v)         => { UiState.copy-result-cell(v); }
                     copy-row(i)          => { UiState.copy-result-row(i); }
                     copy-all-tsv         => { UiState.copy-result-tsv(); }
+                    export-csv           => { UiState.export-csv(); }
                     col-x-offset(j)      => { UiState.col-x-offset(j); }
                     sort-col:            UiState.result-sort-col;
                     sort-asc:            UiState.result-sort-asc;

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -73,6 +73,8 @@ export component ResultTable inherits Rectangle {
     callback copy-row(int);
     /// Copy all visible rows as TSV with column headers.
     callback copy-all-tsv();
+    /// Fired when the "Export CSV" button is clicked.
+    callback export-csv();
     /// Returns cumulative x-offset (logical px as float) of column j.
     /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
     pure callback col-x-offset(int) -> float;
@@ -446,6 +448,26 @@ export component ResultTable inherits Rectangle {
                         : @tr("{0} rows", root.row-count);
                     color: #585b70;
                     font-size: 11px;
+                }
+
+                // Export CSV button (only when a result is loaded)
+                if root.columns.length > 0: Rectangle {
+                    x: parent.width - 266px;
+                    y: (parent.height - self.height) / 2;
+                    width: 80px;
+                    height: 20px;
+                    border-radius: 3px;
+                    background: csv-ta.has-hover ? #45475a : #313244;
+                    csv-ta := TouchArea {
+                        clicked => { root.export-csv(); }
+                    }
+                    Text {
+                        text: @tr("Export CSV");
+                        color: #9399b2;
+                        font-size: 11px;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
                 }
 
                 // Page-size selector: four toggle buttons aligned to the right

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -223,6 +223,7 @@ impl UI {
         Self::register_completion_callbacks(&window, tx_cmd.clone());
         Self::register_completion_accept_callback(&window);
         Self::register_formatter_callback(&window);
+        Self::register_export_callbacks(&window, Arc::clone(&original_data));
         // Set initial page size on the Slint window from shared state.
         window
             .global::<crate::UiState>()
@@ -1094,6 +1095,52 @@ impl UI {
             let text = ui.get_editor_text().to_string();
             let formatted = wf_query::formatter::format_sql(&text);
             ui.set_editor_text(formatted.into());
+        });
+    }
+
+    const CSV_DEFAULT_FILENAME: &str = "query_result.csv";
+
+    fn register_export_callbacks(window: &crate::AppWindow, original_data: SharedOriginalData) {
+        let ui = window.global::<crate::UiState>();
+        let window_weak = window.as_weak(); // clone required: on_export_csv closure
+        ui.on_export_csv(move || {
+            // Snapshot columns + rows while still on the UI thread (Mutex is not Send).
+            let snapshot = {
+                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                orig.as_ref().map(|d| {
+                    let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
+                    (cols, d.rows.clone())
+                })
+            };
+            let Some((columns, rows)) = snapshot else {
+                return;
+            };
+            let window_weak = window_weak.clone(); // clone required: tokio::spawn needs 'static
+            tokio::spawn(async move {
+                let Some(handle) = rfd::AsyncFileDialog::new()
+                    .set_title("Save CSV")
+                    .set_file_name(Self::CSV_DEFAULT_FILENAME)
+                    .add_filter("CSV files", &["csv"])
+                    .save_file()
+                    .await
+                else {
+                    return; // user cancelled
+                };
+                let path = handle.path().to_path_buf();
+                let result = wf_query::export::export_csv(&columns, &rows, &path);
+                let msg = match result {
+                    Ok(()) => format!("Saved CSV: {}", path.display()),
+                    Err(e) => format!("CSV export failed: {e}"),
+                };
+                let _ = slint::invoke_from_event_loop(move || {
+                    let Some(window) = window_weak.upgrade() else {
+                        return;
+                    };
+                    window
+                        .global::<crate::UiState>()
+                        .set_status_message(msg.into());
+                });
+            });
         });
     }
 

--- a/crates/wf-query/Cargo.toml
+++ b/crates/wf-query/Cargo.toml
@@ -15,3 +15,4 @@ serde     = { workspace = true }
 anyhow    = { workspace = true }
 thiserror = { workspace = true }
 sqlformat = "0.5.0"
+csv       = "1.4.0"

--- a/crates/wf-query/src/export.rs
+++ b/crates/wf-query/src/export.rs
@@ -1,1 +1,69 @@
-// CSV / JSON export — implemented in T045/T071/T072
+use std::path::Path;
+
+const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
+
+/// Serialise `columns` + `rows` to UTF-8 BOM CSV bytes.
+/// NULL cells become empty strings.  Used by [`export_csv`] and in unit tests.
+pub fn result_to_csv_bytes(columns: &[String], rows: &[Vec<Option<String>>]) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(UTF8_BOM);
+    {
+        let mut wtr = csv::Writer::from_writer(&mut buf);
+        // SAFETY: writing to Vec<u8> is infallible; the only error path in csv::Writer is I/O failure, which cannot occur for an in-memory buffer.
+        wtr.write_record(columns).unwrap();
+        for row in rows {
+            let cells: Vec<&str> = row.iter().map(|c| c.as_deref().unwrap_or("")).collect();
+            // SAFETY: same as above — writing to Vec<u8> is infallible.
+            wtr.write_record(&cells).unwrap();
+        }
+        // SAFETY: flushing a Vec<u8>-backed writer is infallible.
+        wtr.flush().unwrap();
+    }
+    buf
+}
+
+/// Write a UTF-8 BOM CSV file at `path`.  NULL cells become empty strings.
+pub fn export_csv(
+    columns: &[String],
+    rows: &[Vec<Option<String>>],
+    path: &Path,
+) -> anyhow::Result<()> {
+    let bytes = result_to_csv_bytes(columns, rows);
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_to_csv_bytes_should_include_bom_and_header() {
+        let cols = vec!["id".to_string(), "name".to_string()];
+        let rows: Vec<Vec<Option<String>>> = vec![];
+        let bytes = result_to_csv_bytes(&cols, &rows);
+        assert!(bytes.starts_with(b"\xef\xbb\xbf"), "BOM missing");
+        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        assert!(text.contains("id"), "header missing");
+        assert!(text.contains("name"), "header missing");
+    }
+
+    #[test]
+    fn result_to_csv_bytes_should_export_null_as_empty_string() {
+        let cols = vec!["a".to_string(), "b".to_string()];
+        let rows = vec![vec![Some("hello".to_string()), None]];
+        let bytes = result_to_csv_bytes(&cols, &rows);
+        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        assert!(text.contains("hello"), "value missing");
+        assert!(text.contains("hello,"), "NULL not serialised as empty");
+    }
+
+    #[test]
+    fn result_to_csv_bytes_should_escape_commas_in_values() {
+        let cols = vec!["v".to_string()];
+        let rows = vec![vec![Some("a,b".to_string())]];
+        let bytes = result_to_csv_bytes(&cols, &rows);
+        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        assert!(text.contains("\"a,b\""), "comma not escaped: {text}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a CSV export feature to the result table toolbar. When a query result is loaded, an "Export CSV" button appears; clicking it opens a native save-file dialog defaulting to `query_result.csv`, and writes a UTF-8 BOM CSV file so Excel opens it correctly. Success or failure is reported in the status bar.

## Changes

- `crates/wf-query`: new `export` module with `result_to_csv_bytes` (pure, testable) and `export_csv`; added `csv = "1.4.0"` dependency
- `app/src/ui/components/result_table.slint`: added `callback export-csv()` and Export CSV button in toolbar (visible only when a result is loaded)
- `app/src/ui/app.slint`: wired `export-csv` callback through `UiState`
- `app/src/ui/mod.rs`: added `register_export_callbacks` — snapshots column/row data on the UI thread, spawns a tokio task for the `rfd` dialog and file write, then posts the status message back via `invoke_from_event_loop`; default filename extracted as `CSV_DEFAULT_FILENAME` constant
- Added SAFETY comments on the three `unwrap()` calls in `result_to_csv_bytes` (writing to `Vec<u8>` is infallible)

## Related Issues

Closes #45

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes