### PR TITLE
refactor(app): replace magic numbers with named constants

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -10,7 +10,7 @@
 //! UI callbacks  ──(tx_cmd)──▶  AppController::run  ──(tx_event)──▶  UI event handler
 //! ```
 //!
-//! Both channels are bounded (`capacity = 64`). The controller task exits cleanly
+//! Both channels are bounded (`capacity = CMD_CHANNEL_CAPACITY`). The controller task exits cleanly
 //! when all `Sender<Command>` clones are dropped (i.e. when the UI window closes).
 
 use std::path::PathBuf;
@@ -34,6 +34,8 @@ use crate::{
 
 /// Async command loop that drives the application backend.
 ///
+const CMD_CHANNEL_CAPACITY: usize = 64;
+
 /// Owns the [`DbService`] pool, the [`SessionManager`] for config persistence,
 /// and the [`SharedState`] shared with the UI layer. Created by [`AppController::new`]
 /// and consumed by [`AppController::run`], which is spawned as a tokio task.
@@ -69,8 +71,8 @@ impl AppController {
         history_path: PathBuf,
         metadata_cache_path: PathBuf,
     ) -> (Self, mpsc::Sender<Command>, mpsc::Receiver<Event>) {
-        let (tx_cmd, rx_cmd) = mpsc::channel(64);
-        let (tx_event, rx_event) = mpsc::channel(64);
+        let (tx_cmd, rx_cmd) = mpsc::channel(CMD_CHANNEL_CAPACITY);
+        let (tx_event, rx_event) = mpsc::channel(CMD_CHANNEL_CAPACITY);
         (
             Self {
                 state,

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -11,6 +11,10 @@ use tokio::sync::mpsc;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, TableInfo};
 
+const COMPLETION_DEBOUNCE_MS: u64 = 300;
+const ERROR_TRUNCATION_CHARS: usize = 80;
+const DEFAULT_COLUMN_WIDTH: f32 = 150.0;
+
 // ---------------------------------------------------------------------------
 // Original query result — retained for client-side filtering
 // ---------------------------------------------------------------------------
@@ -431,10 +435,9 @@ impl UI {
                             ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
                             ui.set_result_row_count(row_count);
                             ui.set_result_total_rows(row_count);
-                            // Initialise per-column widths (150 px each).
-                            const DEFAULT_COL_W: f32 = 150.0;
-                            let widths: Vec<f32> = vec![DEFAULT_COL_W; col_count];
-                            let total_w = col_count as f32 * DEFAULT_COL_W;
+                            // Initialise per-column widths.
+                            let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
+                            let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
                             ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
                             ui.set_result_total_col_width(total_w);
                             ui.set_status_message(
@@ -458,13 +461,13 @@ impl UI {
                     }
                     Event::QueryError(ref msg) => {
                         let msg = msg.clone();
-                        // Short summary: first non-empty line, truncated to 80 chars.
+                        // Short summary: first non-empty line, truncated to ERROR_TRUNCATION_CHARS.
                         let summary = msg
                             .lines()
                             .find(|l| !l.trim().is_empty())
                             .unwrap_or(&msg)
                             .chars()
-                            .take(80)
+                            .take(ERROR_TRUNCATION_CHARS)
                             .collect::<String>();
                         // clone required: invoke_from_event_loop closure must be 'static
                         let window_weak = window_weak.clone();
@@ -933,7 +936,7 @@ impl UI {
                 let timer = slint::Timer::default();
                 timer.start(
                     slint::TimerMode::SingleShot,
-                    Duration::from_millis(300),
+                    Duration::from_millis(COMPLETION_DEBOUNCE_MS),
                     move || {
                         let tx = tx.clone(); // clone required: tokio::spawn
                         let sql = sql.clone();


### PR DESCRIPTION
## Summary

Replaces four bare numeric literals in the app layer with named constants declared close to their use site, making intent explicit and simplifying future tuning.

## Changes

- `controller.rs`: added `CMD_CHANNEL_CAPACITY: usize = 64`; used for both `mpsc::channel` calls
- `ui/mod.rs`: added `COMPLETION_DEBOUNCE_MS: u64 = 300`, `ERROR_TRUNCATION_CHARS: usize = 80`, `DEFAULT_COLUMN_WIDTH: f32 = 150.0`; replaced all inline literals

## Related Issues

Resolves #169

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes