### PR TITLE
feat(sidebar): add connection status dot and one-click switching

### DIFF
--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -167,6 +167,14 @@ export component Sidebar inherits Rectangle {
                         // Spacer for item nodes
                         if node.level >= 2 : Rectangle { width: 14px; }
 
+                        // Connection status dot (● active / ○ inactive)
+                        if node.level == 0 : Text {
+                            text: node.is-active ? "●" : "○";
+                            color: node.is-active ? Colors.blue : Colors.surface2;
+                            font-size: Typography.size-sm;
+                            vertical-alignment: center;
+                        }
+
                         // Main label
                         Text {
                             text: node.label;

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -626,7 +626,7 @@ impl UI {
         }
 
         // toggle-sidebar-node: expand/collapse a tree node; also switches active
-        // connection when a level-0 (connection) node is clicked.
+        // connection when an inactive level-0 (connection) node is clicked.
         {
             // clone required: callback closure needs owned captures
             let tx_cmd = tx_cmd.clone();
@@ -635,22 +635,31 @@ impl UI {
             let window_weak = window.as_weak();
             ui_state.on_toggle_sidebar_node(move |id| {
                 let id = id.to_string();
-                // If this is a connection node, send a Connect command.
+                // For connection nodes, switch only when not already active.
                 if let Some(conn_id) = id.strip_prefix("conn:") {
-                    let conn = state.conn.all().into_iter().find(|c| c.id == conn_id);
-                    if let Some(conn) = conn {
-                        let password = conn
-                            .password_encrypted
-                            .as_ref()
-                            .and_then(|enc| crypto::decrypt(enc, &enc_key).ok());
-                        // clone required: tokio::spawn requires 'static
-                        let tx_cmd = tx_cmd.clone();
-                        tokio::spawn(async move {
-                            let _ = tx_cmd.send(Command::Connect(conn, password)).await;
-                        });
+                    let active_id = state
+                        .conn
+                        .active()
+                        .map(|c| c.id.clone())
+                        .unwrap_or_default();
+                    if conn_id != active_id {
+                        let conn = state.conn.all().into_iter().find(|c| c.id == conn_id);
+                        if let Some(conn) = conn {
+                            let password = conn
+                                .password_encrypted
+                                .as_ref()
+                                .and_then(|enc| crypto::decrypt(enc, &enc_key).ok());
+                            // clone required: tokio::spawn requires 'static
+                            let tx_cmd = tx_cmd.clone();
+                            tokio::spawn(async move {
+                                let _ = tx_cmd.send(Command::Connect(conn, password)).await;
+                            });
+                        }
+                        // Return early — Event::Connected will auto-expand the newly active node.
+                        return;
                     }
                 }
-                // Toggle expanded state
+                // Toggle expanded state (active connection and category nodes).
                 {
                     let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
                     if sb.expanded.contains(&id) {


### PR DESCRIPTION
## Summary

Adds `●`/`○` status dot indicators to sidebar connection nodes and enables one-click switching between connections. The active connection shows a blue `●`; inactive connections show a muted `○`. Clicking an inactive connection immediately triggers `Command::Connect` (the previously active connection's expand/collapse state is preserved). Clicking the already-active connection only toggles its expand/collapse as before.

## Changes

- `sidebar.slint`: Added `●`/`○` dot `Text` element between the expand icon and the connection label for level-0 nodes — blue (`Colors.blue`) when active, muted (`Colors.surface2`) when inactive
- `mod.rs`: Updated `on_toggle_sidebar_node` to check `state.conn.active()` before sending `Command::Connect` — skips the command when the connection is already active; returns early after dispatching so `Event::Connected` handles the auto-expand of the newly active node

## Related Issues

Closes #171

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes