### PR TITLE
feat(query): add JSON export of query results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -6633,6 +6634,7 @@ dependencies = [
  "anyhow",
  "csv",
  "serde",
+ "serde_json",
  "sqlformat",
  "thiserror 2.0.18",
 ]

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -56,6 +56,8 @@ export global UiState {
     callback copy-result-tsv();
     /// Fired by the Export CSV button; Rust opens a save dialog and writes the file.
     callback export-csv();
+    /// Fired by the Export JSON button; Rust opens a save dialog and writes the file.
+    callback export-json();
     /// Returns cumulative x-offset (logical px as float) of column j.
     pure callback col-x-offset(int) -> float;
 
@@ -523,6 +525,7 @@ export component AppWindow inherits Window {
                     copy-row(i)          => { UiState.copy-result-row(i); }
                     copy-all-tsv         => { UiState.copy-result-tsv(); }
                     export-csv           => { UiState.export-csv(); }
+                    export-json          => { UiState.export-json(); }
                     col-x-offset(j)      => { UiState.col-x-offset(j); }
                     sort-col:            UiState.result-sort-col;
                     sort-asc:            UiState.result-sort-asc;

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -75,6 +75,8 @@ export component ResultTable inherits Rectangle {
     callback copy-all-tsv();
     /// Fired when the "Export CSV" button is clicked.
     callback export-csv();
+    /// Fired when the "Export JSON" button is clicked.
+    callback export-json();
     /// Returns cumulative x-offset (logical px as float) of column j.
     /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
     pure callback col-x-offset(int) -> float;
@@ -313,6 +315,63 @@ export component ResultTable inherits Rectangle {
             }
         }
 
+        // ── Export dropdown menu ──────────────────────────────────────────────
+        // Positioned just below the Export button in the toolbar.
+        // x/y are relative to table-fs, which covers the full component.
+        export-popup := PopupWindow {
+            x: root.width - 266px;
+            y: root.toolbar-h + 2px;
+            width: 120px;
+            height: 60px;
+            close-policy: PopupClosePolicy.close-on-click;
+
+            Rectangle {
+                width: 120px;
+                height: 60px;
+                background: #313244;
+                border-radius: 4px;
+                border-width: 1px;
+                border-color: #585b70;
+                drop-shadow-blur: 8px;
+                drop-shadow-color: #00000088;
+                clip: true;
+
+                VerticalLayout {
+                    spacing: 0;
+
+                    Rectangle {
+                        height: 30px;
+                        background: exp-csv-mi.has-hover ? #45475a : transparent;
+                        exp-csv-mi := TouchArea {
+                            clicked => { root.export-csv(); }
+                        }
+                        Text {
+                            x: 12px;
+                            y: (parent.height - self.height) / 2;
+                            text: @tr("Export CSV");
+                            color: #cdd6f4;
+                            font-size: 12px;
+                        }
+                    }
+
+                    Rectangle {
+                        height: 30px;
+                        background: exp-json-mi.has-hover ? #45475a : transparent;
+                        exp-json-mi := TouchArea {
+                            clicked => { root.export-json(); }
+                        }
+                        Text {
+                            x: 12px;
+                            y: (parent.height - self.height) / 2;
+                            text: @tr("Export JSON");
+                            color: #cdd6f4;
+                            font-size: 12px;
+                        }
+                    }
+                }
+            }
+        }
+
         // ── Right-click context menu ──────────────────────────────────────────
         ctx-popup := PopupWindow {
             x: root.ctx-menu-x;
@@ -450,19 +509,19 @@ export component ResultTable inherits Rectangle {
                     font-size: 11px;
                 }
 
-                // Export CSV button (only when a result is loaded)
+                // Export button — opens a dropdown with CSV / JSON options
                 if root.columns.length > 0: Rectangle {
                     x: parent.width - 266px;
                     y: (parent.height - self.height) / 2;
                     width: 80px;
                     height: 20px;
                     border-radius: 3px;
-                    background: csv-ta.has-hover ? #45475a : #313244;
-                    csv-ta := TouchArea {
-                        clicked => { root.export-csv(); }
+                    background: export-btn-ta.has-hover ? #45475a : #313244;
+                    export-btn-ta := TouchArea {
+                        clicked => { export-popup.show(); }
                     }
                     Text {
-                        text: @tr("Export CSV");
+                        text: @tr("Export") + " \u{25BE}";
                         color: #9399b2;
                         font-size: 11px;
                         horizontal-alignment: center;

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1099,49 +1099,99 @@ impl UI {
     }
 
     const CSV_DEFAULT_FILENAME: &str = "query_result.csv";
+    const JSON_DEFAULT_FILENAME: &str = "query_result.json";
 
     fn register_export_callbacks(window: &crate::AppWindow, original_data: SharedOriginalData) {
         let ui = window.global::<crate::UiState>();
+
+        // ── CSV export ────────────────────────────────────────────────────────
         let window_weak = window.as_weak(); // clone required: on_export_csv closure
-        ui.on_export_csv(move || {
-            // Snapshot columns + rows while still on the UI thread (Mutex is not Send).
-            let snapshot = {
-                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
-                orig.as_ref().map(|d| {
-                    let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
-                    (cols, d.rows.clone())
-                })
-            };
-            let Some((columns, rows)) = snapshot else {
-                return;
-            };
-            let window_weak = window_weak.clone(); // clone required: tokio::spawn needs 'static
-            tokio::spawn(async move {
-                let Some(handle) = rfd::AsyncFileDialog::new()
-                    .set_title("Save CSV")
-                    .set_file_name(Self::CSV_DEFAULT_FILENAME)
-                    .add_filter("CSV files", &["csv"])
-                    .save_file()
-                    .await
-                else {
-                    return; // user cancelled
+        {
+            let original_data = Arc::clone(&original_data); // clone required: on_export_csv closure
+            ui.on_export_csv(move || {
+                // Snapshot columns + rows while still on the UI thread (Mutex is not Send).
+                let snapshot = {
+                    let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                    orig.as_ref().map(|d| {
+                        let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
+                        (cols, d.rows.clone())
+                    })
                 };
-                let path = handle.path().to_path_buf();
-                let result = wf_query::export::export_csv(&columns, &rows, &path);
-                let msg = match result {
-                    Ok(()) => format!("Saved CSV: {}", path.display()),
-                    Err(e) => format!("CSV export failed: {e}"),
+                let Some((columns, rows)) = snapshot else {
+                    return;
                 };
-                let _ = slint::invoke_from_event_loop(move || {
-                    let Some(window) = window_weak.upgrade() else {
-                        return;
+                let window_weak = window_weak.clone(); // clone required: tokio::spawn needs 'static
+                tokio::spawn(async move {
+                    let Some(handle) = rfd::AsyncFileDialog::new()
+                        .set_title("Save CSV")
+                        .set_file_name(Self::CSV_DEFAULT_FILENAME)
+                        .add_filter("CSV files", &["csv"])
+                        .save_file()
+                        .await
+                    else {
+                        return; // user cancelled
                     };
-                    window
-                        .global::<crate::UiState>()
-                        .set_status_message(msg.into());
+                    let path = handle.path().to_path_buf();
+                    let result = wf_query::export::export_csv(&columns, &rows, &path);
+                    let msg = match result {
+                        Ok(()) => format!("Saved CSV: {}", path.display()),
+                        Err(e) => format!("CSV export failed: {e}"),
+                    };
+                    let _ = slint::invoke_from_event_loop(move || {
+                        let Some(window) = window_weak.upgrade() else {
+                            return;
+                        };
+                        window
+                            .global::<crate::UiState>()
+                            .set_status_message(msg.into());
+                    });
                 });
             });
-        });
+        }
+
+        // ── JSON export ───────────────────────────────────────────────────────
+        {
+            let window_weak = window.as_weak(); // clone required: on_export_json closure
+            let original_data = Arc::clone(&original_data); // clone required: on_export_json closure
+            ui.on_export_json(move || {
+                let snapshot = {
+                    let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                    orig.as_ref().map(|d| {
+                        let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
+                        (cols, d.rows.clone())
+                    })
+                };
+                let Some((columns, rows)) = snapshot else {
+                    return;
+                };
+                let window_weak = window_weak.clone(); // clone required: tokio::spawn needs 'static
+                tokio::spawn(async move {
+                    let Some(handle) = rfd::AsyncFileDialog::new()
+                        .set_title("Save JSON")
+                        .set_file_name(Self::JSON_DEFAULT_FILENAME)
+                        .add_filter("JSON files", &["json"])
+                        .save_file()
+                        .await
+                    else {
+                        return; // user cancelled
+                    };
+                    let path = handle.path().to_path_buf();
+                    let result = wf_query::export::export_json(&columns, &rows, &path);
+                    let msg = match result {
+                        Ok(()) => format!("Saved JSON: {}", path.display()),
+                        Err(e) => format!("JSON export failed: {e}"),
+                    };
+                    let _ = slint::invoke_from_event_loop(move || {
+                        let Some(window) = window_weak.upgrade() else {
+                            return;
+                        };
+                        window
+                            .global::<crate::UiState>()
+                            .set_status_message(msg.into());
+                    });
+                });
+            });
+        }
     }
 
     // ── Result callbacks ──────────────────────────────────────────────────────

--- a/crates/wf-query/Cargo.toml
+++ b/crates/wf-query/Cargo.toml
@@ -15,4 +15,5 @@ serde     = { workspace = true }
 anyhow    = { workspace = true }
 thiserror = { workspace = true }
 sqlformat = "0.5.0"
-csv       = "1.4.0"
+csv        = "1.4.0"
+serde_json = { version = "1.0.149", features = ["preserve_order"] }

--- a/crates/wf-query/src/export.rs
+++ b/crates/wf-query/src/export.rs
@@ -22,6 +22,60 @@ pub fn result_to_csv_bytes(columns: &[String], rows: &[Vec<Option<String>>]) -> 
     buf
 }
 
+/// Serialise `columns` + `rows` to JSON bytes (pretty-printed array of objects).
+///
+/// Type coercion rules applied to each cell value:
+/// - `None`                → JSON `null`
+/// - Parseable as `i64`   → JSON integer
+/// - Parseable as `f64`   → JSON float (non-finite values fall back to string)
+/// - Otherwise            → JSON string
+///
+/// Column order is preserved (requires the `preserve_order` feature of `serde_json`).
+pub fn result_to_json_bytes(columns: &[String], rows: &[Vec<Option<String>>]) -> Vec<u8> {
+    let array: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|row| {
+            let obj: serde_json::Map<String, serde_json::Value> = columns
+                .iter()
+                .zip(row.iter())
+                .map(|(col, cell)| {
+                    let val = match cell {
+                        None => serde_json::Value::Null,
+                        Some(s) => {
+                            if let Ok(n) = s.parse::<i64>() {
+                                serde_json::Value::Number(n.into())
+                            } else if let Ok(f) = s.parse::<f64>() {
+                                // from_f64 returns None for NaN / ±Infinity
+                                serde_json::Number::from_f64(f)
+                                    .map(serde_json::Value::Number)
+                                    .unwrap_or_else(|| serde_json::Value::String(s.clone()))
+                            } else {
+                                serde_json::Value::String(s.clone())
+                            }
+                        }
+                    };
+                    (col.clone(), val)
+                })
+                .collect();
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+    // SAFETY: serializing to Vec<u8> is infallible; the only error path is OOM,
+    // which the Rust allocator handles as a process abort before returning Err.
+    serde_json::to_vec_pretty(&serde_json::Value::Array(array)).unwrap()
+}
+
+/// Write a JSON file at `path`.  See [`result_to_json_bytes`] for format details.
+pub fn export_json(
+    columns: &[String],
+    rows: &[Vec<Option<String>>],
+    path: &Path,
+) -> anyhow::Result<()> {
+    let bytes = result_to_json_bytes(columns, rows);
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
 /// Write a UTF-8 BOM CSV file at `path`.  NULL cells become empty strings.
 pub fn export_csv(
     columns: &[String],
@@ -36,6 +90,34 @@ pub fn export_csv(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn result_to_json_bytes_should_map_null_to_json_null() {
+        let cols = vec!["a".to_string(), "b".to_string()];
+        let rows = vec![vec![Some("hello".to_string()), None]];
+        let bytes = result_to_json_bytes(&cols, &rows);
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            parsed[0]["a"],
+            serde_json::Value::String("hello".to_string())
+        );
+        assert_eq!(parsed[0]["b"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn result_to_json_bytes_should_coerce_numeric_strings_to_json_numbers() {
+        let cols = vec!["i".to_string(), "f".to_string(), "s".to_string()];
+        let rows = vec![vec![
+            Some("42".to_string()),
+            Some("1.5".to_string()),
+            Some("hello".to_string()),
+        ]];
+        let bytes = result_to_json_bytes(&cols, &rows);
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed[0]["i"], serde_json::json!(42));
+        assert_eq!(parsed[0]["f"], serde_json::json!(1.5));
+        assert_eq!(parsed[0]["s"], serde_json::json!("hello"));
+    }
 
     #[test]
     fn result_to_csv_bytes_should_include_bom_and_header() {


### PR DESCRIPTION
## Summary

Implements JSON export of query results (issue #46 / T072). Adds `result_to_json_bytes` and `export_json` to `wf-query`, wires the save-file dialog in `app`, and consolidates the export toolbar into a single "Export ▾" dropdown that shows both CSV and JSON options.

## Changes

- `crates/wf-query/src/export.rs`: add `result_to_json_bytes` (type-coercing serializer: `None`→`null`, integer strings→JSON integer, float strings→JSON float with NaN/Inf fallback to string) and `export_json`; add 2 unit tests
- `crates/wf-query/Cargo.toml`: add `serde_json` with `preserve_order` feature
- `app/src/ui/components/result_table.slint`: replace two separate Export buttons with a single "Export ▾" button that opens a `PopupWindow` dropdown containing "Export CSV" and "Export JSON" menu items
- `app/src/ui/app.slint`: add `callback export-json()` to `UiState`, wire from `result-table-inst`
- `app/src/ui/mod.rs`: extend `register_export_callbacks` with a JSON export block (same `rfd::AsyncFileDialog` + `tokio::spawn` + `invoke_from_event_loop` pattern as CSV)

## Related Issues

Closes #46

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes