### PR TITLE
refactor(ui): centralise theme tokens and extract Button/MenuItem components

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -1,10 +1,12 @@
 import { ConnectionEntry, RowData, SidebarNode, CompletionRow } from "globals.slint";
+import { Colors, Typography } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
 import { Sidebar }         from "components/sidebar.slint";
 import { Editor }          from "components/editor.slint";
 import { ResultTable }     from "components/result_table.slint";
 import { StatusBar }       from "components/status_bar.slint";
+import { ActionButton }    from "components/common.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -307,7 +309,7 @@ export component AppWindow inherits Window {
                 y: 0;
                 width:  root.gutter-col-width;
                 height: parent.height;
-                background: #1e1e2e;
+                background: Colors.base;
                 clip: true;
 
                 for i in editor-inst.gutter-vis-count: Text {
@@ -316,7 +318,7 @@ export component AppWindow inherits Window {
                     height: editor-inst.gutter-line-h;
                     width:  root.gutter-col-width - 8px;
                     text:   "\{line-nr + 1}";
-                    color:  line-nr == editor-inst.current-line ? #cdd6f4 : #585b70;
+                    color:  line-nr == editor-inst.current-line ? Colors.text : Colors.surface2;
                     font-family: UiState.font-family;
                     font-size:   UiState.font-size * 1px;
                     horizontal-alignment: right;
@@ -359,7 +361,7 @@ export component AppWindow inherits Window {
                 y: parent.height - root.panel-height - root.preview-strip-h;
                 width:  parent.width - root.gutter-col-width;
                 height: root.preview-strip-h;
-                background: #181825;
+                background: Colors.mantle;
                 clip: true;
                 visible: UiState.result-panel-open;
 
@@ -367,23 +369,23 @@ export component AppWindow inherits Window {
                 Rectangle {
                     x: 0; y: 0;
                     width: parent.width; height: 1px;
-                    background: #45475a;
+                    background: Colors.surface1;
                 }
 
                 // Placeholder — nothing selected or row-only selection
                 if !result-table-inst.selected-cell-is-null
                         && result-table-inst.selected-cell-value == "": Text {
                     x: 10px; y: 8px;
-                    color: #45475a;
-                    font-size: 12px;
+                    color: Colors.surface1;
+                    font-size: Typography.size-base;
                     text: @tr("Select a cell to preview its value");
                 }
 
                 // NULL indicator
                 if result-table-inst.selected-cell-is-null: Text {
                     x: 10px; y: 8px;
-                    color: #9399b2;
-                    font-size: 12px;
+                    color: Colors.overlay2;
+                    font-size: Typography.size-base;
                     text: @tr("NULL");
                 }
 
@@ -399,8 +401,8 @@ export component AppWindow inherits Window {
                         x: 10px; y: 4px;
                         width: parent.width - 20px;
                         text: result-table-inst.selected-cell-value;
-                        color: #cdd6f4;
-                        font-size: 12px;
+                        color: Colors.text;
+                        font-size: Typography.size-base;
                         wrap: word-wrap;
                     }
                 }
@@ -415,7 +417,7 @@ export component AppWindow inherits Window {
                 y: parent.height - root.panel-height;
                 width:  parent.width - root.gutter-col-width;
                 height: root.panel-height;
-                background: #1e1e2e;
+                background: Colors.base;
                 clip: true;
                 visible: UiState.result-panel-open;
 
@@ -426,11 +428,11 @@ export component AppWindow inherits Window {
                     y: 0;
                     width:  parent.width;
                     height: root.divider-thickness;
-                    background: #313244;
+                    background: Colors.surface0;
 
                     states [
                         active when panel-drag-ta.has-hover || panel-drag-ta.pressed: {
-                            background: #585b70;
+                            background: Colors.surface2;
                         }
                     ]
 
@@ -464,15 +466,15 @@ export component AppWindow inherits Window {
                     y: root.divider-thickness;
                     width:  parent.width;
                     height: root.panel-header-height;
-                    background: #313244;
+                    background: Colors.surface0;
 
                     // Tab label
                     Text {
                         x: 12px;
                         y: (parent.height - self.height) / 2;
                         text: UiState.error-message != "" ? @tr("Error") : @tr("Results");
-                        color: UiState.error-message != "" ? #f38ba8 : #cdd6f4;
-                        font-size: 12px;
+                        color: UiState.error-message != "" ? Colors.red : Colors.text;
+                        font-size: Typography.size-base;
                         font-weight: 600;
                     }
 
@@ -486,14 +488,14 @@ export component AppWindow inherits Window {
 
                         states [
                             hovered when close-ta.has-hover: {
-                                background: #45475a;
+                                background: Colors.surface1;
                             }
                         ]
 
                         Text {
                             text: "×";
-                            color: #585b70;
-                            font-size: 16px;
+                            color: Colors.surface2;
+                            font-size: Typography.size-2xl;
                             horizontal-alignment: center;
                             vertical-alignment:   center;
                         }
@@ -574,7 +576,7 @@ export component AppWindow inherits Window {
             width:  sidebar-width;
             height: content-height;
             border-width: 2px;
-            border-color: #89b4fa;
+            border-color: Colors.blue;
             background: transparent;
         }
 
@@ -585,7 +587,7 @@ export component AppWindow inherits Window {
             width:  main-width;
             height: content-height;
             border-width: 2px;
-            border-color: #89b4fa;
+            border-color: Colors.blue;
             background: transparent;
         }
 
@@ -596,7 +598,7 @@ export component AppWindow inherits Window {
             width:  main-width;
             height: panel-height + preview-strip-h;
             border-width: 2px;
-            border-color: #89b4fa;
+            border-color: Colors.blue;
             background: transparent;
         }
 
@@ -607,7 +609,7 @@ export component AppWindow inherits Window {
             y: 0;
             width:  root.width;
             height: root.height;
-            background: #00000088;
+            background: Colors.shadow;
 
             ConnectionForm {
                 x: (parent.width  - self.width)  / 2;
@@ -640,7 +642,7 @@ export component AppWindow inherits Window {
             y: 0;
             width:  root.width;
             height: root.height;
-            background: #00000099;
+            background: Colors.modal-overlay;
 
             VerticalLayout {
                 alignment: center;
@@ -648,12 +650,12 @@ export component AppWindow inherits Window {
                     alignment: center;
                     Rectangle {
                         width: 360px;
-                        background: #313244;
+                        background: Colors.surface0;
                         border-radius: 8px;
                         border-width: 1px;
-                        border-color: #585b70;
+                        border-color: Colors.surface2;
                         drop-shadow-blur: 20px;
-                        drop-shadow-color: #00000088;
+                        drop-shadow-color: Colors.shadow;
 
                         VerticalLayout {
                             padding: 24px;
@@ -664,34 +666,28 @@ export component AppWindow inherits Window {
                                 text: UiState.test-result-ok
                                     ? @tr("Connection Successful")
                                     : @tr("Connection Failed");
-                                color: UiState.test-result-ok ? #a6e3a1 : #f38ba8;
-                                font-size: 15px;
+                                color: UiState.test-result-ok ? Colors.green : Colors.red;
+                                font-size: Typography.size-xl;
                                 font-weight: 700;
                                 horizontal-alignment: center;
                             }
 
                             if !UiState.test-result-ok: Text {
                                 text: UiState.test-result-message;
-                                color: #cdd6f4;
-                                font-size: 12px;
+                                color: Colors.text;
+                                font-size: Typography.size-base;
                                 wrap: word-wrap;
                                 horizontal-alignment: center;
                             }
 
                             HorizontalLayout {
                                 alignment: center;
-                                Rectangle {
+                                ActionButton {
                                     width: 80px;
-                                    height: 32px;
-                                    background: #89b4fa;
-                                    border-radius: 4px;
-                                    Text {
-                                        text: @tr("OK");
-                                        color: #1e1e2e;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                    TouchArea { clicked => { UiState.dismiss-test-popup(); } }
+                                    text: @tr("OK");
+                                    bg: Colors.blue;
+                                    fg: Colors.base;
+                                    clicked => { UiState.dismiss-test-popup(); }
                                 }
                             }
                         }
@@ -707,7 +703,7 @@ export component AppWindow inherits Window {
             y: 0;
             width:  root.width;
             height: root.height;
-            background: #00000099;
+            background: Colors.modal-overlay;
 
             VerticalLayout {
                 alignment: center;
@@ -715,12 +711,12 @@ export component AppWindow inherits Window {
                     alignment: center;
                     Rectangle {
                         width: 360px;
-                        background: #313244;
+                        background: Colors.surface0;
                         border-radius: 8px;
                         border-width: 1px;
-                        border-color: #585b70;
+                        border-color: Colors.surface2;
                         drop-shadow-blur: 20px;
-                        drop-shadow-color: #00000088;
+                        drop-shadow-color: Colors.shadow;
 
                         VerticalLayout {
                             padding: 24px;
@@ -729,48 +725,32 @@ export component AppWindow inherits Window {
 
                             Text {
                                 text: @tr("Warning");
-                                color: #f9e2af;
-                                font-size: 15px;
+                                color: Colors.yellow;
+                                font-size: Typography.size-xl;
                                 font-weight: 700;
                             }
 
                             Text {
                                 text: @tr("Connection test was not successful. Add anyway?");
-                                color: #cdd6f4;
-                                font-size: 13px;
+                                color: Colors.text;
+                                font-size: Typography.size-lg;
                                 wrap: word-wrap;
                             }
 
                             HorizontalLayout {
                                 spacing: 8px;
                                 alignment: end;
-
-                                Rectangle {
+                                ActionButton {
                                     width: 80px;
-                                    height: 32px;
-                                    background: #45475a;
-                                    border-radius: 4px;
-                                    Text {
-                                        text: @tr("No");
-                                        color: #cdd6f4;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                    TouchArea { clicked => { UiState.dismiss-add-confirm(); } }
+                                    text: @tr("No");
+                                    clicked => { UiState.dismiss-add-confirm(); }
                                 }
-
-                                Rectangle {
+                                ActionButton {
                                     width: 80px;
-                                    height: 32px;
-                                    background: #f38ba8;
-                                    border-radius: 4px;
-                                    Text {
-                                        text: @tr("Yes");
-                                        color: #1e1e2e;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                    TouchArea { clicked => { UiState.confirm-add-connection(); } }
+                                    text: @tr("Yes");
+                                    bg: Colors.red;
+                                    fg: Colors.base;
+                                    clicked => { UiState.confirm-add-connection(); }
                                 }
                             }
                         }
@@ -778,6 +758,7 @@ export component AppWindow inherits Window {
                 }
             }
         }
+
         // ── Fetch-all-rows confirmation popup ────────────────────────────────
         // Shown when the user clicks the ALL button in the result toolbar.
         if UiState.show-all-rows-confirm: Rectangle {
@@ -785,7 +766,7 @@ export component AppWindow inherits Window {
             y: 0;
             width:  root.width;
             height: root.height;
-            background: #00000099;
+            background: Colors.modal-overlay;
 
             VerticalLayout {
                 alignment: center;
@@ -793,12 +774,12 @@ export component AppWindow inherits Window {
                     alignment: center;
                     Rectangle {
                         width: 360px;
-                        background: #313244;
+                        background: Colors.surface0;
                         border-radius: 8px;
                         border-width: 1px;
-                        border-color: #585b70;
+                        border-color: Colors.surface2;
                         drop-shadow-blur: 20px;
-                        drop-shadow-color: #00000088;
+                        drop-shadow-color: Colors.shadow;
 
                         VerticalLayout {
                             padding: 24px;
@@ -807,48 +788,32 @@ export component AppWindow inherits Window {
 
                             Text {
                                 text: @tr("Fetch all rows?");
-                                color: #f9e2af;
-                                font-size: 15px;
+                                color: Colors.yellow;
+                                font-size: Typography.size-xl;
                                 font-weight: 700;
                             }
 
                             Text {
                                 text: @tr("No LIMIT will be applied. This may take a long time for large tables.");
-                                color: #cdd6f4;
-                                font-size: 13px;
+                                color: Colors.text;
+                                font-size: Typography.size-lg;
                                 wrap: word-wrap;
                             }
 
                             HorizontalLayout {
                                 spacing: 8px;
                                 alignment: end;
-
-                                Rectangle {
+                                ActionButton {
                                     width: 80px;
-                                    height: 32px;
-                                    background: #45475a;
-                                    border-radius: 4px;
-                                    Text {
-                                        text: @tr("Cancel");
-                                        color: #cdd6f4;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                    TouchArea { clicked => { UiState.dismiss-all-rows-confirm(); } }
+                                    text: @tr("Cancel");
+                                    clicked => { UiState.dismiss-all-rows-confirm(); }
                                 }
-
-                                Rectangle {
+                                ActionButton {
                                     width: 80px;
-                                    height: 32px;
-                                    background: #f38ba8;
-                                    border-radius: 4px;
-                                    Text {
-                                        text: @tr("Fetch");
-                                        color: #1e1e2e;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                    TouchArea { clicked => { UiState.confirm-all-rows(); } }
+                                    text: @tr("Fetch");
+                                    bg: Colors.red;
+                                    fg: Colors.base;
+                                    clicked => { UiState.confirm-all-rows(); }
                                 }
                             }
                         }

--- a/app/src/ui/components/common.slint
+++ b/app/src/ui/components/common.slint
@@ -1,0 +1,86 @@
+// Shared UI primitives used across multiple components.
+// All components here depend only on theme.slint — no circular imports.
+
+import { Colors, Typography } from "../theme.slint";
+
+// ── ToolbarButton ─────────────────────────────────────────────────────────────
+// Small toggle button used in the result-table toolbar (page-size selector,
+// Export button).  Height is fixed at 20px; caller sets width.
+// active: true → blue background + dark text (selected page size)
+// active: false → surface0 background + muted text (default)
+
+export component ToolbarButton inherits Rectangle {
+    in property <string> text;
+    in property <bool>   active: false;
+    callback clicked;
+
+    height: 20px;
+    border-radius: 3px;
+    background: ta.has-hover ? Colors.surface1
+        : root.active ? Colors.blue : Colors.surface0;
+
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+    }
+    Text {
+        text: root.text;
+        color: root.active ? Colors.base : Colors.overlay2;
+        font-size: Typography.size-md;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+// ── ActionButton ──────────────────────────────────────────────────────────────
+// Full-height button for forms and modal dialogs.  Height is fixed at 32px;
+// caller sets width and supplies bg / fg colours to express intent:
+//   primary   → bg: Colors.blue,    fg: Colors.base
+//   secondary → bg: Colors.surface1, fg: Colors.text  (default)
+//   success   → bg: Colors.green,   fg: Colors.base
+//   danger    → bg: Colors.red,     fg: Colors.base
+
+export component ActionButton inherits Rectangle {
+    in property <string> text;
+    in property <bool>   enabled: true;
+    in property <color>  bg: Colors.surface1;
+    in property <color>  fg: Colors.text;
+    callback clicked;
+
+    height: 32px;
+    border-radius: 4px;
+    background: root.bg;
+
+    Text {
+        text: root.text;
+        color: root.fg;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+    TouchArea {
+        enabled: root.enabled;
+        clicked => { root.clicked(); }
+    }
+}
+
+// ── MenuItem ──────────────────────────────────────────────────────────────────
+// One row inside a popup / context menu.  Height is fixed at 30px; the
+// containing PopupWindow / Rectangle sets the overall popup dimensions.
+
+export component MenuItem inherits Rectangle {
+    in property <string> text;
+    callback clicked;
+
+    height: 30px;
+    background: ta.has-hover ? Colors.surface1 : transparent;
+
+    ta := TouchArea {
+        clicked => { root.clicked(); }
+    }
+    Text {
+        x: 12px;
+        y: (parent.height - self.height) / 2;
+        text: root.text;
+        color: Colors.text;
+        font-size: Typography.size-base;
+    }
+}

--- a/app/src/ui/components/completion_popup.slint
+++ b/app/src/ui/components/completion_popup.slint
@@ -1,4 +1,5 @@
 import { CompletionRow } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
 
 export component CompletionPopup inherits Rectangle {
     in property    <[CompletionRow]> items: [];
@@ -6,12 +7,12 @@ export component CompletionPopup inherits Rectangle {
 
     property <length> item-h: 22px;
 
-    background: #313244;
+    background: Colors.surface0;
     border-radius: 4px;
     border-width: 1px;
-    border-color: #585b70;
+    border-color: Colors.surface2;
     drop-shadow-blur: 10px;
-    drop-shadow-color: #00000088;
+    drop-shadow-color: Colors.shadow;
     width: 320px;
     height: min(items.length, 8) * item-h;
     clip: true;
@@ -26,14 +27,14 @@ export component CompletionPopup inherits Rectangle {
             y: i * root.item-h;
             height: root.item-h;
             width: root.width;
-            background: i == root.selected-index ? #45475a : transparent;
+            background: i == root.selected-index ? Colors.surface1 : transparent;
 
             Text {
                 x: 8px;
                 y: (parent.height - self.preferred-height) / 2;
                 text: item.label;
-                color: #cdd6f4;
-                font-size: 13px;
+                color: Colors.text;
+                font-size: Typography.size-lg;
                 font-family: "JetBrains Mono";
             }
 
@@ -41,8 +42,8 @@ export component CompletionPopup inherits Rectangle {
                 x: 200px;
                 y: (parent.height - self.preferred-height) / 2;
                 text: item.kind;
-                color: #6c7086;
-                font-size: 11px;
+                color: Colors.overlay0;
+                font-size: Typography.size-md;
             }
         }
     }

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -3,6 +3,9 @@
 // Does not import UiState directly to avoid circular imports
 // (app.slint imports this file; UiState is defined in app.slint).
 
+import { Colors, Typography } from "../theme.slint";
+import { ActionButton } from "common.slint";
+
 // ── Helper: labelled text field row ──────────────────────────────────────────
 
 component FieldRow inherits HorizontalLayout {
@@ -14,13 +17,13 @@ component FieldRow inherits HorizontalLayout {
     spacing: 8px;
     Text {
         text: label-text;
-        color: #a6adc8;
+        color: Colors.subtext0;
         width: 80px;
         vertical-alignment: center;
     }
     Rectangle {
         horizontal-stretch: 1;
-        background: #1e1e2e;
+        background: Colors.base;
         border-radius: 4px;
         height: 28px;
         // Placeholder overlaid at the same position as TextInput.
@@ -32,7 +35,7 @@ component FieldRow inherits HorizontalLayout {
             width: parent.width - 12px;
             height: parent.height;
             text: root.placeholder;
-            color: #585b70;
+            color: Colors.surface2;
             vertical-alignment: center;
         }
         // TextInput rendered last → on top → receives all pointer/focus events.
@@ -43,7 +46,7 @@ component FieldRow inherits HorizontalLayout {
             height: parent.height;
             vertical-alignment: center;
             text <=> value;
-            color: #cdd6f4;
+            color: Colors.text;
             input-type: is-password ? InputType.password : InputType.text;
         }
     }
@@ -59,14 +62,14 @@ component TabButton inherits VerticalLayout {
     horizontal-stretch: 1;
     Text {
         text: label-text;
-        color: active ? #89b4fa : #a6adc8;
+        color: active ? Colors.blue : Colors.subtext0;
         horizontal-alignment: center;
         vertical-alignment: center;
         height: 28px;
     }
     Rectangle {
         height: 2px;
-        background: active ? #89b4fa : #45475a;
+        background: active ? Colors.blue : Colors.surface1;
     }
     TouchArea { clicked => { root.clicked(); } }
 }
@@ -78,13 +81,13 @@ component DbTypeButton inherits Rectangle {
     in property <bool>   active;
     callback clicked;
 
-    background: active ? #89b4fa : #45475a;
+    background: active ? Colors.blue : Colors.surface1;
     border-radius: 4px;
     height: 28px;
     horizontal-stretch: 1;
     Text {
         text: label-text;
-        color: active ? #1e1e2e : #cdd6f4;
+        color: active ? Colors.base : Colors.text;
         horizontal-alignment: center;
         vertical-alignment: center;
     }
@@ -116,12 +119,12 @@ export component ConnectionForm inherits Rectangle {
     callback add-connection();
 
     // ── Layout ────────────────────────────────────────────────────────────────
-    background: #313244;
+    background: Colors.surface0;
     border-radius: 8px;
     border-width: 1px;
-    border-color: #585b70;
+    border-color: Colors.surface2;
     drop-shadow-blur: 24px;
-    drop-shadow-color: #00000066;
+    drop-shadow-color: Colors.shadow-light;
     width: 480px;
 
     VerticalLayout {
@@ -131,8 +134,8 @@ export component ConnectionForm inherits Rectangle {
         // Title
         Text {
             text: @tr("Add Connection");
-            color: #cdd6f4;
-            font-size: 16px;
+            color: Colors.text;
+            font-size: Typography.size-2xl;
             font-weight: 700;
         }
 
@@ -179,7 +182,7 @@ export component ConnectionForm inherits Rectangle {
 
         // Connection String tab
         if root.tab-index == 0: Rectangle {
-            background: #1e1e2e;
+            background: Colors.base;
             border-radius: 4px;
             height: 28px;
             if root.conn-string == "": Text {
@@ -188,7 +191,7 @@ export component ConnectionForm inherits Rectangle {
                 width: parent.width - 12px;
                 height: parent.height;
                 text: "postgres://user:pass@host:5432/db";
-                color: #585b70;
+                color: Colors.surface2;
                 vertical-alignment: center;
             }
             TextInput {
@@ -198,7 +201,7 @@ export component ConnectionForm inherits Rectangle {
                 height: parent.height;
                 vertical-alignment: center;
                 text <=> root.conn-string;
-                color: #cdd6f4;
+                color: Colors.text;
             }
         }
 
@@ -235,9 +238,9 @@ export component ConnectionForm inherits Rectangle {
         // Status message (shown only when not empty)
         Text {
             text: root.status;
-            color: root.status == "" ? transparent : #f38ba8;
+            color: root.status == "" ? transparent : Colors.red;
             height: 20px;
-            font-size: 12px;
+            font-size: Typography.size-base;
             overflow: elide;
         }
 
@@ -246,59 +249,31 @@ export component ConnectionForm inherits Rectangle {
             spacing: 8px;
             alignment: end;
 
-            // Cancel
-            Rectangle {
+            ActionButton {
                 width: 80px;
-                height: 32px;
-                background: #45475a;
-                border-radius: 4px;
-                Text {
-                    text: @tr("Cancel");
-                    color: #cdd6f4;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
-                }
-                TouchArea {
-                    clicked => { root.cancel(); }
-                }
+                text: @tr("Cancel");
+                clicked => { root.cancel(); }
             }
 
-            // Test Connection
-            Rectangle {
+            ActionButton {
                 width: 150px;
-                height: 32px;
-                background: root.testing ? #585b70 : #89b4fa;
-                border-radius: 4px;
-                Text {
-                    text: root.testing ? @tr("Testing\u{2026}") : @tr("Test Connection");
-                    color: root.testing ? #a6adc8 : #1e1e2e;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
-                }
-                TouchArea {
-                    enabled: !root.testing;
-                    clicked => { root.test-connection(); }
-                }
+                text: root.testing ? @tr("Testing\u{2026}") : @tr("Test Connection");
+                bg: root.testing ? Colors.surface2 : Colors.blue;
+                fg: root.testing ? Colors.subtext0 : Colors.base;
+                enabled: !root.testing;
+                clicked => { root.test-connection(); }
             }
 
             // Add — green when test passed, muted when not yet tested / failed
-            Rectangle {
+            ActionButton {
                 width: 80px;
-                height: 32px;
-                background: root.testing ? #585b70
-                          : root.test-ok  ? #a6e3a1
-                          :                 #6c7086;
-                border-radius: 4px;
-                Text {
-                    text: @tr("Add");
-                    color: root.testing ? #a6adc8 : #1e1e2e;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
-                }
-                TouchArea {
-                    enabled: !root.testing;
-                    clicked => { root.add-connection(); }
-                }
+                text: @tr("Add");
+                bg: root.testing ? Colors.surface2
+                  : root.test-ok  ? Colors.green
+                  :                 Colors.overlay0;
+                fg: root.testing ? Colors.subtext0 : Colors.base;
+                enabled: !root.testing;
+                clicked => { root.add-connection(); }
             }
         }
     }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -1,4 +1,5 @@
 import { CompletionRow } from "../globals.slint";
+import { Colors } from "../theme.slint";
 
 // SQL editor component — multi-line TextInput with synchronised line numbers.
 //
@@ -37,7 +38,7 @@ import { CompletionRow } from "../globals.slint";
 // This component does NOT import app.slint to avoid circular dependencies.
 
 export component Editor inherits Rectangle {
-    background: #181825;
+    background: Colors.mantle;
     clip: true;
     // preferred-height: 0 and min-height: 0 prevent content from propagating
     // up through the layout chain and resizing the window.
@@ -202,7 +203,7 @@ export component Editor inherits Rectangle {
         y: root.current-line * root.line-h + editor-scroll.viewport-y;
         width: root.width;
         height: root.line-h;
-        background: #2a2a3e;
+        background: Colors.current-line;
     }
 
     // ── Scrollable text area ─────────────────────────────────────────────────
@@ -369,9 +370,9 @@ export component Editor inherits Rectangle {
                 height: max(self.preferred-height, editor-scroll.height);
                 single-line: false;
                 wrap:        no-wrap;
-                color:                      #cdd6f4;
-                selection-background-color: #264f78;
-                selection-foreground-color: #cdd6f4;
+                color:                      Colors.text;
+                selection-background-color: Colors.selection;
+                selection-foreground-color: Colors.text;
                 font-family: root.font-family;
                 font-size:   root.font-size-px * 1px;
 

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -1,5 +1,7 @@
 import { ListView } from "std-widgets.slint";
 import { RowData, RowCellData } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
+import { ToolbarButton, MenuItem } from "common.slint";
 
 // Result table — column headers + scrollable data rows.
 //
@@ -27,7 +29,7 @@ import { RowData, RowCellData } from "../globals.slint";
 //   Search:    type to build query; Enter — apply; Esc — cancel
 
 export component ResultTable inherits Rectangle {
-    background: #1e1e2e;
+    background: Colors.base;
     clip: true;
     preferred-height: 0;
     min-height: 0;
@@ -73,9 +75,9 @@ export component ResultTable inherits Rectangle {
     callback copy-row(int);
     /// Copy all visible rows as TSV with column headers.
     callback copy-all-tsv();
-    /// Fired when the "Export CSV" button is clicked.
+    /// Fired when the "Export CSV" menu item is clicked.
     callback export-csv();
-    /// Fired when the "Export JSON" button is clicked.
+    /// Fired when the "Export JSON" menu item is clicked.
     callback export-json();
     /// Returns cumulative x-offset (logical px as float) of column j.
     /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
@@ -328,45 +330,23 @@ export component ResultTable inherits Rectangle {
             Rectangle {
                 width: 120px;
                 height: 60px;
-                background: #313244;
+                background: Colors.surface0;
                 border-radius: 4px;
                 border-width: 1px;
-                border-color: #585b70;
+                border-color: Colors.surface2;
                 drop-shadow-blur: 8px;
-                drop-shadow-color: #00000088;
+                drop-shadow-color: Colors.shadow;
                 clip: true;
 
                 VerticalLayout {
                     spacing: 0;
-
-                    Rectangle {
-                        height: 30px;
-                        background: exp-csv-mi.has-hover ? #45475a : transparent;
-                        exp-csv-mi := TouchArea {
-                            clicked => { root.export-csv(); }
-                        }
-                        Text {
-                            x: 12px;
-                            y: (parent.height - self.height) / 2;
-                            text: @tr("Export CSV");
-                            color: #cdd6f4;
-                            font-size: 12px;
-                        }
+                    MenuItem {
+                        text: @tr("Export CSV");
+                        clicked => { root.export-csv(); }
                     }
-
-                    Rectangle {
-                        height: 30px;
-                        background: exp-json-mi.has-hover ? #45475a : transparent;
-                        exp-json-mi := TouchArea {
-                            clicked => { root.export-json(); }
-                        }
-                        Text {
-                            x: 12px;
-                            y: (parent.height - self.height) / 2;
-                            text: @tr("Export JSON");
-                            color: #cdd6f4;
-                            font-size: 12px;
-                        }
+                    MenuItem {
+                        text: @tr("Export JSON");
+                        clicked => { root.export-json(); }
                     }
                 }
             }
@@ -383,60 +363,27 @@ export component ResultTable inherits Rectangle {
             Rectangle {
                 width: 204px;
                 height: 90px;
-                background: #313244;
+                background: Colors.surface0;
                 border-radius: 4px;
                 border-width: 1px;
-                border-color: #585b70;
+                border-color: Colors.surface2;
                 drop-shadow-blur: 8px;
-                drop-shadow-color: #00000088;
+                drop-shadow-color: Colors.shadow;
                 clip: true;
 
                 VerticalLayout {
                     spacing: 0;
-
-                    Rectangle {
-                        height: 30px;
-                        background: mi1.has-hover ? #45475a : transparent;
-                        mi1 := TouchArea {
-                            clicked => { root.copy-cell(root.ctx-cell-value); }
-                        }
-                        Text {
-                            x: 12px;
-                            y: (parent.height - self.height) / 2;
-                            text: @tr("Copy cell value");
-                            color: #cdd6f4;
-                            font-size: 12px;
-                        }
+                    MenuItem {
+                        text: @tr("Copy cell value");
+                        clicked => { root.copy-cell(root.ctx-cell-value); }
                     }
-
-                    Rectangle {
-                        height: 30px;
-                        background: mi2.has-hover ? #45475a : transparent;
-                        mi2 := TouchArea {
-                            clicked => { root.copy-row(root.ctx-row); }
-                        }
-                        Text {
-                            x: 12px;
-                            y: (parent.height - self.height) / 2;
-                            text: @tr("Copy row (tab-separated)");
-                            color: #cdd6f4;
-                            font-size: 12px;
-                        }
+                    MenuItem {
+                        text: @tr("Copy row (tab-separated)");
+                        clicked => { root.copy-row(root.ctx-row); }
                     }
-
-                    Rectangle {
-                        height: 30px;
-                        background: mi3.has-hover ? #45475a : transparent;
-                        mi3 := TouchArea {
-                            clicked => { root.copy-all-tsv(); }
-                        }
-                        Text {
-                            x: 12px;
-                            y: (parent.height - self.height) / 2;
-                            text: @tr("Copy as TSV (with headers)");
-                            color: #cdd6f4;
-                            font-size: 12px;
-                        }
+                    MenuItem {
+                        text: @tr("Copy as TSV (with headers)");
+                        clicked => { root.copy-all-tsv(); }
                     }
                 }
             }
@@ -446,13 +393,13 @@ export component ResultTable inherits Rectangle {
         if root.is-loading: Rectangle {
             width:  parent.width;
             height: parent.height;
-            background: #1e1e2e;
+            background: Colors.base;
             Text {
                 x: (parent.width  - self.width)  / 2;
                 y: (parent.height - self.height) / 2;
                 text: @tr("Running\u{2026}");
-                color: #cdd6f4;
-                font-size: 13px;
+                color: Colors.text;
+                font-size: Typography.size-lg;
             }
         }
 
@@ -460,21 +407,21 @@ export component ResultTable inherits Rectangle {
         if !root.is-loading && root.error-message != "": Rectangle {
             width:  parent.width;
             height: parent.height;
-            background: #2d1b1b;
+            background: Colors.error-bg;
             VerticalLayout {
                 alignment: start;
                 padding: 16px;
                 spacing: 8px;
                 Text {
                     text: @tr("Query Error");
-                    color: #f38ba8;
-                    font-size: 13px;
+                    color: Colors.red;
+                    font-size: Typography.size-lg;
                     font-weight: 700;
                 }
                 Text {
                     text: root.error-message;
-                    color: #cdd6f4;
-                    font-size: 12px;
+                    color: Colors.text;
+                    font-size: Typography.size-base;
                     wrap: word-wrap;
                 }
             }
@@ -488,14 +435,14 @@ export component ResultTable inherits Rectangle {
             // ── Toolbar (page-size selector + row count) ──────────────────────
             Rectangle {
                 height: root.toolbar-h;
-                background: #181825;
+                background: Colors.mantle;
                 clip: true;
 
                 // Bottom separator
                 Rectangle {
                     x: 0; y: parent.height - 1px;
                     width: parent.width; height: 1px;
-                    background: #313244;
+                    background: Colors.surface0;
                 }
 
                 // Row count display (left side; only when a result is loaded)
@@ -505,28 +452,17 @@ export component ResultTable inherits Rectangle {
                     text: root.row-count != root.total-rows
                         ? @tr("{0} / {1} rows", root.row-count, root.total-rows)
                         : @tr("{0} rows", root.row-count);
-                    color: #585b70;
-                    font-size: 11px;
+                    color: Colors.surface2;
+                    font-size: Typography.size-md;
                 }
 
                 // Export button — opens a dropdown with CSV / JSON options
-                if root.columns.length > 0: Rectangle {
+                if root.columns.length > 0: ToolbarButton {
                     x: parent.width - 266px;
                     y: (parent.height - self.height) / 2;
                     width: 80px;
-                    height: 20px;
-                    border-radius: 3px;
-                    background: export-btn-ta.has-hover ? #45475a : #313244;
-                    export-btn-ta := TouchArea {
-                        clicked => { export-popup.show(); }
-                    }
-                    Text {
-                        text: @tr("Export") + " \u{25BE}";
-                        color: #9399b2;
-                        font-size: 11px;
-                        horizontal-alignment: center;
-                        vertical-alignment: center;
-                    }
+                    text: @tr("Export") + " \u{25BE}";
+                    clicked => { export-popup.show(); }
                 }
 
                 // Page-size selector: four toggle buttons aligned to the right
@@ -538,80 +474,29 @@ export component ResultTable inherits Rectangle {
                     height: 20px;
                     spacing: 2px;
 
-                    // 100
-                    Rectangle {
+                    ToolbarButton {
                         width: 38px;
-                        height: 20px;
-                        border-radius: 3px;
-                        background: ps100-ta.has-hover ? #45475a
-                            : root.page-size == 100 ? #89b4fa : #313244;
-                        ps100-ta := TouchArea {
-                            clicked => { root.change-page-size(100); }
-                        }
-                        Text {
-                            text: "100";
-                            color: root.page-size == 100 ? #1e1e2e : #9399b2;
-                            font-size: 11px;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
+                        text: "100";
+                        active: root.page-size == 100;
+                        clicked => { root.change-page-size(100); }
                     }
-
-                    // 500
-                    Rectangle {
+                    ToolbarButton {
                         width: 38px;
-                        height: 20px;
-                        border-radius: 3px;
-                        background: ps500-ta.has-hover ? #45475a
-                            : root.page-size == 500 ? #89b4fa : #313244;
-                        ps500-ta := TouchArea {
-                            clicked => { root.change-page-size(500); }
-                        }
-                        Text {
-                            text: "500";
-                            color: root.page-size == 500 ? #1e1e2e : #9399b2;
-                            font-size: 11px;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
+                        text: "500";
+                        active: root.page-size == 500;
+                        clicked => { root.change-page-size(500); }
                     }
-
-                    // 1000
-                    Rectangle {
+                    ToolbarButton {
                         width: 46px;
-                        height: 20px;
-                        border-radius: 3px;
-                        background: ps1000-ta.has-hover ? #45475a
-                            : root.page-size == 1000 ? #89b4fa : #313244;
-                        ps1000-ta := TouchArea {
-                            clicked => { root.change-page-size(1000); }
-                        }
-                        Text {
-                            text: "1000";
-                            color: root.page-size == 1000 ? #1e1e2e : #9399b2;
-                            font-size: 11px;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
+                        text: "1000";
+                        active: root.page-size == 1000;
+                        clicked => { root.change-page-size(1000); }
                     }
-
-                    // ALL (0 = no LIMIT)
-                    Rectangle {
+                    ToolbarButton {
                         width: 38px;
-                        height: 20px;
-                        border-radius: 3px;
-                        background: psall-ta.has-hover ? #45475a
-                            : root.page-size == 0 ? #89b4fa : #313244;
-                        psall-ta := TouchArea {
-                            clicked => { root.change-page-size(0); }
-                        }
-                        Text {
-                            text: @tr("ALL");
-                            color: root.page-size == 0 ? #1e1e2e : #9399b2;
-                            font-size: 11px;
-                            horizontal-alignment: center;
-                            vertical-alignment: center;
-                        }
+                        text: @tr("ALL");
+                        active: root.page-size == 0;
+                        clicked => { root.change-page-size(0); }
                     }
                 }
             }
@@ -631,7 +516,7 @@ export component ResultTable inherits Rectangle {
                             ? root.col-widths[i] * 1px
                             : root.default-col-w;
                         height: root.row-height;
-                        background: sort-hdr-ta.has-hover ? #383850 : #313244;
+                        background: sort-hdr-ta.has-hover ? Colors.header-hover : Colors.surface0;
                         clip: true;
 
                         // Sort click area — covers the full cell except the 4px resize handle.
@@ -650,8 +535,8 @@ export component ResultTable inherits Rectangle {
                                 ? parent.width - 28px
                                 : parent.width - 12px;
                             text: col;
-                            color: #cdd6f4;
-                            font-size: 12px;
+                            color: Colors.text;
+                            font-size: Typography.size-base;
                             overflow: elide;
                         }
 
@@ -660,8 +545,8 @@ export component ResultTable inherits Rectangle {
                             x: parent.width - 20px;
                             y: (parent.height - self.height) / 2;
                             text: root.sort-asc ? "▲" : "▼";
-                            color: #89b4fa;
-                            font-size: 10px;
+                            color: Colors.blue;
+                            font-size: Typography.size-sm;
                         }
 
                         // ── Column resize drag handle ─────────────────────────
@@ -671,7 +556,7 @@ export component ResultTable inherits Rectangle {
                             width:  4px;
                             height: parent.height;
                             background: col-resize-ta.has-hover || col-resize-ta.pressed
-                                ? #89b4fa : #45475a;
+                                ? Colors.blue : Colors.surface1;
 
                             col-resize-ta := TouchArea {
                                 mouse-cursor: ew-resize;
@@ -710,14 +595,14 @@ export component ResultTable inherits Rectangle {
                         height: root.row-height;
                         width:  root.vp-w;
                         background: i == root.selected-row
-                            ? #264f78
-                            : (mod(i, 2) == 0 ? #1e1e2e : #181825);
+                            ? Colors.selection
+                            : (mod(i, 2) == 0 ? Colors.base : Colors.mantle);
 
                         Rectangle {   // bottom border
                             y: parent.height - 1px;
                             width: parent.width;
                             height: 1px;
-                            background: #313244;
+                            background: Colors.surface0;
                         }
 
                         HorizontalLayout {
@@ -735,14 +620,14 @@ export component ResultTable inherits Rectangle {
                                         && root.nav-mode == 1: Rectangle {
                                     width:  parent.width;
                                     height: parent.height;
-                                    background: #89b4fa44;
+                                    background: Colors.cell-highlight;
                                 }
 
                                 Rectangle {   // right border
                                     x: parent.width - 1px;
                                     width: 1px;
                                     height: parent.height;
-                                    background: #313244;
+                                    background: Colors.surface0;
                                 }
 
                                 // NULL badge — shown only when cell.is-null is true.
@@ -752,13 +637,13 @@ export component ResultTable inherits Rectangle {
                                     width: 36px;
                                     height: 16px;
                                     border-radius: 3px;
-                                    background: #45475a;
+                                    background: Colors.surface1;
                                     Text {
                                         width: parent.width;
                                         height: parent.height;
                                         text: @tr("NULL");
-                                        color: #9399b2;
-                                        font-size: 10px;
+                                        color: Colors.overlay2;
+                                        font-size: Typography.size-sm;
                                         horizontal-alignment: center;
                                         vertical-alignment: center;
                                     }
@@ -770,8 +655,8 @@ export component ResultTable inherits Rectangle {
                                     y: (parent.height - self.height) / 2;
                                     width: parent.width - 16px;
                                     text: cell.value;
-                                    color: i == root.selected-row ? #ffffff : #a6adc8;
-                                    font-size: 12px;
+                                    color: i == root.selected-row ? Colors.selected-text : Colors.subtext0;
+                                    font-size: Typography.size-base;
                                     overflow: elide;
                                 }
 
@@ -820,8 +705,8 @@ export component ResultTable inherits Rectangle {
                         x: (parent.width  - self.width)  / 2;
                         y: (parent.height - self.height) / 2;
                         text: @tr("0 rows");
-                        color: #585b70;
-                        font-size: 13px;
+                        color: Colors.surface2;
+                        font-size: Typography.size-lg;
                     }
                 }
             }
@@ -835,21 +720,21 @@ export component ResultTable inherits Rectangle {
             y: root.height - root.filter-banner-h - root.search-bar-h;
             width:  root.width;
             height: root.search-bar-h;
-            background: #1e1e2e;
+            background: Colors.base;
             clip: true;
 
             Rectangle {   // top separator
                 x: 0; y: 0;
                 width: parent.width; height: 1px;
-                background: #45475a;
+                background: Colors.surface1;
             }
 
             Text {
                 x: 10px;
                 y: (parent.height - self.height) / 2;
                 text: "/";
-                color: #89b4fa;
-                font-size: 13px;
+                color: Colors.blue;
+                font-size: Typography.size-lg;
                 font-weight: 700;
             }
 
@@ -859,10 +744,10 @@ export component ResultTable inherits Rectangle {
                 width: parent.width - 34px;
                 text <=> root.search-query;
                 single-line: true;
-                color: #cdd6f4;
-                selection-background-color: #264f78;
-                selection-foreground-color: #ffffff;
-                font-size: 12px;
+                color: Colors.text;
+                selection-background-color: Colors.selection;
+                selection-foreground-color: Colors.selected-text;
+                font-size: Typography.size-base;
             }
         }
 
@@ -873,13 +758,13 @@ export component ResultTable inherits Rectangle {
             y: root.height - root.filter-banner-h;
             width:  root.width;
             height: root.filter-banner-h;
-            background: #1e3a5f;
+            background: Colors.filter-bg;
             clip: true;
 
             Rectangle {   // top separator
                 x: 0; y: 0;
                 width: parent.width; height: 1px;
-                background: #2a5298;
+                background: Colors.filter-accent;
             }
 
             HorizontalLayout {
@@ -889,23 +774,23 @@ export component ResultTable inherits Rectangle {
 
                 Text {
                     text: @tr("Filter:");
-                    color: #89b4fa;
-                    font-size: 11px;
+                    color: Colors.blue;
+                    font-size: Typography.size-md;
                     font-weight: 700;
                     vertical-alignment: center;
                 }
                 Text {
                     text: root.active-filter;
-                    color: #cdd6f4;
-                    font-size: 11px;
+                    color: Colors.text;
+                    font-size: Typography.size-md;
                     vertical-alignment: center;
                     overflow: elide;
                     horizontal-stretch: 1;
                 }
                 Text {
                     text: @tr("[Esc to clear]");
-                    color: #585b70;
-                    font-size: 11px;
+                    color: Colors.surface2;
+                    font-size: Typography.size-md;
                     vertical-alignment: center;
                 }
             }

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -1,7 +1,8 @@
 import { SidebarNode } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
 
 export component Sidebar inherits Rectangle {
-    background: #1e1e2e;
+    background: Colors.base;
 
     in property <[SidebarNode]> tree: [];
     in property <bool> is-loading: false;
@@ -113,8 +114,8 @@ export component Sidebar inherits Rectangle {
                     clip: true;
 
                     background: i == root.kb-focus
-                        ? #3d3d5c
-                        : (node.is-active && node.level == 0 ? #313244 : transparent);
+                        ? Colors.sidebar-sel
+                        : (node.is-active && node.level == 0 ? Colors.surface0 : transparent);
 
                     ta := TouchArea {
                         width: parent.width;
@@ -142,7 +143,7 @@ export component Sidebar inherits Rectangle {
                         background: ta.has-hover
                             && i != root.kb-focus
                             && !(node.is-active && node.level == 0)
-                            ? #ffffff0d : transparent;
+                            ? Colors.hover-subtle : transparent;
                         width: parent.width;
                         height: parent.height;
                     }
@@ -158,8 +159,8 @@ export component Sidebar inherits Rectangle {
                         // Expand/collapse toggle icon for connection and category nodes
                         if node.level < 2 : Text {
                             text: node.is-expanded ? "▼" : "▶";
-                            color: #585b70;
-                            font-size: 9px;
+                            color: Colors.surface2;
+                            font-size: Typography.size-xs;
                             vertical-alignment: center;
                             width: 14px;
                         }
@@ -170,9 +171,9 @@ export component Sidebar inherits Rectangle {
                         Text {
                             text: node.label;
                             color: node.level == 0
-                                ? (node.is-active ? #cdd6f4 : #bac2de)
-                                : (node.level == 1 ? #7f849c : #a6adc8);
-                            font-size: node.level == 0 ? 13px : 12px;
+                                ? (node.is-active ? Colors.text : Colors.subtext1)
+                                : (node.level == 1 ? Colors.overlay1 : Colors.subtext0);
+                            font-size: node.level == 0 ? Typography.size-lg : Typography.size-base;
                             vertical-alignment: center;
                             overflow: elide;
                             horizontal-stretch: 1;
@@ -181,8 +182,8 @@ export component Sidebar inherits Rectangle {
                         // Sub-label badge (db-type for connection nodes)
                         if node.sub-label != "" : Text {
                             text: node.sub-label;
-                            color: #585b70;
-                            font-size: 10px;
+                            color: Colors.surface2;
+                            font-size: Typography.size-sm;
                             vertical-alignment: center;
                         }
                     }
@@ -195,8 +196,8 @@ export component Sidebar inherits Rectangle {
                         padding-left: 24px;
                         Text {
                             text: @tr("Loading\u{2026}");
-                            color: #585b70;
-                            font-size: 11px;
+                            color: Colors.surface2;
+                            font-size: Typography.size-md;
                             vertical-alignment: center;
                             font-italic: true;
                         }
@@ -206,7 +207,7 @@ export component Sidebar inherits Rectangle {
                 // ── Divider ───────────────────────────────────────────────────────────
                 Rectangle {
                     height: 1px;
-                    background: #313244;
+                    background: Colors.surface0;
                 }
 
                 // ── Add connection button ─────────────────────────────────────────────
@@ -218,7 +219,7 @@ export component Sidebar inherits Rectangle {
                         padding-left: 12px;
                         Text {
                             text: @tr("＋ Add connection");
-                            color: #89b4fa;
+                            color: Colors.blue;
                             vertical-alignment: center;
                         }
                     }

--- a/app/src/ui/components/status_bar.slint
+++ b/app/src/ui/components/status_bar.slint
@@ -2,8 +2,10 @@
 // Left: active connection name (and DB) or "Not connected".
 // Right: query lifecycle status — "Running…", "N ms · M rows", "Cancelled", "Error: …".
 
+import { Colors, Typography } from "../theme.slint";
+
 export component StatusBar inherits Rectangle {
-    background: #11111b;
+    background: Colors.crust;
 
     /// Text shown on the left: active connection name (and DB) or "Not connected".
     /// Updated from Rust via invoke_from_event_loop on Event::Connected / Event::Disconnected.
@@ -18,16 +20,16 @@ export component StatusBar inherits Rectangle {
 
         Text {
             text: root.connection-text;
-            color: #a6adc8;
-            font-size: 12px;
+            color: Colors.subtext0;
+            font-size: Typography.size-base;
             vertical-alignment: center;
             horizontal-stretch: 1;
         }
 
         Text {
             text: root.query-status;
-            color: #a6adc8;
-            font-size: 12px;
+            color: Colors.subtext0;
+            font-size: Typography.size-base;
             vertical-alignment: center;
         }
     }

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -1,0 +1,51 @@
+// Design tokens for the Catppuccin Mocha theme.
+// Import this file in every .slint file that uses colours or font sizes.
+
+export global Colors {
+    // ── Catppuccin Mocha backgrounds ──────────────────────────────────────────
+    out property <color> crust:    #11111b;  // deepest bg — status bar
+    out property <color> mantle:   #181825;  // editor bg, toolbar bg, preview strip
+    out property <color> base:     #1e1e2e;  // main application background
+    out property <color> surface0: #313244;  // widget default bg, popup bg, panel header
+    out property <color> surface1: #45475a;  // hover bg, drag-handle active, null badge
+    out property <color> surface2: #585b70;  // border, disabled / placeholder text
+
+    // ── Text / overlay ────────────────────────────────────────────────────────
+    out property <color> overlay0:  #6c7086;  // completion-item kind; Add-btn unverified
+    out property <color> overlay1:  #7f849c;  // sidebar category label
+    out property <color> overlay2:  #9399b2;  // toolbar button text (inactive)
+    out property <color> subtext0:  #a6adc8;  // secondary text, status bar
+    out property <color> subtext1:  #bac2de;  // inactive connection name in sidebar
+    out property <color> text:      #cdd6f4;  // primary text
+
+    // ── Accent colours ────────────────────────────────────────────────────────
+    out property <color> blue:   #89b4fa;  // active state, focus border, links, sort
+    out property <color> green:  #a6e3a1;  // success, Add button (test passed)
+    out property <color> red:    #f38ba8;  // error text, danger button (Yes / Fetch)
+    out property <color> yellow: #f9e2af;  // warning / caution heading
+
+    // ── Semantic / app-specific ───────────────────────────────────────────────
+    out property <color> selection:      #264f78;   // selected-row background
+    out property <color> current-line:   #2a2a3e;   // editor current-line highlight
+    out property <color> error-bg:       #2d1b1b;   // result-table error-panel background
+    out property <color> filter-bg:      #1e3a5f;   // filter-banner background
+    out property <color> filter-accent:  #2a5298;   // filter-banner top border
+    out property <color> sidebar-sel:    #3d3d5c;   // sidebar keyboard-focus row
+    out property <color> header-hover:   #383850;   // column-header hover tint
+    out property <color> cell-highlight: #89b4fa44; // cell-mode focus column overlay
+    out property <color> selected-text:  #ffffff;   // high-contrast text on selection bg
+    out property <color> shadow-light:   #00000066; // light drop-shadow (forms)
+    out property <color> shadow:         #00000088; // standard drop-shadow (popups)
+    out property <color> modal-overlay:  #00000099; // modal dim overlay
+    out property <color> hover-subtle:   #ffffff0d; // sidebar row hover tint
+}
+
+export global Typography {
+    out property <length> size-xs:   9px;   // sidebar expand/collapse icon
+    out property <length> size-sm:  10px;   // NULL badge, completion-item kind
+    out property <length> size-md:  11px;   // toolbar buttons, filter-bar text
+    out property <length> size-base: 12px;  // most body text (cells, status bar, menus)
+    out property <length> size-lg:  13px;   // editor content, loading/placeholder text
+    out property <length> size-xl:  15px;   // modal dialog titles
+    out property <length> size-2xl: 16px;   // connection-form title, close button
+}


### PR DESCRIPTION
## Summary

Eliminates all hard-coded hex colour literals and magic font-size values from every `.slint` file by introducing a single `theme.slint` design-token file.  Adds a `common.slint` module with three reusable primitives that replace duplicated `Rectangle + TouchArea + Text` button/menu patterns across the codebase.

## Changes

**New files**
- `app/src/ui/theme.slint` — `global Colors` (30 named Catppuccin Mocha tokens + semantic colours) and `global Typography` (7 font-size steps); single source of truth for the entire visual theme
- `app/src/ui/components/common.slint` — three exported components:
  - `ToolbarButton` — 20 px toggle button used in the result-table toolbar (page-size selector, Export)
  - `ActionButton` — 32 px form/modal button with configurable `bg`/`fg` properties
  - `MenuItem` — 30 px popup row used in Export dropdown and right-click context menu

**Updated files** — all `.slint` files now import `theme.slint` and replace literals with `Colors.*` / `Typography.*`:
- `result_table.slint`: 4× page-size buttons → `ToolbarButton`; Export button → `ToolbarButton`; 5× menu items → `MenuItem` (-116 lines)
- `connection_form.slint`: Cancel / Test Connection / Add buttons → `ActionButton` (-26 lines)
- `app.slint`: OK / No / Yes / Cancel / Fetch modal buttons → `ActionButton` (-36 lines)
- `sidebar.slint`, `editor.slint`, `completion_popup.slint`, `status_bar.slint` — colour-only updates

## Related Issues

Closes #163
Closes #164

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes