### PR TITLE
refactor(ui): split result_table.slint and extract UI helpers

### DIFF
--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -1,800 +1,150 @@
-import { ListView } from "std-widgets.slint";
-import { RowData, RowCellData } from "../globals.slint";
+import { RowData } from "../globals.slint";
 import { Colors, Typography } from "../theme.slint";
-import { ToolbarButton, MenuItem } from "common.slint";
-
-// Result table — column headers + scrollable data rows.
-//
-// Features:
-//   • Per-column widths, adjustable by dragging the right-edge divider on each header.
-//   • Overflow text is elided (…) within the cell.
-//   • Three navigation modes: row (default), cell (Enter), search (F).
-//   • Client-side row filtering via search bar; active-filter banner shows applied filter.
-//
-// Scroll architecture:
-//   header-scroll (Flickable, interactive: false) + body-scroll (ListView, H+V).
-//   ListView only renders visible rows for smooth scrolling with large result sets.
-//   `changed viewport-x =>` in body-scroll syncs header-scroll so headers
-//   track horizontal scroll without scrolling vertically.
-//
-// Keyboard navigation:
-//   Row mode:  ↑↓ Home End PgUp PgDn — move selected row
-//              Enter — enter cell mode at column 0
-//              F     — enter search mode
-//              Esc   — clear filter (if active) or deselect row
-//              Ctrl+C — copy selected cell value to clipboard
-//   Cell mode: ←→ Home End — move selected column within current row
-//              Esc  — return to row mode
-//              Ctrl+C — copy current cell value to clipboard
-//   Search:    type to build query; Enter — apply; Esc — cancel
+import { ResultTableToolbar } from "result_table_toolbar.slint";
+import { ResultTableHeader } from "result_table_header.slint";
+import { ResultTableBody }   from "result_table_body.slint";
+import { ResultTableSearch } from "result_table_search.slint";
 
 export component ResultTable inherits Rectangle {
     background: Colors.base;
     clip: true;
     preferred-height: 0;
     min-height: 0;
-
-    // ── In properties ─────────────────────────────────────────────────────────
-    in property <[string]>  columns:       [];
-    in property <[RowData]> rows:          [];
-    in property <int>       row-count:     0;
-    in property <bool>      is-loading:    false;
-    in property <string>    error-message: "";
-    in property <[float]>   col-widths:    [];
+    in property <[string]>  columns:         [];
+    in property <[RowData]> rows:            [];
+    in property <int>       row-count:       0;
+    in property <bool>      is-loading:      false;
+    in property <string>    error-message:   "";
+    in property <[float]>   col-widths:      [];
     in property <float>     total-col-width: 0.0;
-    /// Currently active filter text (empty = no filter). Set by Rust after filter-rows fires.
-    in property <string>    active-filter: "";
-
-    // ── Focus API ─────────────────────────────────────────────────────────────
-    /// True when this table (or its search input) holds focus.
-    out property <bool> result-focused:
-        table-fs.has-focus
-        || (root.nav-mode == 2 && search-input.has-focus);
-
-    public function grab-focus() {
-        table-fs.focus();
-        if (root.selected-row < 0 && root.row-count > 0) {
-            root.selected-row = 0;
-        }
-    }
-
-    // ── Pagination / row-count state ─────────────────────────────────────────
-    /// Active page size (100 / 500 / 1000). Driven from Rust; reflects config.
-    in property <int> page-size:   500;
-    /// Total rows returned by the last query (before client-side filtering).
-    in property <int> total-rows:  0;
-    /// User selected a new page size; Rust persists to config and updates state.
-    callback change-page-size(int);
-
-    // ── Callbacks ─────────────────────────────────────────────────────────────
+    in property <string>    active-filter:   "";
+    in property <int>       page-size:       500;
+    in property <int>       total-rows:      0;
+    in property <int>       sort-col:        -1;
+    in property <bool>      sort-asc:        true;
     callback resize-column(int, float);
     callback filter-rows(string);
     callback clear-filter();
     callback copy-cell(string);
-    /// Copy row i cells to clipboard (tab-separated, NULL → empty string).
     callback copy-row(int);
-    /// Copy all visible rows as TSV with column headers.
     callback copy-all-tsv();
-    /// Fired when the "Export CSV" menu item is clicked.
     callback export-csv();
-    /// Fired when the "Export JSON" menu item is clicked.
     callback export-json();
-    /// Returns cumulative x-offset (logical px as float) of column j.
-    /// Implemented in Rust; used for horizontal auto-scroll in cell mode.
     pure callback col-x-offset(int) -> float;
-    /// Fired when a column header is clicked; Rust toggles sort direction and re-renders.
     callback sort-col-clicked(int);
-
-    // ── Sort state (driven from Rust via in properties) ───────────────────────
-    /// -1 = no active sort; ≥0 = index of the currently sorted column.
-    in property <int>  sort-col: -1;
-    /// true = ascending (▲), false = descending (▼).
-    in property <bool> sort-asc: true;
-
-    // ── Context menu state ────────────────────────────────────────────────────
-    property <length> ctx-menu-x:       0;
-    property <length> ctx-menu-y:       0;
-    property <int>    ctx-row:          -1;
-    property <string> ctx-cell-value:   "";
-    property <bool>   ctx-cell-is-null: false;
-
-    // ── Style constants ───────────────────────────────────────────────────────
+    callback change-page-size(int);
+    out property <bool>   result-focused:
+        body-inst.has-focus
+        || (body-inst.nav-mode == 2 && search-inst.has-focus);
+    out property <string> selected-cell-value:   body-inst.selected-cell-value;
+    out property <bool>   selected-cell-is-null: body-inst.selected-cell-is-null;
+    public function grab-focus() { body-inst.grab-focus(); }
     property <length> row-height:    28px;
-    property <length> toolbar-h:     28px;
     property <length> default-col-w: 150px;
     property <length> min-col-w:     48px;
-
-    // ── Selection / nav state ─────────────────────────────────────────────────
-    property <int>        selected-row:          -1;
-    /// Full value of the last clicked cell; "" when no specific cell is selected.
-    out property <string> selected-cell-value:   "";
-    /// true when the selected cell contains SQL NULL (distinct from empty string).
-    out property <bool>   selected-cell-is-null: false;
-    property <int>        selected-col:          -1;
-    /// 0 = row mode  1 = cell mode  2 = search mode
-    property <int>    nav-mode:    0;
-    property <string> search-query: "";
-
-    // ── Bottom strip heights ──────────────────────────────────────────────────
-    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
-    property <length> search-bar-h:    root.nav-mode == 2 ? 32px : 0px;
-    property <length> bottom-total:
-        root.filter-banner-h + root.search-bar-h;
-
-    // ── Viewport width ────────────────────────────────────────────────────────
     property <length> vp-w: root.total-col-width > 0
         ? max(root.total-col-width * 1px, root.width)
         : max(root.columns.length * root.default-col-w, root.width);
+    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
+    property <length> search-bar-h:    body-inst.nav-mode == 2 ? 32px : 0px;
+    property <length> bottom-total:    root.filter-banner-h + root.search-bar-h;
+    property <string> search-query: "";
 
-    // ── Page size for Page Up/Down ────────────────────────────────────────────
-    property <int> page-rows: max(1,
-        (root.height - root.row-height - root.bottom-total - root.toolbar-h) / root.row-height);
-
-    // ── Body viewport state ───────────────────────────────────────────────────
-    // Mirrored at component level so `changed` handlers can update them without
-    // referencing body-scroll (which lives inside a conditional if-block).
-    // Two-way bound to body-scroll.viewport-y/x inside the if-block.
-    property <length> body-vp-y: 0;
-    property <length> body-vp-x: 0;
-    // Visible body height (full height minus toolbar, header row, and collapsed strips).
-    property <length> body-h: max(1px, root.height - root.bottom-total - root.row-height - root.toolbar-h);
-
-    // Reset selection and nav state when a new query result arrives.
-    changed rows => {
-        root.selected-row          = -1;
-        root.selected-col          = -1;
-        root.nav-mode              = 0;
-        root.selected-cell-value   = "";
-        root.selected-cell-is-null = false;
-        root.body-vp-y             = 0;
-        root.body-vp-x             = 0;
-    }
-
-    // ── Auto-scroll: keep selected row visible ────────────────────────────────
-    changed selected-row => {
-        if (root.selected-row >= 0) {
-            let row-top = root.selected-row * root.row-height;
-            let row-bot = row-top + root.row-height;
-            if (row-top < -root.body-vp-y) {
-                root.body-vp-y = -row-top;
-            } else if (row-bot > -root.body-vp-y + root.body-h) {
-                root.body-vp-y = -(row-bot - root.body-h);
-            }
-        }
-    }
-
-    // ── Auto-scroll: keep selected column visible ─────────────────────────────
-    changed selected-col => {
-        if (root.selected-col >= 0) {
-            let col-left  = root.col-x-offset(root.selected-col) * 1px;
-            let col-w     = root.col-widths.length > root.selected-col
-                            && root.col-widths[root.selected-col] > 0
-                ? root.col-widths[root.selected-col] * 1px
-                : root.default-col-w;
-            let col-right = col-left + col-w;
-            if (col-left < -root.body-vp-x) {
-                root.body-vp-x = -col-left;
-            } else if (col-right > -root.body-vp-x + root.width) {
-                root.body-vp-x = -(col-right - root.width);
-            }
-        }
-    }
-
-    // ── Root FocusScope ───────────────────────────────────────────────────────
-    // capture-key-pressed fires root→focused so it intercepts keys regardless
-    // of which child (e.g. search-input) currently holds focus.
-    table-fs := FocusScope {
+    VerticalLayout {
         x: 0; y: 0;
-        width: parent.width; height: parent.height;
-        focus-on-click: true;
+        width: root.width;
+        height: root.height - root.bottom-total;
 
-        capture-key-pressed(event) => {
-            if (root.is-loading || root.error-message != "" || root.columns.length == 0) {
-                EventResult.reject
-            } else if (root.nav-mode == 2) {
-                // Search mode: intercept Enter and Esc; reject all other keys so
-                // search-input receives them for editing.
-                if (event.text == Key.Return) {
-                    root.filter-rows(root.search-query);
-                    root.nav-mode = 0;
-                    table-fs.focus();
-                    EventResult.accept
-                } else if (event.text == Key.Escape) {
-                    root.nav-mode = 0;
-                    table-fs.focus();
-                    EventResult.accept
-                } else {
-                    EventResult.reject
-                }
-            } else if (root.nav-mode == 1) {
-                // Cell mode
-                if (event.text == Key.LeftArrow) {
-                    if (root.selected-col > 0) { root.selected-col -= 1; }
-                    EventResult.accept
-                } else if (event.text == Key.RightArrow) {
-                    if (root.selected-col < root.columns.length - 1) {
-                        root.selected-col += 1;
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.Home) {
-                    root.selected-col = 0;
-                    EventResult.accept
-                } else if (event.text == Key.End) {
-                    if (root.columns.length > 0) {
-                        root.selected-col = root.columns.length - 1;
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.Escape) {
-                    root.nav-mode = 0;
-                    root.selected-col = -1;
-                    EventResult.accept
-                } else if (event.text == "c" && event.modifiers.control) {
-                    if (root.selected-row >= 0 && root.selected-col >= 0
-                            && root.selected-row < root.rows.length
-                            && root.selected-col < root.rows[root.selected-row].cells.length) {
-                        root.copy-cell(root.rows[root.selected-row].cells[root.selected-col].value);
-                    }
-                    EventResult.accept
-                } else {
-                    EventResult.reject
-                }
-            } else {
-                // Row mode
-                if (event.text == Key.UpArrow) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.selected-row > 0) {
-                        root.selected-row -= 1;
-                    } else if (root.row-count > 0) {
-                        root.selected-row = 0;
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.DownArrow) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.selected-row < 0 && root.row-count > 0) {
-                        root.selected-row = 0;
-                    } else if (root.selected-row < root.row-count - 1) {
-                        root.selected-row += 1;
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.Home) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.row-count > 0) { root.selected-row = 0; }
-                    EventResult.accept
-                } else if (event.text == Key.End) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.row-count > 0) { root.selected-row = root.row-count - 1; }
-                    EventResult.accept
-                } else if (event.text == Key.PageUp) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.selected-row > 0) {
-                        root.selected-row = max(0, root.selected-row - root.page-rows);
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.PageDown) {
-                    root.selected-cell-value   = "";
-                    root.selected-cell-is-null = false;
-                    if (root.selected-row < root.row-count - 1) {
-                        root.selected-row = min(
-                            root.row-count - 1, root.selected-row + root.page-rows);
-                    }
-                    EventResult.accept
-                } else if (event.text == Key.Return) {
-                    if (root.selected-row >= 0 && root.columns.length > 0) {
-                        root.nav-mode = 1;
-                        root.selected-col = 0;
-                    }
-                    EventResult.accept
-                } else if (event.text == "f"
-                        && !event.modifiers.control
-                        && !event.modifiers.alt
-                        && !event.modifiers.shift) {
-                    root.search-query = "";
-                    root.nav-mode = 2;
-                    search-input.focus();
-                    EventResult.accept
-                } else if (event.text == Key.Escape) {
-                    if (root.active-filter != "") {
-                        root.clear-filter();
-                    } else {
-                        root.selected-row          = -1;
-                        root.selected-cell-value   = "";
-                        root.selected-cell-is-null = false;
-                    }
-                    EventResult.accept
-                } else if (event.text == "c" && event.modifiers.control) {
-                    if (root.selected-cell-value != "") {
-                        root.copy-cell(root.selected-cell-value);
-                    }
-                    EventResult.accept
-                } else {
-                    EventResult.reject
-                }
-            }
+        toolbar-inst := ResultTableToolbar {
+            col-count:  root.columns.length;
+            row-count:  root.row-count;
+            total-rows: root.total-rows;
+            page-size:  root.page-size;
+            change-page-size(n) => { root.change-page-size(n); }
+            export-csv  => { root.export-csv(); }
+            export-json => { root.export-json(); }
         }
 
-        // ── Export dropdown menu ──────────────────────────────────────────────
-        // Positioned just below the Export button in the toolbar.
-        // x/y are relative to table-fs, which covers the full component.
-        export-popup := PopupWindow {
-            x: root.width - 266px;
-            y: root.toolbar-h + 2px;
-            width: 120px;
-            height: 60px;
-            close-policy: PopupClosePolicy.close-on-click;
-
-            Rectangle {
-                width: 120px;
-                height: 60px;
-                background: Colors.surface0;
-                border-radius: 4px;
-                border-width: 1px;
-                border-color: Colors.surface2;
-                drop-shadow-blur: 8px;
-                drop-shadow-color: Colors.shadow;
-                clip: true;
-
-                VerticalLayout {
-                    spacing: 0;
-                    MenuItem {
-                        text: @tr("Export CSV");
-                        clicked => { root.export-csv(); }
-                    }
-                    MenuItem {
-                        text: @tr("Export JSON");
-                        clicked => { root.export-json(); }
-                    }
-                }
-            }
+        header-inst := ResultTableHeader {
+            height:        root.row-height;
+            columns:       root.columns;
+            col-widths:    root.col-widths;
+            sort-col:      root.sort-col;
+            sort-asc:      root.sort-asc;
+            default-col-w: root.default-col-w;
+            min-col-w:     root.min-col-w;
+            vp-w:          root.vp-w;
+            body-vp-x:     body-inst.body-vp-x;
+            sort-col-clicked(i) => { root.sort-col-clicked(i); }
+            resize-column(i, w) => { root.resize-column(i, w); }
         }
 
-        // ── Right-click context menu ──────────────────────────────────────────
-        ctx-popup := PopupWindow {
-            x: root.ctx-menu-x;
-            y: root.ctx-menu-y;
-            width: 204px;
-            height: 90px;
-            close-policy: PopupClosePolicy.close-on-click;
-
-            Rectangle {
-                width: 204px;
-                height: 90px;
-                background: Colors.surface0;
-                border-radius: 4px;
-                border-width: 1px;
-                border-color: Colors.surface2;
-                drop-shadow-blur: 8px;
-                drop-shadow-color: Colors.shadow;
-                clip: true;
-
-                VerticalLayout {
-                    spacing: 0;
-                    MenuItem {
-                        text: @tr("Copy cell value");
-                        clicked => { root.copy-cell(root.ctx-cell-value); }
-                    }
-                    MenuItem {
-                        text: @tr("Copy row (tab-separated)");
-                        clicked => { root.copy-row(root.ctx-row); }
-                    }
-                    MenuItem {
-                        text: @tr("Copy as TSV (with headers)");
-                        clicked => { root.copy-all-tsv(); }
-                    }
-                }
-            }
+        body-inst := ResultTableBody {
+            vertical-stretch: 1;
+            columns:       root.columns;
+            rows:          root.rows;
+            row-count:     root.row-count;
+            col-widths:    root.col-widths;
+            default-col-w: root.default-col-w;
+            vp-w:          root.vp-w;
+            row-height:    root.row-height;
+            active-filter: root.active-filter;
+            is-loading:    root.is-loading;
+            error-message: root.error-message;
+            search-query  <=> root.search-query;
+            filter-rows(q) => { root.filter-rows(q); }
+            clear-filter   => { root.clear-filter(); }
+            copy-cell(v)   => { root.copy-cell(v); }
+            copy-row(i)    => { root.copy-row(i); }
+            copy-all-tsv   => { root.copy-all-tsv(); }
+            focus-search   => { search-inst.grab-focus(); }
+            col-x-offset(j) => { root.col-x-offset(j); }
         }
+    }
 
-        // ── Loading overlay ───────────────────────────────────────────────────
-        if root.is-loading: Rectangle {
-            width:  parent.width;
-            height: parent.height;
-            background: Colors.base;
+    search-inst := ResultTableSearch {
+        x: 0;
+        y: root.height - root.bottom-total;
+        width:  root.width;
+        height: root.bottom-total;
+        active-filter:  root.active-filter;
+        in-search-mode: body-inst.nav-mode == 2;
+        search-query   <=> root.search-query;
+    }
+
+    if root.is-loading: Rectangle {
+        x: 0; y: 0; width: root.width; height: root.height;
+        background: Colors.base;
+        TouchArea {}
+        Text {
+            x: (parent.width  - self.width)  / 2;
+            y: (parent.height - self.height) / 2;
+            text: @tr("Running\u{2026}");
+            color: Colors.text;
+            font-size: Typography.size-lg;
+        }
+    }
+
+    if !root.is-loading && root.error-message != "": Rectangle {
+        x: 0; y: 0; width: root.width; height: root.height;
+        background: Colors.error-bg;
+        TouchArea {}
+        VerticalLayout {
+            alignment: start;
+            padding: 16px;
+            spacing: 8px;
             Text {
-                x: (parent.width  - self.width)  / 2;
-                y: (parent.height - self.height) / 2;
-                text: @tr("Running\u{2026}");
-                color: Colors.text;
-                font-size: Typography.size-lg;
-            }
-        }
-
-        // ── Error panel ───────────────────────────────────────────────────────
-        if !root.is-loading && root.error-message != "": Rectangle {
-            width:  parent.width;
-            height: parent.height;
-            background: Colors.error-bg;
-            VerticalLayout {
-                alignment: start;
-                padding: 16px;
-                spacing: 8px;
-                Text {
-                    text: @tr("Query Error");
-                    color: Colors.red;
-                    font-size: Typography.size-lg;
-                    font-weight: 700;
-                }
-                Text {
-                    text: root.error-message;
-                    color: Colors.text;
-                    font-size: Typography.size-base;
-                    wrap: word-wrap;
-                }
-            }
-        }
-
-        // ── Result content ────────────────────────────────────────────────────
-        if !root.is-loading && root.error-message == "": VerticalLayout {
-            width:  parent.width;
-            height: parent.height - root.bottom-total;
-
-            // ── Toolbar (page-size selector + row count) ──────────────────────
-            Rectangle {
-                height: root.toolbar-h;
-                background: Colors.mantle;
-                clip: true;
-
-                // Bottom separator
-                Rectangle {
-                    x: 0; y: parent.height - 1px;
-                    width: parent.width; height: 1px;
-                    background: Colors.surface0;
-                }
-
-                // Row count display (left side; only when a result is loaded)
-                if root.columns.length > 0: Text {
-                    x: 10px;
-                    y: (parent.height - self.height) / 2;
-                    text: root.row-count != root.total-rows
-                        ? @tr("{0} / {1} rows", root.row-count, root.total-rows)
-                        : @tr("{0} rows", root.row-count);
-                    color: Colors.surface2;
-                    font-size: Typography.size-md;
-                }
-
-                // Export button — opens a dropdown with CSV / JSON options
-                if root.columns.length > 0: ToolbarButton {
-                    x: parent.width - 266px;
-                    y: (parent.height - self.height) / 2;
-                    width: 80px;
-                    text: @tr("Export") + " \u{25BE}";
-                    clicked => { export-popup.show(); }
-                }
-
-                // Page-size selector: four toggle buttons aligned to the right
-                // 0 = unlimited (ALL); 100/500/1000 inject LIMIT N.
-                HorizontalLayout {
-                    x: parent.width - 178px;
-                    y: (parent.height - self.height) / 2;
-                    width: 170px;
-                    height: 20px;
-                    spacing: 2px;
-
-                    ToolbarButton {
-                        width: 38px;
-                        text: "100";
-                        active: root.page-size == 100;
-                        clicked => { root.change-page-size(100); }
-                    }
-                    ToolbarButton {
-                        width: 38px;
-                        text: "500";
-                        active: root.page-size == 500;
-                        clicked => { root.change-page-size(500); }
-                    }
-                    ToolbarButton {
-                        width: 46px;
-                        text: "1000";
-                        active: root.page-size == 1000;
-                        clicked => { root.change-page-size(1000); }
-                    }
-                    ToolbarButton {
-                        width: 38px;
-                        text: @tr("ALL");
-                        active: root.page-size == 0;
-                        clicked => { root.change-page-size(0); }
-                    }
-                }
-            }
-
-            // ── Header row ────────────────────────────────────────────────────
-            header-scroll := Flickable {
-                height:         root.row-height;
-                interactive:    false;
-                viewport-width: root.vp-w;
-                // One-way bind: follows body-vp-x so header tracks horizontal scroll.
-                viewport-x:     root.body-vp-x;
-
-                HorizontalLayout {
-                    spacing: 0;
-                    for col[i] in root.columns: Rectangle {
-                        width: root.col-widths.length > i && root.col-widths[i] > 0
-                            ? root.col-widths[i] * 1px
-                            : root.default-col-w;
-                        height: root.row-height;
-                        background: sort-hdr-ta.has-hover ? Colors.header-hover : Colors.surface0;
-                        clip: true;
-
-                        // Sort click area — covers the full cell except the 4px resize handle.
-                        sort-hdr-ta := TouchArea {
-                            width: parent.width - 4px;
-                            height: parent.height;
-                            mouse-cursor: pointer;
-                            clicked => { root.sort-col-clicked(i); }
-                        }
-
-                        Text {
-                            x: 8px;
-                            y: (parent.height - self.height) / 2;
-                            // Shrink right margin when the sort indicator is visible.
-                            width: root.sort-col == i
-                                ? parent.width - 28px
-                                : parent.width - 12px;
-                            text: col;
-                            color: Colors.text;
-                            font-size: Typography.size-base;
-                            overflow: elide;
-                        }
-
-                        // ▲/▼ sort direction indicator for the active sort column.
-                        if root.sort-col == i: Text {
-                            x: parent.width - 20px;
-                            y: (parent.height - self.height) / 2;
-                            text: root.sort-asc ? "▲" : "▼";
-                            color: Colors.blue;
-                            font-size: Typography.size-sm;
-                        }
-
-                        // ── Column resize drag handle ─────────────────────────
-                        Rectangle {
-                            x: parent.width - 4px;
-                            y: 0;
-                            width:  4px;
-                            height: parent.height;
-                            background: col-resize-ta.has-hover || col-resize-ta.pressed
-                                ? Colors.blue : Colors.surface1;
-
-                            col-resize-ta := TouchArea {
-                                mouse-cursor: ew-resize;
-                                moved => {
-                                    let cw = root.col-widths.length > i
-                                             && root.col-widths[i] > 0
-                                        ? root.col-widths[i] * 1px
-                                        : root.default-col-w;
-                                    let new-w = max(
-                                        cw + (self.mouse-x - self.pressed-x),
-                                        root.min-col-w
-                                    );
-                                    root.resize-column(i, new-w / 1px);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // ── Body (ListView for virtual scrolling) ─────────────────────────
-            Rectangle {
-                vertical-stretch: 1;
-                clip: true;
-
-                body-scroll := ListView {
-                    width:          parent.width;
-                    height:         parent.height;
-                    viewport-width: root.vp-w;
-                    // Two-way bindings: user scroll gestures update root.body-vp-y/x;
-                    // programmatic scroll (changed selected-row/col) flows the other way.
-                    viewport-y <=> root.body-vp-y;
-                    viewport-x <=> root.body-vp-x;
-
-                    for row[i] in root.rows: Rectangle {
-                        height: root.row-height;
-                        width:  root.vp-w;
-                        background: i == root.selected-row
-                            ? Colors.selection
-                            : (mod(i, 2) == 0 ? Colors.base : Colors.mantle);
-
-                        Rectangle {   // bottom border
-                            y: parent.height - 1px;
-                            width: parent.width;
-                            height: 1px;
-                            background: Colors.surface0;
-                        }
-
-                        HorizontalLayout {
-                            spacing: 0;
-                            for cell[j] in row.cells: Rectangle {
-                                width: root.col-widths.length > j
-                                       && root.col-widths[j] > 0
-                                    ? root.col-widths[j] * 1px
-                                    : root.default-col-w;
-                                height: root.row-height;
-                                clip: true;
-
-                                // Cell-mode highlight: distinct tint on the focused column.
-                                if i == root.selected-row && j == root.selected-col
-                                        && root.nav-mode == 1: Rectangle {
-                                    width:  parent.width;
-                                    height: parent.height;
-                                    background: Colors.cell-highlight;
-                                }
-
-                                Rectangle {   // right border
-                                    x: parent.width - 1px;
-                                    width: 1px;
-                                    height: parent.height;
-                                    background: Colors.surface0;
-                                }
-
-                                // NULL badge — shown only when cell.is-null is true.
-                                if cell.is-null: Rectangle {
-                                    x: 8px;
-                                    y: (parent.height - self.height) / 2;
-                                    width: 36px;
-                                    height: 16px;
-                                    border-radius: 3px;
-                                    background: Colors.surface1;
-                                    Text {
-                                        width: parent.width;
-                                        height: parent.height;
-                                        text: @tr("NULL");
-                                        color: Colors.overlay2;
-                                        font-size: Typography.size-sm;
-                                        horizontal-alignment: center;
-                                        vertical-alignment: center;
-                                    }
-                                }
-
-                                // Regular value text — shown only when the cell is not NULL.
-                                if !cell.is-null: Text {
-                                    x: 8px;
-                                    y: (parent.height - self.height) / 2;
-                                    width: parent.width - 16px;
-                                    text: cell.value;
-                                    color: i == root.selected-row ? Colors.selected-text : Colors.subtext0;
-                                    font-size: Typography.size-base;
-                                    overflow: elide;
-                                }
-
-                                TouchArea {
-                                    clicked => {
-                                        root.selected-row          = i;
-                                        root.selected-cell-value   = cell.value;
-                                        root.selected-cell-is-null = cell.is-null;
-                                        table-fs.focus();
-                                    }
-                                    pointer-event(event) => {
-                                        if (event.button == PointerEventButton.right
-                                                && event.kind == PointerEventKind.down) {
-                                            root.selected-row          = i;
-                                            root.ctx-row               = i;
-                                            root.ctx-cell-value        = cell.value;
-                                            root.ctx-cell-is-null      = cell.is-null;
-                                            root.selected-cell-value   = cell.value;
-                                            root.selected-cell-is-null = cell.is-null;
-                                            root.ctx-menu-x = clamp(
-                                                root.col-x-offset(j) * 1px + root.body-vp-x + self.mouse-x,
-                                                0,
-                                                root.width - 208px
-                                            );
-                                            root.ctx-menu-y = clamp(
-                                                root.row-height + i * root.row-height + root.body-vp-y + self.mouse-y,
-                                                0,
-                                                root.height - 96px
-                                            );
-                                            ctx-popup.show();
-                                            table-fs.focus();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Zero-row placeholder
-                if root.row-count == 0 && root.columns.length > 0: Rectangle {
-                    x: 0; y: 0;
-                    width:  parent.width;
-                    height: parent.height;
-                    Text {
-                        x: (parent.width  - self.width)  / 2;
-                        y: (parent.height - self.height) / 2;
-                        text: @tr("0 rows");
-                        color: Colors.surface2;
-                        font-size: Typography.size-lg;
-                    }
-                }
-            }
-        }
-
-        // ── Search bar ────────────────────────────────────────────────────────
-        // Always in the tree (so search-input is always reachable) but
-        // clipped to height 0 when not in search mode.
-        Rectangle {
-            x: 0;
-            y: root.height - root.filter-banner-h - root.search-bar-h;
-            width:  root.width;
-            height: root.search-bar-h;
-            background: Colors.base;
-            clip: true;
-
-            Rectangle {   // top separator
-                x: 0; y: 0;
-                width: parent.width; height: 1px;
-                background: Colors.surface1;
-            }
-
-            Text {
-                x: 10px;
-                y: (parent.height - self.height) / 2;
-                text: "/";
-                color: Colors.blue;
+                text: @tr("Query Error");
+                color: Colors.red;
                 font-size: Typography.size-lg;
                 font-weight: 700;
             }
-
-            search-input := TextInput {
-                x: 26px;
-                y: (parent.height - self.height) / 2;
-                width: parent.width - 34px;
-                text <=> root.search-query;
-                single-line: true;
+            Text {
+                text: root.error-message;
                 color: Colors.text;
-                selection-background-color: Colors.selection;
-                selection-foreground-color: Colors.selected-text;
                 font-size: Typography.size-base;
+                wrap: word-wrap;
             }
         }
-
-        // ── Filter indicator banner ───────────────────────────────────────────
-        // Shown below the search bar when a filter is active.
-        Rectangle {
-            x: 0;
-            y: root.height - root.filter-banner-h;
-            width:  root.width;
-            height: root.filter-banner-h;
-            background: Colors.filter-bg;
-            clip: true;
-
-            Rectangle {   // top separator
-                x: 0; y: 0;
-                width: parent.width; height: 1px;
-                background: Colors.filter-accent;
-            }
-
-            HorizontalLayout {
-                padding-left: 10px;
-                padding-right: 10px;
-                spacing: 6px;
-
-                Text {
-                    text: @tr("Filter:");
-                    color: Colors.blue;
-                    font-size: Typography.size-md;
-                    font-weight: 700;
-                    vertical-alignment: center;
-                }
-                Text {
-                    text: root.active-filter;
-                    color: Colors.text;
-                    font-size: Typography.size-md;
-                    vertical-alignment: center;
-                    overflow: elide;
-                    horizontal-stretch: 1;
-                }
-                Text {
-                    text: @tr("[Esc to clear]");
-                    color: Colors.surface2;
-                    font-size: Typography.size-md;
-                    vertical-alignment: center;
-                }
-            }
-        }
-
     }
 }

--- a/app/src/ui/components/result_table_body.slint
+++ b/app/src/ui/components/result_table_body.slint
@@ -1,0 +1,376 @@
+import { ListView } from "std-widgets.slint";
+import { RowData } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
+import { MenuItem } from "common.slint";
+
+// Data body: keyboard handler (FocusScope), virtualised row list, and right-click context menu.
+export component ResultTableBody inherits Rectangle {
+    clip: true;
+    preferred-height: 0;
+    min-height: 0;
+
+    in property <[string]>  columns:       [];
+    in property <[RowData]> rows:          [];
+    in property <int>       row-count:     0;
+    in property <[float]>   col-widths:    [];
+    in property <length>    default-col-w: 150px;
+    in property <length>    vp-w:          0;
+    in property <length>    row-height:    28px;
+    in property <string>    active-filter: "";
+    in property <bool>      is-loading:    false;
+    in property <string>    error-message: "";
+
+    in-out property <string> search-query: "";
+    in-out property <length> body-vp-x:    0;
+
+    out property <int>    nav-mode:              0;
+    out property <string> selected-cell-value:   "";
+    out property <bool>   selected-cell-is-null: false;
+    out property <bool>   has-focus:             table-fs.has-focus;
+
+    callback filter-rows(string);
+    callback clear-filter();
+    callback copy-cell(string);
+    callback copy-row(int);
+    callback copy-all-tsv();
+    /// Called when the keyboard "f" shortcut requests search mode; root wires to search.grab-focus().
+    callback focus-search();
+    pure callback col-x-offset(int) -> float;
+
+    public function grab-focus() {
+        table-fs.focus();
+        if (root.selected-row < 0 && root.row-count > 0) {
+            root.selected-row = 0;
+        }
+    }
+
+    property <int>    selected-row:       -1;
+    property <int>    selected-col:       -1;
+    property <length> body-vp-y:          0;
+    property <length> ctx-menu-x:         0;
+    property <length> ctx-menu-y:         0;
+    property <int>    ctx-row:            -1;
+    property <string> ctx-cell-value:     "";
+    property <bool>   ctx-cell-is-null:   false;
+    property <int>    page-rows: max(1, root.height / root.row-height);
+
+    changed rows => {
+        root.selected-row          = -1;
+        root.selected-col          = -1;
+        root.nav-mode              = 0;
+        root.selected-cell-value   = "";
+        root.selected-cell-is-null = false;
+        root.body-vp-y             = 0;
+        root.body-vp-x             = 0;
+    }
+
+    changed selected-row => {
+        if (root.selected-row >= 0) {
+            let row-top = root.selected-row * root.row-height;
+            let row-bot = row-top + root.row-height;
+            if (row-top < -root.body-vp-y) {
+                root.body-vp-y = -row-top;
+            } else if (row-bot > -root.body-vp-y + root.height) {
+                root.body-vp-y = -(row-bot - root.height);
+            }
+        }
+    }
+
+    changed selected-col => {
+        if (root.selected-col >= 0) {
+            let col-left  = root.col-x-offset(root.selected-col) * 1px;
+            let col-w     = root.col-widths.length > root.selected-col
+                            && root.col-widths[root.selected-col] > 0
+                ? root.col-widths[root.selected-col] * 1px
+                : root.default-col-w;
+            let col-right = col-left + col-w;
+            if (col-left < -root.body-vp-x) {
+                root.body-vp-x = -col-left;
+            } else if (col-right > -root.body-vp-x + root.width) {
+                root.body-vp-x = -(col-right - root.width);
+            }
+        }
+    }
+
+    table-fs := FocusScope {
+        x: 0; y: 0;
+        width: parent.width; height: parent.height;
+        focus-on-click: true;
+
+        capture-key-pressed(event) => {
+            if (root.is-loading || root.error-message != "" || root.columns.length == 0) {
+                EventResult.reject
+            } else if (root.nav-mode == 2) {
+                if (event.text == Key.Return) {
+                    root.filter-rows(root.search-query);
+                    root.nav-mode = 0;
+                    table-fs.focus();
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    root.nav-mode = 0;
+                    table-fs.focus();
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            } else if (root.nav-mode == 1) {
+                if (event.text == Key.LeftArrow) {
+                    if (root.selected-col > 0) { root.selected-col -= 1; }
+                    EventResult.accept
+                } else if (event.text == Key.RightArrow) {
+                    if (root.selected-col < root.columns.length - 1) {
+                        root.selected-col += 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Home) {
+                    root.selected-col = 0;
+                    EventResult.accept
+                } else if (event.text == Key.End) {
+                    if (root.columns.length > 0) {
+                        root.selected-col = root.columns.length - 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    root.nav-mode = 0;
+                    root.selected-col = -1;
+                    EventResult.accept
+                } else if (event.text == "c" && event.modifiers.control) {
+                    if (root.selected-row >= 0 && root.selected-col >= 0
+                            && root.selected-row < root.rows.length
+                            && root.selected-col < root.rows[root.selected-row].cells.length) {
+                        root.copy-cell(root.rows[root.selected-row].cells[root.selected-col].value);
+                    }
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            } else {
+                if (event.text == Key.UpArrow) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.selected-row > 0) {
+                        root.selected-row -= 1;
+                    } else if (root.row-count > 0) {
+                        root.selected-row = 0;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.DownArrow) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.selected-row < 0 && root.row-count > 0) {
+                        root.selected-row = 0;
+                    } else if (root.selected-row < root.row-count - 1) {
+                        root.selected-row += 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Home) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.row-count > 0) { root.selected-row = 0; }
+                    EventResult.accept
+                } else if (event.text == Key.End) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.row-count > 0) { root.selected-row = root.row-count - 1; }
+                    EventResult.accept
+                } else if (event.text == Key.PageUp) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.selected-row > 0) {
+                        root.selected-row = max(0, root.selected-row - root.page-rows);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.PageDown) {
+                    root.selected-cell-value   = "";
+                    root.selected-cell-is-null = false;
+                    if (root.selected-row < root.row-count - 1) {
+                        root.selected-row = min(
+                            root.row-count - 1, root.selected-row + root.page-rows);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Return) {
+                    if (root.selected-row >= 0 && root.columns.length > 0) {
+                        root.nav-mode = 1;
+                        root.selected-col = 0;
+                    }
+                    EventResult.accept
+                } else if (event.text == "f"
+                        && !event.modifiers.control
+                        && !event.modifiers.alt
+                        && !event.modifiers.shift) {
+                    root.search-query = "";
+                    root.nav-mode = 2;
+                    root.focus-search();
+                    EventResult.accept
+                } else if (event.text == Key.Escape) {
+                    if (root.active-filter != "") {
+                        root.clear-filter();
+                    } else {
+                        root.selected-row          = -1;
+                        root.selected-cell-value   = "";
+                        root.selected-cell-is-null = false;
+                    }
+                    EventResult.accept
+                } else if (event.text == "c" && event.modifiers.control) {
+                    if (root.selected-cell-value != "") {
+                        root.copy-cell(root.selected-cell-value);
+                    }
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            }
+        }
+
+        ctx-popup := PopupWindow {
+            x: root.ctx-menu-x;
+            y: root.ctx-menu-y;
+            width: 204px;
+            height: 90px;
+            close-policy: PopupClosePolicy.close-on-click;
+
+            Rectangle {
+                width: 204px;
+                height: 90px;
+                background: Colors.surface0;
+                border-radius: 4px;
+                border-width: 1px;
+                border-color: Colors.surface2;
+                drop-shadow-blur: 8px;
+                drop-shadow-color: Colors.shadow;
+                clip: true;
+
+                VerticalLayout {
+                    spacing: 0;
+                    MenuItem {
+                        text: @tr("Copy cell value");
+                        clicked => { root.copy-cell(root.ctx-cell-value); }
+                    }
+                    MenuItem {
+                        text: @tr("Copy row (tab-separated)");
+                        clicked => { root.copy-row(root.ctx-row); }
+                    }
+                    MenuItem {
+                        text: @tr("Copy as TSV (with headers)");
+                        clicked => { root.copy-all-tsv(); }
+                    }
+                }
+            }
+        }
+
+        body-scroll := ListView {
+            width:          parent.width;
+            height:         parent.height;
+            viewport-width: root.vp-w;
+            viewport-y <=> root.body-vp-y;
+            viewport-x <=> root.body-vp-x;
+
+            for row[i] in root.rows: Rectangle {
+                height: root.row-height;
+                width:  root.vp-w;
+                background: i == root.selected-row
+                    ? Colors.selection
+                    : (mod(i, 2) == 0 ? Colors.base : Colors.mantle);
+
+                Rectangle {
+                    y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: Colors.surface0;
+                }
+
+                HorizontalLayout {
+                    spacing: 0;
+                    for cell[j] in row.cells: Rectangle {
+                        width: root.col-widths.length > j && root.col-widths[j] > 0
+                            ? root.col-widths[j] * 1px
+                            : root.default-col-w;
+                        height: root.row-height;
+                        clip: true;
+
+                        if i == root.selected-row && j == root.selected-col
+                                && root.nav-mode == 1: Rectangle {
+                            width: parent.width; height: parent.height;
+                            background: Colors.cell-highlight;
+                        }
+
+                        Rectangle {
+                            x: parent.width - 1px;
+                            width: 1px; height: parent.height;
+                            background: Colors.surface0;
+                        }
+
+                        if cell.is-null: Rectangle {
+                            x: 8px;
+                            y: (parent.height - self.height) / 2;
+                            width: 36px; height: 16px;
+                            border-radius: 3px;
+                            background: Colors.surface1;
+                            Text {
+                                width: parent.width; height: parent.height;
+                                text: @tr("NULL");
+                                color: Colors.overlay2;
+                                font-size: Typography.size-sm;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                            }
+                        }
+
+                        if !cell.is-null: Text {
+                            x: 8px;
+                            y: (parent.height - self.height) / 2;
+                            width: parent.width - 16px;
+                            text: cell.value;
+                            color: i == root.selected-row ? Colors.selected-text : Colors.subtext0;
+                            font-size: Typography.size-base;
+                            overflow: elide;
+                        }
+
+                        TouchArea {
+                            clicked => {
+                                root.selected-row          = i;
+                                root.selected-cell-value   = cell.value;
+                                root.selected-cell-is-null = cell.is-null;
+                                table-fs.focus();
+                            }
+                            pointer-event(event) => {
+                                if (event.button == PointerEventButton.right
+                                        && event.kind == PointerEventKind.down) {
+                                    root.selected-row          = i;
+                                    root.ctx-row               = i;
+                                    root.ctx-cell-value        = cell.value;
+                                    root.ctx-cell-is-null      = cell.is-null;
+                                    root.selected-cell-value   = cell.value;
+                                    root.selected-cell-is-null = cell.is-null;
+                                    root.ctx-menu-x = clamp(
+                                        root.col-x-offset(j) * 1px + root.body-vp-x + self.mouse-x,
+                                        0,
+                                        root.width - 208px
+                                    );
+                                    root.ctx-menu-y = clamp(
+                                        i * root.row-height + root.body-vp-y + self.mouse-y,
+                                        0,
+                                        root.height - 96px
+                                    );
+                                    ctx-popup.show();
+                                    table-fs.focus();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if root.row-count == 0 && root.columns.length > 0: Rectangle {
+            x: 0; y: 0;
+            width: parent.width; height: parent.height;
+            Text {
+                x: (parent.width  - self.width)  / 2;
+                y: (parent.height - self.height) / 2;
+                text: @tr("0 rows");
+                color: Colors.surface2;
+                font-size: Typography.size-lg;
+            }
+        }
+    }
+}

--- a/app/src/ui/components/result_table_header.slint
+++ b/app/src/ui/components/result_table_header.slint
@@ -1,0 +1,82 @@
+import { Colors, Typography } from "../theme.slint";
+
+// Column header row with sort indicators and drag-to-resize handles.
+export component ResultTableHeader inherits Flickable {
+    interactive: false;
+    viewport-width: root.vp-w;
+    viewport-x: root.body-vp-x;
+
+    in property <[string]> columns:       [];
+    in property <[float]>  col-widths:    [];
+    in property <int>      sort-col:      -1;
+    in property <bool>     sort-asc:      true;
+    in property <length>   default-col-w: 150px;
+    in property <length>   min-col-w:     48px;
+    in property <length>   vp-w:          0;
+    in property <length>   body-vp-x:     0;
+
+    callback sort-col-clicked(int);
+    callback resize-column(int, float);
+
+    HorizontalLayout {
+        spacing: 0;
+        for col[i] in root.columns: Rectangle {
+            width: root.col-widths.length > i && root.col-widths[i] > 0
+                ? root.col-widths[i] * 1px
+                : root.default-col-w;
+            height: root.height;
+            background: sort-hdr-ta.has-hover ? Colors.header-hover : Colors.surface0;
+            clip: true;
+
+            sort-hdr-ta := TouchArea {
+                width: parent.width - 4px;
+                height: parent.height;
+                mouse-cursor: pointer;
+                clicked => { root.sort-col-clicked(i); }
+            }
+
+            Text {
+                x: 8px;
+                y: (parent.height - self.height) / 2;
+                width: root.sort-col == i
+                    ? parent.width - 28px
+                    : parent.width - 12px;
+                text: col;
+                color: Colors.text;
+                font-size: Typography.size-base;
+                overflow: elide;
+            }
+
+            if root.sort-col == i: Text {
+                x: parent.width - 20px;
+                y: (parent.height - self.height) / 2;
+                text: root.sort-asc ? "▲" : "▼";
+                color: Colors.blue;
+                font-size: Typography.size-sm;
+            }
+
+            Rectangle {
+                x: parent.width - 4px;
+                y: 0;
+                width: 4px;
+                height: parent.height;
+                background: col-resize-ta.has-hover || col-resize-ta.pressed
+                    ? Colors.blue : Colors.surface1;
+
+                col-resize-ta := TouchArea {
+                    mouse-cursor: ew-resize;
+                    moved => {
+                        let cw = root.col-widths.length > i && root.col-widths[i] > 0
+                            ? root.col-widths[i] * 1px
+                            : root.default-col-w;
+                        let new-w = max(
+                            cw + (self.mouse-x - self.pressed-x),
+                            root.min-col-w
+                        );
+                        root.resize-column(i, new-w / 1px);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/result_table_search.slint
+++ b/app/src/ui/components/result_table_search.slint
@@ -1,0 +1,98 @@
+import { Colors, Typography } from "../theme.slint";
+
+// Search bar (shown when in search mode) + active-filter indicator banner.
+export component ResultTableSearch inherits Rectangle {
+    clip: true;
+
+    in property <string>     active-filter:  "";
+    in property <bool>       in-search-mode: false;
+    in-out property <string> search-query:   "";
+
+    out property <bool>   has-focus:    search-input.has-focus;
+    out property <length> total-height: search-bar-h + filter-banner-h;
+
+    public function grab-focus() { search-input.focus(); }
+
+    property <length> search-bar-h:    root.in-search-mode ? 32px : 0px;
+    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
+
+    // Search bar
+    Rectangle {
+        x: 0; y: 0;
+        width: parent.width;
+        height: root.search-bar-h;
+        background: Colors.base;
+        clip: true;
+
+        Rectangle {
+            x: 0; y: 0;
+            width: parent.width; height: 1px;
+            background: Colors.surface1;
+        }
+
+        Text {
+            x: 10px;
+            y: (parent.height - self.height) / 2;
+            text: "/";
+            color: Colors.blue;
+            font-size: Typography.size-lg;
+            font-weight: 700;
+        }
+
+        search-input := TextInput {
+            x: 26px;
+            y: (parent.height - self.height) / 2;
+            width: parent.width - 34px;
+            text <=> root.search-query;
+            single-line: true;
+            color: Colors.text;
+            selection-background-color: Colors.selection;
+            selection-foreground-color: Colors.selected-text;
+            font-size: Typography.size-base;
+        }
+    }
+
+    // Active-filter indicator banner
+    Rectangle {
+        x: 0;
+        y: root.search-bar-h;
+        width: parent.width;
+        height: root.filter-banner-h;
+        background: Colors.filter-bg;
+        clip: true;
+
+        Rectangle {
+            x: 0; y: 0;
+            width: parent.width; height: 1px;
+            background: Colors.filter-accent;
+        }
+
+        HorizontalLayout {
+            padding-left: 10px;
+            padding-right: 10px;
+            spacing: 6px;
+
+            Text {
+                text: @tr("Filter:");
+                color: Colors.blue;
+                font-size: Typography.size-md;
+                font-weight: 700;
+                vertical-alignment: center;
+            }
+            Text {
+                text: root.active-filter;
+                color: Colors.text;
+                font-size: Typography.size-md;
+                vertical-alignment: center;
+                overflow: elide;
+                horizontal-stretch: 1;
+            }
+            Text {
+                text: @tr("[Esc to clear]");
+                color: Colors.surface2;
+                font-size: Typography.size-md;
+                vertical-alignment: center;
+            }
+        }
+    }
+}

--- a/app/src/ui/components/result_table_toolbar.slint
+++ b/app/src/ui/components/result_table_toolbar.slint
@@ -1,0 +1,97 @@
+import { Colors, Typography } from "../theme.slint";
+import { ToolbarButton, MenuItem } from "common.slint";
+
+// Toolbar strip for the result table: row-count display, Export button, page-size selector.
+export component ResultTableToolbar inherits Rectangle {
+    height: 28px;
+    background: Colors.mantle;
+    clip: true;
+
+    in property <int> col-count:  0;
+    in property <int> row-count:  0;
+    in property <int> total-rows: 0;
+    in property <int> page-size:  500;
+
+    callback change-page-size(int);
+    callback export-csv();
+    callback export-json();
+
+    Rectangle {
+        x: 0; y: parent.height - 1px;
+        width: parent.width; height: 1px;
+        background: Colors.surface0;
+    }
+
+    if root.col-count > 0: Text {
+        x: 10px;
+        y: (parent.height - self.height) / 2;
+        text: root.row-count != root.total-rows
+            ? @tr("{0} / {1} rows", root.row-count, root.total-rows)
+            : @tr("{0} rows", root.row-count);
+        color: Colors.surface2;
+        font-size: Typography.size-md;
+    }
+
+    if root.col-count > 0: ToolbarButton {
+        x: parent.width - 266px;
+        y: (parent.height - self.height) / 2;
+        width: 80px;
+        text: @tr("Export") + " \u{25BE}";
+        clicked => { export-popup.show(); }
+    }
+
+    HorizontalLayout {
+        x: parent.width - 178px;
+        y: (parent.height - self.height) / 2;
+        width: 170px;
+        height: 20px;
+        spacing: 2px;
+
+        ToolbarButton {
+            width: 38px; text: "100";
+            active: root.page-size == 100;
+            clicked => { root.change-page-size(100); }
+        }
+        ToolbarButton {
+            width: 38px; text: "500";
+            active: root.page-size == 500;
+            clicked => { root.change-page-size(500); }
+        }
+        ToolbarButton {
+            width: 46px; text: "1000";
+            active: root.page-size == 1000;
+            clicked => { root.change-page-size(1000); }
+        }
+        ToolbarButton {
+            width: 38px; text: @tr("ALL");
+            active: root.page-size == 0;
+            clicked => { root.change-page-size(0); }
+        }
+    }
+
+    export-popup := PopupWindow {
+        x: root.width - 266px;
+        y: root.height + 2px;
+        width: 120px;
+        height: 60px;
+        close-policy: PopupClosePolicy.close-on-click;
+
+        Rectangle {
+            width: 120px;
+            height: 60px;
+            background: Colors.surface0;
+            border-radius: 4px;
+            border-width: 1px;
+            border-color: Colors.surface2;
+            drop-shadow-blur: 8px;
+            drop-shadow-color: Colors.shadow;
+            clip: true;
+
+            VerticalLayout {
+                spacing: 0;
+                MenuItem { text: @tr("Export CSV");  clicked => { root.export-csv(); } }
+                MenuItem { text: @tr("Export JSON"); clicked => { root.export-json(); } }
+            }
+        }
+    }
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -16,6 +16,32 @@ const COMPLETION_DEBOUNCE_MS: u64 = 300;
 const ERROR_TRUNCATION_CHARS: usize = 80;
 const DEFAULT_COLUMN_WIDTH: f32 = 150.0;
 
+// ── UI-thread helpers ────────────────────────────────────────────────────────
+
+/// Upgrade `weak`, run `f` against the UiState global; no-op if window is gone.
+fn with_ui<F: FnOnce(&crate::UiState)>(weak: &slint::Weak<crate::AppWindow>, f: F) {
+    let Some(window) = weak.upgrade() else {
+        return;
+    };
+    let ui = window.global::<crate::UiState>();
+    f(&ui);
+}
+
+/// Fire-and-forget: send `cmd` on `tx` from a new tokio task.
+fn send_cmd(tx: &mpsc::Sender<Command>, cmd: Command) {
+    let tx = tx.clone(); // clone required: tokio::spawn needs 'static
+    tokio::spawn(async move {
+        let _ = tx.send(cmd).await;
+    });
+}
+
+/// Post a status-bar update to the UI thread from any thread.
+fn set_status(weak: slint::Weak<crate::AppWindow>, msg: String) {
+    let _ = slint::invoke_from_event_loop(move || {
+        with_ui(&weak, |ui| ui.set_status_message(msg.into()));
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Original query result — retained for client-side filtering
 // ---------------------------------------------------------------------------
@@ -353,78 +379,68 @@ impl UI {
         };
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            let model = Rc::new(slint::VecModel::from(entries));
-            ui.set_connection_list(model.into());
-            ui.set_active_connection_id(id.into());
-            ui.set_show_connection_form(false);
-            ui.set_form_testing(false);
-            ui.set_form_status("".into());
-            ui.set_error_message("".into());
-            ui.set_status_connection(status_conn.into());
-            ui.set_sidebar_tree(Rc::new(slint::VecModel::from(sidebar_nodes)).into());
-            ui.set_sidebar_loading(true);
+            with_ui(&ww, move |ui| {
+                let model = Rc::new(slint::VecModel::from(entries));
+                ui.set_connection_list(model.into());
+                ui.set_active_connection_id(id.into());
+                ui.set_show_connection_form(false);
+                ui.set_form_testing(false);
+                ui.set_form_status("".into());
+                ui.set_error_message("".into());
+                ui.set_status_connection(status_conn.into());
+                ui.set_sidebar_tree(Rc::new(slint::VecModel::from(sidebar_nodes)).into());
+                ui.set_sidebar_loading(true);
+            });
         });
     }
 
     fn handle_test_ok(ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_form_testing(false);
-            ui.set_form_test_ok(true);
-            ui.set_test_result_ok(true);
-            ui.set_test_result_message("".into());
-            ui.set_show_test_result_popup(true);
+            with_ui(&ww, |ui| {
+                ui.set_form_testing(false);
+                ui.set_form_test_ok(true);
+                ui.set_test_result_ok(true);
+                ui.set_test_result_message("".into());
+                ui.set_show_test_result_popup(true);
+            });
         });
     }
 
     fn handle_test_failed(msg: String, ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_form_testing(false);
-            ui.set_form_test_ok(false);
-            ui.set_test_result_ok(false);
-            ui.set_test_result_message(msg.into());
-            ui.set_show_test_result_popup(true);
+            with_ui(&ww, move |ui| {
+                ui.set_form_testing(false);
+                ui.set_form_test_ok(false);
+                ui.set_test_result_ok(false);
+                ui.set_test_result_message(msg.into());
+                ui.set_show_test_result_popup(true);
+            });
         });
     }
 
     fn handle_connect_error(msg: String, ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_form_testing(false);
-            ui.set_form_status(msg.clone().into());
-            ui.set_status_message(format!("Connection failed: {msg}").into());
-            ui.set_sidebar_loading(false);
+            with_ui(&ww, |ui| {
+                ui.set_form_testing(false);
+                ui.set_form_status(msg.clone().into());
+                ui.set_status_message(format!("Connection failed: {msg}").into());
+                ui.set_sidebar_loading(false);
+            });
         });
     }
 
     fn handle_query_started(ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_is_loading(true);
-            ui.set_error_message("".into());
-            ui.set_status_message("Running\u{2026}".into());
-            ui.set_result_panel_open(true);
+            with_ui(&ww, |ui| {
+                ui.set_is_loading(true);
+                ui.set_error_message("".into());
+                ui.set_status_message("Running\u{2026}".into());
+                ui.set_result_panel_open(true);
+            });
         });
     }
 
@@ -451,38 +467,34 @@ impl UI {
         }
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_is_loading(false);
-            ui.set_result_active_filter("".into());
-            ui.set_result_sort_col(-1);
-            ui.set_result_sort_asc(true);
-            let col_model = Rc::new(slint::VecModel::from(columns));
-            ui.set_result_columns(col_model.into());
-            let rows: Vec<crate::RowData> = raw_rows.into_iter().map(rows_to_ui).collect();
-            ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
-            ui.set_result_row_count(row_count);
-            ui.set_result_total_rows(row_count);
-            let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
-            let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
-            ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
-            ui.set_result_total_col_width(total_w);
-            ui.set_status_message(format!("{exec_ms} ms  ·  {row_count} rows").into());
-            ui.set_result_panel_open(true);
+            with_ui(&ww, move |ui| {
+                ui.set_is_loading(false);
+                ui.set_result_active_filter("".into());
+                ui.set_result_sort_col(-1);
+                ui.set_result_sort_asc(true);
+                let col_model = Rc::new(slint::VecModel::from(columns));
+                ui.set_result_columns(col_model.into());
+                let rows: Vec<crate::RowData> = raw_rows.into_iter().map(rows_to_ui).collect();
+                ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                ui.set_result_row_count(row_count);
+                ui.set_result_total_rows(row_count);
+                let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
+                let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
+                ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
+                ui.set_result_total_col_width(total_w);
+                ui.set_status_message(format!("{exec_ms} ms  ·  {row_count} rows").into());
+                ui.set_result_panel_open(true);
+            });
         });
     }
 
     fn handle_query_cancelled(ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_is_loading(false);
-            ui.set_status_message("Cancelled".into());
+            with_ui(&ww, |ui| {
+                ui.set_is_loading(false);
+                ui.set_status_message("Cancelled".into());
+            });
         });
     }
 
@@ -496,28 +508,24 @@ impl UI {
             .collect::<String>();
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_is_loading(false);
-            ui.set_form_status(msg.clone().into());
-            ui.set_form_testing(false);
-            ui.set_error_message(msg.into());
-            ui.set_status_message(format!("Error: {summary}").into());
-            ui.set_result_panel_open(true);
+            with_ui(&ww, move |ui| {
+                ui.set_is_loading(false);
+                ui.set_form_status(msg.clone().into());
+                ui.set_form_testing(false);
+                ui.set_error_message(msg.into());
+                ui.set_status_message(format!("Error: {summary}").into());
+                ui.set_result_panel_open(true);
+            });
         });
     }
 
     fn handle_disconnected(id: String, ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_status_message(format!("Disconnected: {id}").into());
-            ui.set_status_connection("Not connected".into());
+            with_ui(&ww, move |ui| {
+                ui.set_status_message(format!("Disconnected: {id}").into());
+                ui.set_status_connection("Not connected".into());
+            });
         });
     }
 
@@ -544,36 +552,30 @@ impl UI {
         };
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
-            ui.set_sidebar_loading(false);
+            with_ui(&ww, move |ui| {
+                ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                ui.set_sidebar_loading(false);
+            });
         });
     }
 
     fn handle_metadata_fetch_failed(msg: String, ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            ui.set_sidebar_loading(false);
-            ui.set_status_message(format!("Metadata unavailable: {msg}").into());
+            with_ui(&ww, move |ui| {
+                ui.set_sidebar_loading(false);
+                ui.set_status_message(format!("Metadata unavailable: {msg}").into());
+            });
         });
     }
 
     fn handle_insert_text(text: String, ww: slint::Weak<crate::AppWindow>) {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            let current = ui.get_editor_text().to_string();
-            ui.set_editor_text(append_editor_text(&current, &text).into());
+            with_ui(&ww, move |ui| {
+                let current = ui.get_editor_text().to_string();
+                ui.set_editor_text(append_editor_text(&current, &text).into());
+            });
         });
     }
 
@@ -592,18 +594,16 @@ impl UI {
             .collect();
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = ww.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            if rows.is_empty() {
-                ui.set_completion_visible(false);
-            } else {
-                let model = Rc::new(slint::VecModel::from(rows));
-                ui.set_completion_items(model.into());
-                ui.set_completion_selected(0);
-                ui.set_completion_visible(true);
-            }
+            with_ui(&ww, move |ui| {
+                if rows.is_empty() {
+                    ui.set_completion_visible(false);
+                } else {
+                    let model = Rc::new(slint::VecModel::from(rows));
+                    ui.set_completion_items(model.into());
+                    ui.set_completion_selected(0);
+                    ui.set_completion_visible(true);
+                }
+            });
         });
     }
 
@@ -622,25 +622,23 @@ impl UI {
         {
             let window_weak = window.as_weak();
             ui_state.on_open_connection_form(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                ui.set_form_name("".into());
-                ui.set_form_conn_string("".into());
-                ui.set_form_host("".into());
-                ui.set_form_port("".into());
-                ui.set_form_user("".into());
-                ui.set_form_password("".into());
-                ui.set_form_database("".into());
-                ui.set_form_status("".into());
-                ui.set_form_testing(false);
-                ui.set_form_tab_index(0);
-                ui.set_form_db_type(0);
-                ui.set_form_test_ok(false);
-                ui.set_show_test_result_popup(false);
-                ui.set_show_add_confirm_popup(false);
-                ui.set_show_connection_form(true);
+                with_ui(&window_weak, |ui| {
+                    ui.set_form_name("".into());
+                    ui.set_form_conn_string("".into());
+                    ui.set_form_host("".into());
+                    ui.set_form_port("".into());
+                    ui.set_form_user("".into());
+                    ui.set_form_password("".into());
+                    ui.set_form_database("".into());
+                    ui.set_form_status("".into());
+                    ui.set_form_testing(false);
+                    ui.set_form_tab_index(0);
+                    ui.set_form_db_type(0);
+                    ui.set_form_test_ok(false);
+                    ui.set_show_test_result_popup(false);
+                    ui.set_show_add_confirm_popup(false);
+                    ui.set_show_connection_form(true);
+                });
             });
         }
 
@@ -668,11 +666,7 @@ impl UI {
                                 .password_encrypted
                                 .as_ref()
                                 .and_then(|enc| crypto::decrypt(enc, &enc_key).ok());
-                            // clone required: tokio::spawn requires 'static
-                            let tx_cmd = tx_cmd.clone();
-                            tokio::spawn(async move {
-                                let _ = tx_cmd.send(Command::Connect(conn, password)).await;
-                            });
+                            send_cmd(&tx_cmd, Command::Connect(conn, password));
                         }
                         // Return early — Event::Connected will auto-expand the newly active node.
                         return;
@@ -698,12 +692,9 @@ impl UI {
                         .unwrap_or_default();
                     build_sidebar_tree(&connections, &active_id, &sb.metadata, &sb.expanded)
                 };
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                window
-                    .global::<crate::UiState>()
-                    .set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                with_ui(&window_weak, |ui| {
+                    ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                });
             });
         }
 
@@ -715,18 +706,11 @@ impl UI {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui_state.on_table_double_clicked(move |name| {
                 let sql = format!("SELECT * FROM {}", name);
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let current = ui.get_editor_text().to_string();
-                ui.set_editor_text(append_editor_text(&current, &sql).into());
-                // Auto-execute so the result is visible immediately.
-                let tx_cmd = tx_cmd.clone(); // clone required: tokio::spawn requires 'static
-                let sql_run = sql.clone();
-                tokio::spawn(async move {
-                    let _ = tx_cmd.send(Command::RunQuery(sql_run)).await;
+                with_ui(&window_weak, |ui| {
+                    let current = ui.get_editor_text().to_string();
+                    ui.set_editor_text(append_editor_text(&current, &sql).into());
                 });
+                send_cmd(&tx_cmd, Command::RunQuery(sql));
             });
         }
     }
@@ -744,12 +728,7 @@ impl UI {
         {
             let window_weak = window.as_weak();
             ui_state.on_close_connection_form(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                window
-                    .global::<crate::UiState>()
-                    .set_show_connection_form(false);
+                with_ui(&window_weak, |ui| ui.set_show_connection_form(false));
             });
         }
 
@@ -759,19 +738,12 @@ impl UI {
             // clone required: callback closure needs owned tx_cmd
             let tx_cmd = tx_cmd.clone();
             ui_state.on_test_connection(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                ui.set_form_testing(true);
-                ui.set_form_status("".into());
-                ui.set_form_test_ok(false); // reset stale test state
-
-                let (conn, password) = build_conn_from_form(&ui, &enc_key);
-                // clone required: tokio::spawn requires 'static
-                let tx_cmd = tx_cmd.clone();
-                tokio::spawn(async move {
-                    let _ = tx_cmd.send(Command::TestConnection(conn, password)).await;
+                with_ui(&window_weak, |ui| {
+                    ui.set_form_testing(true);
+                    ui.set_form_status("".into());
+                    ui.set_form_test_ok(false);
+                    let (conn, password) = build_conn_from_form(ui, &enc_key);
+                    send_cmd(&tx_cmd, Command::TestConnection(conn, password));
                 });
             });
         }
@@ -782,23 +754,15 @@ impl UI {
             // clone required: callback closure needs owned tx_cmd
             let tx_cmd = tx_cmd.clone();
             ui_state.on_add_connection(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                if ui.get_form_test_ok() {
-                    // Test was successful — add directly
-                    ui.set_form_testing(true);
-                    let (conn, password) = build_conn_from_form(&ui, &enc_key);
-                    // clone required: tokio::spawn requires 'static
-                    let tx_cmd = tx_cmd.clone();
-                    tokio::spawn(async move {
-                        let _ = tx_cmd.send(Command::Connect(conn, password)).await;
-                    });
-                } else {
-                    // Not tested or failed — show confirmation first
-                    ui.set_show_add_confirm_popup(true);
-                }
+                with_ui(&window_weak, |ui| {
+                    if ui.get_form_test_ok() {
+                        ui.set_form_testing(true);
+                        let (conn, password) = build_conn_from_form(ui, &enc_key);
+                        send_cmd(&tx_cmd, Command::Connect(conn, password));
+                    } else {
+                        ui.set_show_add_confirm_popup(true);
+                    }
+                });
             });
         }
 
@@ -808,17 +772,11 @@ impl UI {
             // clone required: callback closure needs owned tx_cmd
             let tx_cmd = tx_cmd.clone();
             ui_state.on_confirm_add_connection(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                ui.set_show_add_confirm_popup(false);
-                ui.set_form_testing(true);
-                let (conn, password) = build_conn_from_form(&ui, &enc_key);
-                // clone required: tokio::spawn requires 'static
-                let tx_cmd = tx_cmd.clone();
-                tokio::spawn(async move {
-                    let _ = tx_cmd.send(Command::Connect(conn, password)).await;
+                with_ui(&window_weak, |ui| {
+                    ui.set_show_add_confirm_popup(false);
+                    ui.set_form_testing(true);
+                    let (conn, password) = build_conn_from_form(ui, &enc_key);
+                    send_cmd(&tx_cmd, Command::Connect(conn, password));
                 });
             });
         }
@@ -827,12 +785,7 @@ impl UI {
         {
             let window_weak = window.as_weak();
             ui_state.on_dismiss_test_popup(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                window
-                    .global::<crate::UiState>()
-                    .set_show_test_result_popup(false);
+                with_ui(&window_weak, |ui| ui.set_show_test_result_popup(false));
             });
         }
 
@@ -840,12 +793,7 @@ impl UI {
         {
             let window_weak = window.as_weak();
             ui_state.on_dismiss_add_confirm(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                window
-                    .global::<crate::UiState>()
-                    .set_show_add_confirm_popup(false);
+                with_ui(&window_weak, |ui| ui.set_show_add_confirm_popup(false));
             });
         }
     }
@@ -912,20 +860,13 @@ impl UI {
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui.on_run_query(move |sql| {
-                let sql = sql.to_string();
-                let tx_cmd = tx_cmd.clone(); // clone required: tokio::spawn requires 'static
-                tokio::spawn(async move {
-                    let _ = tx_cmd.send(Command::RunQuery(sql)).await;
-                });
+                send_cmd(&tx_cmd, Command::RunQuery(sql.to_string()));
             });
         }
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui.on_cancel_query(move || {
-                let tx_cmd = tx_cmd.clone(); // clone required: tokio::spawn requires 'static
-                tokio::spawn(async move {
-                    let _ = tx_cmd.send(Command::CancelQuery).await;
-                });
+                send_cmd(&tx_cmd, Command::CancelQuery);
             });
         }
     }
@@ -954,13 +895,8 @@ impl UI {
                     slint::TimerMode::SingleShot,
                     Duration::from_millis(COMPLETION_DEBOUNCE_MS),
                     move || {
-                        let tx = tx.clone(); // clone required: tokio::spawn
                         let sql = sql.clone();
-                        tokio::spawn(async move {
-                            let _ = tx
-                                .send(Command::FetchCompletion(sql, cursor_pos as usize))
-                                .await;
-                        });
+                        send_cmd(&tx, Command::FetchCompletion(sql, cursor_pos as usize));
                     },
                 );
                 *debounce.borrow_mut() = Some(timer);
@@ -970,13 +906,10 @@ impl UI {
         // Immediate path (Ctrl+Space → FetchCompletion without delay).
         {
             ui.on_trigger_completion(move |sql, cursor_pos| {
-                let tx = tx_cmd.clone(); // clone required: tokio::spawn
-                let sql = sql.to_string();
-                tokio::spawn(async move {
-                    let _ = tx
-                        .send(Command::FetchCompletion(sql, cursor_pos as usize))
-                        .await;
-                });
+                send_cmd(
+                    &tx_cmd,
+                    Command::FetchCompletion(sql.to_string(), cursor_pos as usize),
+                );
             });
         }
     }
@@ -986,128 +919,127 @@ impl UI {
         let window_weak = window.as_weak(); // clone required: on_accept_completion closure
         ui.on_accept_completion(
             move |insert_text, cursor_pos, cursor_offset_val, table_name| {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let current = ui.get_editor_text().to_string();
-                let pos = (cursor_pos as usize).min(current.len());
-                let mut prefix_start = find_prefix_start(&current, pos);
-                // When accepting a disambiguated column candidate (table_name is set), the
-                // user may have typed "colname tableprefix" with a space.  Extend the
-                // replacement range backward to cover the entire "colname tableprefix" so the
-                // insertion replaces both words, not just the current word after the space.
-                let table_name_str = table_name.to_string();
-                if !table_name_str.is_empty() {
-                    let before_prefix = &current[..prefix_start];
-                    let pattern = format!("{} ", insert_text.as_str());
-                    if before_prefix.ends_with(&pattern) {
-                        let extended = prefix_start - pattern.len();
-                        let at_boundary = extended == 0
-                            || matches!(
-                                current.as_bytes().get(extended - 1),
-                                Some(b' ') | Some(b'\t') | Some(b'\n')
-                            );
-                        if at_boundary {
-                            prefix_start = extended;
+                with_ui(&window_weak, move |ui| {
+                    let current = ui.get_editor_text().to_string();
+                    let pos = (cursor_pos as usize).min(current.len());
+                    let mut prefix_start = find_prefix_start(&current, pos);
+                    // When accepting a disambiguated column candidate (table_name is set), the
+                    // user may have typed "colname tableprefix" with a space.  Extend the
+                    // replacement range backward to cover the entire "colname tableprefix" so the
+                    // insertion replaces both words, not just the current word after the space.
+                    let table_name_str = table_name.to_string();
+                    if !table_name_str.is_empty() {
+                        let before_prefix = &current[..prefix_start];
+                        let pattern = format!("{} ", insert_text.as_str());
+                        if before_prefix.ends_with(&pattern) {
+                            let extended = prefix_start - pattern.len();
+                            let at_boundary = extended == 0
+                                || matches!(
+                                    current.as_bytes().get(extended - 1),
+                                    Some(b' ') | Some(b'\t') | Some(b'\n')
+                                );
+                            if at_boundary {
+                                prefix_start = extended;
+                            }
                         }
                     }
-                }
 
-                // If the accepted text is a SQL keyword (FROM, WHERE, AND …), treat it as
-                // a plain insertion even inside a SELECT list — no comma should be added.
-                let is_keyword = wf_completion::parser::is_sql_keyword(insert_text.as_str());
-                let in_select = !is_keyword && wf_completion::parser::in_select_list(&current, pos);
+                    // If the accepted text is a SQL keyword (FROM, WHERE, AND …), treat it as
+                    // a plain insertion even inside a SELECT list — no comma should be added.
+                    let is_keyword = wf_completion::parser::is_sql_keyword(insert_text.as_str());
+                    let in_select =
+                        !is_keyword && wf_completion::parser::in_select_list(&current, pos);
 
-                let (new_text, new_cursor): (String, i32) = if in_select {
-                    // In SELECT list: auto-insert ", " between columns.
-                    let trimmed = current[..prefix_start].trim_end_matches([' ', '\t']);
-                    let last_char = trimmed.chars().last();
-                    let last_word_start = trimmed
-                        .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-                        .map(|i| i + 1)
-                        .unwrap_or(0);
-                    let last_word = trimmed[last_word_start..].to_ascii_uppercase();
-                    let needs_comma = !matches!(last_char, None | Some(',') | Some('('))
-                        && !matches!(last_word.as_str(), "SELECT" | "DISTINCT");
-                    if needs_comma {
-                        let text = format!("{}, {}{}", trimmed, insert_text, &current[pos..]);
-                        let cur = (trimmed.len() + 2 + insert_text.len()) as i32;
-                        (text, cur)
+                    let (new_text, new_cursor): (String, i32) = if in_select {
+                        // In SELECT list: auto-insert ", " between columns.
+                        let trimmed = current[..prefix_start].trim_end_matches([' ', '\t']);
+                        let last_char = trimmed.chars().last();
+                        let last_word_start = trimmed
+                            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+                            .map(|i| i + 1)
+                            .unwrap_or(0);
+                        let last_word = trimmed[last_word_start..].to_ascii_uppercase();
+                        let needs_comma = !matches!(last_char, None | Some(',') | Some('('))
+                            && !matches!(last_word.as_str(), "SELECT" | "DISTINCT");
+                        if needs_comma {
+                            let text = format!("{}, {}{}", trimmed, insert_text, &current[pos..]);
+                            let cur = (trimmed.len() + 2 + insert_text.len()) as i32;
+                            (text, cur)
+                        } else {
+                            let text = format!(
+                                "{}{}{}",
+                                &current[..prefix_start],
+                                insert_text,
+                                &current[pos..]
+                            );
+                            let cur = (prefix_start + insert_text.len()) as i32;
+                            (text, cur)
+                        }
                     } else {
+                        // Determine whether to replace the typed prefix or insert at cursor.
+                        // When the accepted text is unrelated to the prefix (e.g. user finished
+                        // typing "users" and now accepts a NextClause keyword like "WHERE"),
+                        // insert at the cursor position with a leading space rather than
+                        // overwriting the table/column name.
+                        let prefix_word = &current[prefix_start..pos];
+                        let (actual_start, add_leading_space) = if prefix_word.is_empty() {
+                            // Cursor is at whitespace or string start — plain insert.
+                            (pos, false)
+                        } else if insert_text
+                            .as_str()
+                            .to_ascii_uppercase()
+                            .starts_with(&prefix_word.to_ascii_uppercase())
+                        {
+                            // Prefix is a partial match of insert_text — replace it.
+                            (prefix_start, false)
+                        } else {
+                            // Prefix is unrelated (e.g. "users" + "WHERE") — insert at cursor.
+                            let needs_space =
+                                !current[..pos].ends_with(|c: char| c.is_ascii_whitespace());
+                            (pos, needs_space)
+                        };
+                        let leading = if add_leading_space { " " } else { "" };
                         let text = format!(
-                            "{}{}{}",
-                            &current[..prefix_start],
+                            "{}{}{}{}",
+                            &current[..actual_start],
+                            leading,
                             insert_text,
                             &current[pos..]
                         );
-                        let cur = (prefix_start + insert_text.len()) as i32;
+                        let cur = if cursor_offset_val > 0 {
+                            actual_start as i32 + add_leading_space as i32 + cursor_offset_val
+                        } else {
+                            (actual_start + leading.len() + insert_text.len()) as i32
+                        };
                         (text, cur)
+                    };
+
+                    // Auto-append FROM <table> when a column with a known table was accepted
+                    // inside a SELECT list that has no FROM clause yet.
+                    let appended_from =
+                        in_select && !table_name_str.is_empty() && !sql_has_from(&current);
+                    let (final_text, final_cursor) = if appended_from {
+                        let appended = format!("{} FROM {}", new_text.trim_end(), table_name_str);
+                        let cur = appended.len() as i32;
+                        (appended, cur)
+                    } else {
+                        (new_text, new_cursor)
+                    };
+
+                    // inserted text, e.g. between the quotes in `''`).
+                    let at_end = final_cursor as usize == final_text.len();
+                    ui.set_editor_text(final_text.clone().into());
+                    ui.set_editor_cursor_target(final_cursor);
+                    // Re-trigger only when the cursor is at end of inserted text AND the text
+                    // does not end at a syntactically terminal expression (IS NULL, TRUE, FALSE,
+                    // a string/numeric literal, ASC/DESC).  Terminal positions use a virtual
+                    // trailing space so the parser sees the next context without polluting the
+                    // editor with a stale space the user would have to delete before typing `;`.
+                    if cursor_offset_val == 0 && at_end && !is_terminal_expression(&final_text) {
+                        let trigger_sql = format!("{} ", final_text);
+                        ui.invoke_trigger_completion(trigger_sql.into(), final_cursor + 1);
                     }
-                } else {
-                    // Determine whether to replace the typed prefix or insert at cursor.
-                    // When the accepted text is unrelated to the prefix (e.g. user finished
-                    // typing "users" and now accepts a NextClause keyword like "WHERE"),
-                    // insert at the cursor position with a leading space rather than
-                    // overwriting the table/column name.
-                    let prefix_word = &current[prefix_start..pos];
-                    let (actual_start, add_leading_space) = if prefix_word.is_empty() {
-                        // Cursor is at whitespace or string start — plain insert.
-                        (pos, false)
-                    } else if insert_text
-                        .as_str()
-                        .to_ascii_uppercase()
-                        .starts_with(&prefix_word.to_ascii_uppercase())
-                    {
-                        // Prefix is a partial match of insert_text — replace it.
-                        (prefix_start, false)
-                    } else {
-                        // Prefix is unrelated (e.g. "users" + "WHERE") — insert at cursor.
-                        let needs_space =
-                            !current[..pos].ends_with(|c: char| c.is_ascii_whitespace());
-                        (pos, needs_space)
-                    };
-                    let leading = if add_leading_space { " " } else { "" };
-                    let text = format!(
-                        "{}{}{}{}",
-                        &current[..actual_start],
-                        leading,
-                        insert_text,
-                        &current[pos..]
-                    );
-                    let cur = if cursor_offset_val > 0 {
-                        actual_start as i32 + add_leading_space as i32 + cursor_offset_val
-                    } else {
-                        (actual_start + leading.len() + insert_text.len()) as i32
-                    };
-                    (text, cur)
-                };
-
-                // Auto-append FROM <table> when a column with a known table was accepted
-                // inside a SELECT list that has no FROM clause yet.
-                let appended_from =
-                    in_select && !table_name_str.is_empty() && !sql_has_from(&current);
-                let (final_text, final_cursor) = if appended_from {
-                    let appended = format!("{} FROM {}", new_text.trim_end(), table_name_str);
-                    let cur = appended.len() as i32;
-                    (appended, cur)
-                } else {
-                    (new_text, new_cursor)
-                };
-
-                // inserted text, e.g. between the quotes in `''`).
-                let at_end = final_cursor as usize == final_text.len();
-                ui.set_editor_text(final_text.clone().into());
-                ui.set_editor_cursor_target(final_cursor);
-                // Re-trigger only when the cursor is at end of inserted text AND the text
-                // does not end at a syntactically terminal expression (IS NULL, TRUE, FALSE,
-                // a string/numeric literal, ASC/DESC).  Terminal positions use a virtual
-                // trailing space so the parser sees the next context without polluting the
-                // editor with a stale space the user would have to delete before typing `;`.
-                if cursor_offset_val == 0 && at_end && !is_terminal_expression(&final_text) {
-                    let trigger_sql = format!("{} ", final_text);
-                    ui.invoke_trigger_completion(trigger_sql.into(), final_cursor + 1);
-                }
+                });
             },
         );
     }
@@ -1116,13 +1048,11 @@ impl UI {
         let ui = window.global::<crate::UiState>();
         let window_weak = window.as_weak(); // clone required: on_format_sql closure
         ui.on_format_sql(move || {
-            let Some(window) = window_weak.upgrade() else {
-                return;
-            };
-            let ui = window.global::<crate::UiState>();
-            let text = ui.get_editor_text().to_string();
-            let formatted = wf_query::formatter::format_sql(&text);
-            ui.set_editor_text(formatted.into());
+            with_ui(&window_weak, |ui| {
+                let text = ui.get_editor_text().to_string();
+                let formatted = wf_query::formatter::format_sql(&text);
+                ui.set_editor_text(formatted.into());
+            });
         });
     }
 
@@ -1165,14 +1095,7 @@ impl UI {
                         Ok(()) => format!("Saved CSV: {}", path.display()),
                         Err(e) => format!("CSV export failed: {e}"),
                     };
-                    let _ = slint::invoke_from_event_loop(move || {
-                        let Some(window) = window_weak.upgrade() else {
-                            return;
-                        };
-                        window
-                            .global::<crate::UiState>()
-                            .set_status_message(msg.into());
-                    });
+                    set_status(window_weak, msg);
                 });
             });
         }
@@ -1209,14 +1132,7 @@ impl UI {
                         Ok(()) => format!("Saved JSON: {}", path.display()),
                         Err(e) => format!("JSON export failed: {e}"),
                     };
-                    let _ = slint::invoke_from_event_loop(move || {
-                        let Some(window) = window_weak.upgrade() else {
-                            return;
-                        };
-                        window
-                            .global::<crate::UiState>()
-                            .set_status_message(msg.into());
-                    });
+                    set_status(window_weak, msg);
                 });
             });
         }
@@ -1239,17 +1155,15 @@ impl UI {
             // clone required: callback closure must be 'static
             let window_weak = window_weak.clone();
             ui_state.on_resize_result_column(move |i, w| {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let model = ui.get_result_col_widths();
-                let n = model.row_count();
-                if (i as usize) < n {
-                    model.set_row_data(i as usize, w);
-                    let total: f32 = (0..n).filter_map(|j| model.row_data(j)).sum();
-                    ui.set_result_total_col_width(total);
-                }
+                with_ui(&window_weak, |ui| {
+                    let model = ui.get_result_col_widths();
+                    let n = model.row_count();
+                    if (i as usize) < n {
+                        model.set_row_data(i as usize, w);
+                        let total: f32 = (0..n).filter_map(|j| model.row_data(j)).sum();
+                        ui.set_result_total_col_width(total);
+                    }
+                });
             });
         }
 
@@ -1259,23 +1173,21 @@ impl UI {
             let window_weak = window_weak.clone();
             let original_data = Arc::clone(&original_data);
             ui_state.on_filter_result_rows(move |query| {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
-                let Some(ref data) = *orig else {
-                    return;
-                };
-                let mut filtered = filter_rows(&data.columns, &data.rows, query.as_str());
-                if let Some(col) = data.sort_col {
-                    sort_rows(&mut filtered, col, data.sort_asc);
-                }
-                let row_count = filtered.len() as i32;
-                let rows: Vec<crate::RowData> = filtered.into_iter().map(rows_to_ui).collect();
-                ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
-                ui.set_result_row_count(row_count);
-                ui.set_result_active_filter(query);
+                with_ui(&window_weak, |ui| {
+                    let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                    let Some(ref data) = *orig else {
+                        return;
+                    };
+                    let mut filtered = filter_rows(&data.columns, &data.rows, query.as_str());
+                    if let Some(col) = data.sort_col {
+                        sort_rows(&mut filtered, col, data.sort_asc);
+                    }
+                    let row_count = filtered.len() as i32;
+                    let rows: Vec<crate::RowData> = filtered.into_iter().map(rows_to_ui).collect();
+                    ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                    ui.set_result_row_count(row_count);
+                    ui.set_result_active_filter(query);
+                });
             });
         }
 
@@ -1285,23 +1197,21 @@ impl UI {
             let window_weak = window_weak.clone();
             let original_data = Arc::clone(&original_data);
             ui_state.on_clear_result_filter(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
-                let Some(ref data) = *orig else {
-                    return;
-                };
-                let mut rows: Vec<Vec<Option<String>>> = data.rows.clone();
-                if let Some(col) = data.sort_col {
-                    sort_rows(&mut rows, col, data.sort_asc);
-                }
-                let row_count = rows.len() as i32;
-                let ui_rows: Vec<crate::RowData> = rows.into_iter().map(rows_to_ui).collect();
-                ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
-                ui.set_result_row_count(row_count);
-                ui.set_result_active_filter("".into());
+                with_ui(&window_weak, |ui| {
+                    let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                    let Some(ref data) = *orig else {
+                        return;
+                    };
+                    let mut rows: Vec<Vec<Option<String>>> = data.rows.clone();
+                    if let Some(col) = data.sort_col {
+                        sort_rows(&mut rows, col, data.sort_asc);
+                    }
+                    let row_count = rows.len() as i32;
+                    let ui_rows: Vec<crate::RowData> = rows.into_iter().map(rows_to_ui).collect();
+                    ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
+                    ui.set_result_row_count(row_count);
+                    ui.set_result_active_filter("".into());
+                });
             });
         }
 
@@ -1319,49 +1229,10 @@ impl UI {
             // clone required: callback closure must be 'static
             let window_weak = window_weak.clone();
             ui_state.on_copy_result_row(move |row_i| {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let rows_model = ui.get_result_rows();
-                if let Some(row) = rows_model.row_data(row_i as usize) {
-                    let cells: Vec<Option<String>> = (0..row.cells.row_count())
-                        .filter_map(|j| row.cells.row_data(j))
-                        .map(|c| {
-                            if c.is_null {
-                                None
-                            } else {
-                                Some(c.value.to_string())
-                            }
-                        })
-                        .collect();
-                    let tsv = cells_to_tsv(&cells);
-                    if let Ok(mut clip) = arboard::Clipboard::new() {
-                        let _ = clip.set_text(tsv);
-                    }
-                }
-            });
-        }
-
-        // copy-result-tsv: export all visible rows as TSV with column headers.
-        {
-            // clone required: callback closure must be 'static
-            let window_weak = window_weak.clone();
-            ui_state.on_copy_result_tsv(move || {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                let cols_model = ui.get_result_columns();
-                let rows_model = ui.get_result_rows();
-                let columns: Vec<String> = (0..cols_model.row_count())
-                    .filter_map(|i| cols_model.row_data(i))
-                    .map(|s| s.to_string())
-                    .collect();
-                let rows: Vec<Vec<Option<String>>> = (0..rows_model.row_count())
-                    .filter_map(|i| rows_model.row_data(i))
-                    .map(|row| {
-                        (0..row.cells.row_count())
+                with_ui(&window_weak, |ui| {
+                    let rows_model = ui.get_result_rows();
+                    if let Some(row) = rows_model.row_data(row_i as usize) {
+                        let cells: Vec<Option<String>> = (0..row.cells.row_count())
                             .filter_map(|j| row.cells.row_data(j))
                             .map(|c| {
                                 if c.is_null {
@@ -1370,14 +1241,49 @@ impl UI {
                                     Some(c.value.to_string())
                                 }
                             })
-                            .collect()
-                    })
-                    .collect();
-                let col_strs: Vec<&str> = columns.iter().map(String::as_str).collect();
-                let tsv = result_to_tsv(&col_strs, &rows);
-                if let Ok(mut clip) = arboard::Clipboard::new() {
-                    let _ = clip.set_text(tsv);
-                }
+                            .collect();
+                        let tsv = cells_to_tsv(&cells);
+                        if let Ok(mut clip) = arboard::Clipboard::new() {
+                            let _ = clip.set_text(tsv);
+                        }
+                    }
+                });
+            });
+        }
+
+        // copy-result-tsv: export all visible rows as TSV with column headers.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_copy_result_tsv(move || {
+                with_ui(&window_weak, |ui| {
+                    let cols_model = ui.get_result_columns();
+                    let rows_model = ui.get_result_rows();
+                    let columns: Vec<String> = (0..cols_model.row_count())
+                        .filter_map(|i| cols_model.row_data(i))
+                        .map(|s| s.to_string())
+                        .collect();
+                    let rows: Vec<Vec<Option<String>>> = (0..rows_model.row_count())
+                        .filter_map(|i| rows_model.row_data(i))
+                        .map(|row| {
+                            (0..row.cells.row_count())
+                                .filter_map(|j| row.cells.row_data(j))
+                                .map(|c| {
+                                    if c.is_null {
+                                        None
+                                    } else {
+                                        Some(c.value.to_string())
+                                    }
+                                })
+                                .collect()
+                        })
+                        .collect();
+                    let col_strs: Vec<&str> = columns.iter().map(String::as_str).collect();
+                    let tsv = result_to_tsv(&col_strs, &rows);
+                    if let Ok(mut clip) = arboard::Clipboard::new() {
+                        let _ = clip.set_text(tsv);
+                    }
+                });
             });
         }
 
@@ -1395,26 +1301,13 @@ impl UI {
             ui_state.on_update_page_size(move |n| {
                 let size = n as usize;
                 state_rerun.ui.set_page_size(size);
-                // Update the Slint property so button highlights refresh on the UI thread.
-                if let Some(window) = window_weak.upgrade() {
-                    window.global::<crate::UiState>().set_page_size(n);
-                }
+                with_ui(&window_weak, |ui| ui.set_page_size(n));
                 if let Ok(ps) = wf_config::models::PageSize::try_from(n as u32) {
-                    // clone required: tokio::spawn requires 'static
-                    let tx_cmd_cfg = tx_cmd.clone();
-                    tokio::spawn(async move {
-                        let _ = tx_cmd_cfg
-                            .send(Command::UpdateConfig(ConfigUpdate::PageSize(ps)))
-                            .await;
-                    });
+                    send_cmd(&tx_cmd, Command::UpdateConfig(ConfigUpdate::PageSize(ps)));
                 }
                 // Auto-rerun the last query so results reflect the new limit immediately.
                 if let Some(last_sql) = state_rerun.query.last_sql() {
-                    // clone required: tokio::spawn requires 'static
-                    let tx_cmd_run = tx_cmd.clone();
-                    tokio::spawn(async move {
-                        let _ = tx_cmd_run.send(Command::RunQuery(last_sql)).await;
-                    });
+                    send_cmd(&tx_cmd, Command::RunQuery(last_sql));
                 }
             });
         }
@@ -1428,17 +1321,12 @@ impl UI {
             let state_all = state.clone(); // clone required: captured by callback
             ui_state.on_confirm_all_rows(move || {
                 state_all.ui.set_page_size(0);
-                if let Some(window) = window_weak.upgrade() {
-                    let ui = window.global::<crate::UiState>();
+                with_ui(&window_weak, |ui| {
                     ui.set_page_size(0);
                     ui.set_show_all_rows_confirm(false);
-                }
+                });
                 if let Some(last_sql) = state_all.query.last_sql() {
-                    // clone required: tokio::spawn requires 'static
-                    let tx_cmd = tx_cmd.clone();
-                    tokio::spawn(async move {
-                        let _ = tx_cmd.send(Command::RunQuery(last_sql)).await;
-                    });
+                    send_cmd(&tx_cmd, Command::RunQuery(last_sql));
                 }
             });
         }
@@ -1448,11 +1336,7 @@ impl UI {
             // clone required: callback closure must be 'static
             let window_weak = window_weak.clone();
             ui_state.on_dismiss_all_rows_confirm(move || {
-                if let Some(window) = window_weak.upgrade() {
-                    window
-                        .global::<crate::UiState>()
-                        .set_show_all_rows_confirm(false);
-                }
+                with_ui(&window_weak, |ui| ui.set_show_all_rows_confirm(false));
             });
         }
 
@@ -1477,37 +1361,34 @@ impl UI {
             let window_weak = window_weak.clone();
             let original_data = Arc::clone(&original_data);
             ui_state.on_sort_result_col(move |col_i| {
-                let Some(window) = window_weak.upgrade() else {
-                    return;
-                };
-                let ui = window.global::<crate::UiState>();
-                // Read active filter before taking the lock.
-                let filter_q = ui.get_result_active_filter().to_string();
-                let (new_col, new_asc, mut rows) = {
-                    let mut orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
-                    let Some(ref mut data) = *orig else {
-                        return;
+                with_ui(&window_weak, |ui| {
+                    let filter_q = ui.get_result_active_filter().to_string();
+                    let (new_col, new_asc, mut rows) = {
+                        let mut orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                        let Some(ref mut data) = *orig else {
+                            return;
+                        };
+                        let col = col_i as usize;
+                        let (new_col, new_asc) = if data.sort_col == Some(col) {
+                            (Some(col), !data.sort_asc)
+                        } else {
+                            (Some(col), true)
+                        };
+                        data.sort_col = new_col;
+                        data.sort_asc = new_asc;
+                        let filtered = filter_rows(&data.columns, &data.rows, &filter_q);
+                        (new_col, new_asc, filtered)
                     };
-                    let col = col_i as usize;
-                    let (new_col, new_asc) = if data.sort_col == Some(col) {
-                        (Some(col), !data.sort_asc)
-                    } else {
-                        (Some(col), true)
-                    };
-                    data.sort_col = new_col;
-                    data.sort_asc = new_asc;
-                    let filtered = filter_rows(&data.columns, &data.rows, &filter_q);
-                    (new_col, new_asc, filtered)
-                };
-                if let Some(col) = new_col {
-                    sort_rows(&mut rows, col, new_asc);
-                }
-                let row_count = rows.len() as i32;
-                let ui_rows: Vec<crate::RowData> = rows.into_iter().map(rows_to_ui).collect();
-                ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
-                ui.set_result_row_count(row_count);
-                ui.set_result_sort_col(new_col.map(|c| c as i32).unwrap_or(-1));
-                ui.set_result_sort_asc(new_asc);
+                    if let Some(col) = new_col {
+                        sort_rows(&mut rows, col, new_asc);
+                    }
+                    let row_count = rows.len() as i32;
+                    let ui_rows: Vec<crate::RowData> = rows.into_iter().map(rows_to_ui).collect();
+                    ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
+                    ui.set_result_row_count(row_count);
+                    ui.set_result_sort_col(new_col.map(|c| c as i32).unwrap_or(-1));
+                    ui.set_result_sort_asc(new_asc);
+                });
             });
         }
     }
@@ -1783,377 +1664,5 @@ fn parse_col_eq(query: &str) -> Option<(String, &str)> {
     Some((col.to_string(), val))
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use wf_db::models::{DbMetadata, DbType, TableInfo};
-
-    // ── find_prefix_start ────────────────────────────────────────────────────
-
-    #[test]
-    fn find_prefix_start_should_return_word_start_before_cursor() {
-        assert_eq!(find_prefix_start("SELECT sel", 10), 7);
-    }
-
-    #[test]
-    fn find_prefix_start_should_return_cursor_when_at_space() {
-        assert_eq!(find_prefix_start("SELECT ", 7), 7);
-    }
-
-    #[test]
-    fn find_prefix_start_should_return_after_dot_for_qualified_name() {
-        assert_eq!(find_prefix_start("u.em", 4), 2);
-    }
-
-    #[test]
-    fn find_prefix_start_should_return_cursor_when_no_prefix() {
-        assert_eq!(find_prefix_start("SELECT * FROM ", 14), 14);
-    }
-
-    // ── sql_has_from ─────────────────────────────────────────────────────────
-
-    #[test]
-    fn sql_has_from_should_return_true_when_from_present() {
-        assert!(sql_has_from("SELECT id FROM users"));
-    }
-
-    #[test]
-    fn sql_has_from_should_return_false_when_no_from() {
-        assert!(!sql_has_from("SELECT id, name"));
-    }
-
-    #[test]
-    fn sql_has_from_should_return_true_for_multiline_from() {
-        assert!(sql_has_from("SELECT id\nFROM users"));
-    }
-
-    #[test]
-    fn sql_has_from_should_return_false_for_from_in_column_name() {
-        // "from" inside a word like "transform" should not match
-        assert!(!sql_has_from("SELECT transform_id"));
-    }
-
-    // ── is_terminal_expression ────────────────────────────────────────────────
-
-    #[test]
-    fn is_terminal_expression_should_return_true_for_is_not_null() {
-        assert!(is_terminal_expression(
-            "SELECT name FROM users WHERE deleted_at IS NOT NULL"
-        ));
-        assert!(is_terminal_expression("WHERE col IS NULL"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_return_true_for_boolean_keywords() {
-        assert!(is_terminal_expression("WHERE active = TRUE"));
-        assert!(is_terminal_expression("WHERE active = FALSE"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_return_true_for_direction_keywords() {
-        assert!(is_terminal_expression("ORDER BY id ASC"));
-        assert!(is_terminal_expression("ORDER BY id DESC"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_return_true_for_string_literal() {
-        assert!(is_terminal_expression("WHERE name = 'alice'"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_return_true_for_numeric_literal() {
-        assert!(is_terminal_expression("WHERE id = 5"));
-        assert!(is_terminal_expression("LIMIT 10"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_return_false_for_non_terminal_positions() {
-        assert!(!is_terminal_expression("FROM users WHERE"));
-        assert!(!is_terminal_expression("SELECT * FROM users"));
-        assert!(!is_terminal_expression("SELECT id"));
-    }
-
-    #[test]
-    fn is_terminal_expression_should_not_match_word_ending_with_null_suffix() {
-        // "nullify" last word is "NULLIFY" — not the keyword "NULL"
-        assert!(!is_terminal_expression("WHERE nullify"));
-        // "is_not_null_col" is a column name, not the keyword NULL
-        assert!(!is_terminal_expression("SELECT is_not_null_col"));
-    }
-
-    fn make_conn(id: &str, name: &str) -> DbConnection {
-        DbConnection {
-            id: id.to_string(),
-            name: name.to_string(),
-            db_type: DbType::SQLite,
-            connection_string: None,
-            host: None,
-            port: None,
-            user: None,
-            password_encrypted: None,
-            database: None,
-        }
-    }
-
-    fn make_meta(tables: &[&str]) -> DbMetadata {
-        DbMetadata {
-            tables: tables
-                .iter()
-                .map(|n| TableInfo {
-                    name: n.to_string(),
-                    columns: vec![],
-                })
-                .collect(),
-            views: vec![],
-            stored_procs: vec![],
-            indexes: vec![],
-        }
-    }
-
-    #[test]
-    fn build_sidebar_tree_should_render_connection_nodes() {
-        let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
-        let nodes = build_sidebar_tree(&conns, "", &HashMap::new(), &HashSet::new());
-        assert_eq!(nodes.len(), 2);
-        assert_eq!(nodes[0].label.as_str(), "Alpha");
-        assert_eq!(nodes[0].level, 0);
-        assert_eq!(nodes[0].node_kind.as_str(), "connection");
-        assert_eq!(nodes[1].label.as_str(), "Beta");
-    }
-
-    #[test]
-    fn build_sidebar_tree_should_show_categories_when_connection_expanded() {
-        let conns = vec![make_conn("a", "Alpha")];
-        let mut expanded = HashSet::new();
-        expanded.insert("conn:a".to_string());
-        let mut metadata = HashMap::new();
-        metadata.insert("a".to_string(), make_meta(&["users"]));
-        let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
-        // conn + Tables + Views + Stored Procedures + Indexes = 5 nodes
-        assert_eq!(nodes.len(), 5);
-        assert_eq!(nodes[1].label.as_str(), "Tables");
-        assert_eq!(nodes[1].level, 1);
-        assert_eq!(nodes[1].node_kind.as_str(), "category");
-    }
-
-    #[test]
-    fn build_sidebar_tree_should_show_items_when_category_expanded() {
-        let conns = vec![make_conn("a", "Alpha")];
-        let mut expanded = HashSet::new();
-        expanded.insert("conn:a".to_string());
-        expanded.insert("cat:a:Tables".to_string());
-        let mut metadata = HashMap::new();
-        metadata.insert("a".to_string(), make_meta(&["users", "orders"]));
-        let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
-        // conn + Tables + users + orders + Views + Stored Procedures + Indexes = 7
-        assert_eq!(nodes.len(), 7);
-        assert_eq!(nodes[2].label.as_str(), "users");
-        assert_eq!(nodes[2].level, 2);
-        assert_eq!(nodes[2].node_kind.as_str(), "table");
-        assert_eq!(nodes[3].label.as_str(), "orders");
-    }
-
-    #[test]
-    fn build_sidebar_tree_should_hide_children_when_collapsed() {
-        let conns = vec![make_conn("a", "Alpha")];
-        let nodes = build_sidebar_tree(&conns, "a", &HashMap::new(), &HashSet::new());
-        assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].level, 0);
-    }
-
-    #[test]
-    fn build_sidebar_tree_should_mark_active_connection() {
-        let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
-        let nodes = build_sidebar_tree(&conns, "b", &HashMap::new(), &HashSet::new());
-        assert!(!nodes[0].is_active);
-        assert!(nodes[1].is_active);
-    }
-
-    // ── filter_rows tests ─────────────────────────────────────────────────────
-
-    fn ss(s: &str) -> slint::SharedString {
-        s.into()
-    }
-
-    fn sv(s: &str) -> Option<String> {
-        Some(s.to_string())
-    }
-
-    #[test]
-    fn filter_rows_should_return_all_when_query_empty() {
-        let cols = vec![ss("id"), ss("name")];
-        let rows = vec![vec![sv("1"), sv("Alice")], vec![sv("2"), sv("Bob")]];
-        assert_eq!(filter_rows(&cols, &rows, "").len(), 2);
-        assert_eq!(filter_rows(&cols, &rows, "   ").len(), 2);
-    }
-
-    #[test]
-    fn filter_rows_should_match_substring_across_all_columns() {
-        let cols = vec![ss("name"), ss("city")];
-        let rows = vec![
-            vec![sv("Alice"), sv("Tokyo")],
-            vec![sv("Bob"), sv("Osaka")],
-            vec![sv("Alice Smith"), sv("Kyoto")],
-        ];
-        let result = filter_rows(&cols, &rows, "alice");
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0][0].as_deref(), Some("Alice"));
-        assert_eq!(result[1][0].as_deref(), Some("Alice Smith"));
-    }
-
-    #[test]
-    fn filter_rows_should_match_exact_column_value() {
-        let cols = vec![ss("name"), ss("city")];
-        let rows = vec![vec![sv("Alice"), sv("Tokyo")], vec![sv("Bob"), sv("Osaka")]];
-        let result = filter_rows(&cols, &rows, "city = 'Tokyo'");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0][1].as_deref(), Some("Tokyo"));
-    }
-
-    #[test]
-    fn filter_rows_should_return_empty_when_column_not_found() {
-        let cols = vec![ss("name")];
-        let rows = vec![vec![sv("Alice")]];
-        let result = filter_rows(&cols, &rows, "missing = 'x'");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn filter_rows_should_not_match_null_with_eq_predicate() {
-        let cols = vec![ss("name")];
-        let rows = vec![vec![None], vec![sv("Alice")]];
-        let result = filter_rows(&cols, &rows, "name = ''");
-        // NULL != '' — only the non-null empty string row should match, but here
-        // there is none, so result is empty.
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn filter_rows_should_treat_null_as_empty_for_substring_match() {
-        let cols = vec![ss("name")];
-        // NULL treated as "" for substring search — empty query prefix matches all.
-        let rows = vec![vec![None], vec![sv("Alice")]];
-        // Substring "" matches everything (but we trim, so empty query returns all).
-        let result = filter_rows(&cols, &rows, "Alice");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0][0].as_deref(), Some("Alice"));
-    }
-
-    // ── sort_rows tests ───────────────────────────────────────────────────────
-
-    #[test]
-    fn sort_rows_should_sort_strings_ascending() {
-        let mut rows = vec![vec![sv("banana")], vec![sv("apple")], vec![sv("cherry")]];
-        sort_rows(&mut rows, 0, true);
-        assert_eq!(rows[0][0].as_deref(), Some("apple"));
-        assert_eq!(rows[1][0].as_deref(), Some("banana"));
-        assert_eq!(rows[2][0].as_deref(), Some("cherry"));
-    }
-
-    #[test]
-    fn sort_rows_should_sort_strings_descending() {
-        let mut rows = vec![vec![sv("banana")], vec![sv("apple")], vec![sv("cherry")]];
-        sort_rows(&mut rows, 0, false);
-        assert_eq!(rows[0][0].as_deref(), Some("cherry"));
-        assert_eq!(rows[1][0].as_deref(), Some("banana"));
-        assert_eq!(rows[2][0].as_deref(), Some("apple"));
-    }
-
-    #[test]
-    fn sort_rows_should_sort_numerically_when_values_are_numbers() {
-        let mut rows = vec![vec![sv("10")], vec![sv("2")], vec![sv("20")]];
-        sort_rows(&mut rows, 0, true);
-        assert_eq!(rows[0][0].as_deref(), Some("2"));
-        assert_eq!(rows[1][0].as_deref(), Some("10"));
-        assert_eq!(rows[2][0].as_deref(), Some("20"));
-    }
-
-    #[test]
-    fn sort_rows_should_put_nulls_last_ascending() {
-        let mut rows = vec![vec![None], vec![sv("b")], vec![sv("a")]];
-        sort_rows(&mut rows, 0, true);
-        assert_eq!(rows[0][0].as_deref(), Some("a"));
-        assert_eq!(rows[1][0].as_deref(), Some("b"));
-        assert!(rows[2][0].is_none());
-    }
-
-    #[test]
-    fn sort_rows_should_put_nulls_last_descending() {
-        let mut rows = vec![vec![None], vec![sv("b")], vec![sv("a")]];
-        sort_rows(&mut rows, 0, false);
-        assert_eq!(rows[0][0].as_deref(), Some("b"));
-        assert_eq!(rows[1][0].as_deref(), Some("a"));
-        assert!(rows[2][0].is_none());
-    }
-
-    // ── cells_to_tsv / result_to_tsv tests ───────────────────────────────────
-
-    #[test]
-    fn cells_to_tsv_should_join_values_with_tabs() {
-        let cells = vec![sv("a"), sv("b"), sv("c")];
-        assert_eq!(cells_to_tsv(&cells), "a\tb\tc");
-    }
-
-    #[test]
-    fn cells_to_tsv_should_render_null_as_empty_string() {
-        let cells = vec![sv("a"), None, sv("c")];
-        assert_eq!(cells_to_tsv(&cells), "a\t\tc");
-    }
-
-    #[test]
-    fn cells_to_tsv_should_handle_empty_row() {
-        let cells: Vec<Option<String>> = vec![];
-        assert_eq!(cells_to_tsv(&cells), "");
-    }
-
-    #[test]
-    fn result_to_tsv_should_include_header_and_rows() {
-        let cols = vec!["id", "name"];
-        let rows = vec![vec![sv("1"), sv("Alice")], vec![sv("2"), sv("Bob")]];
-        let tsv = result_to_tsv(&cols, &rows);
-        assert_eq!(tsv, "id\tname\n1\tAlice\n2\tBob");
-    }
-
-    #[test]
-    fn result_to_tsv_should_render_null_cells_as_empty_string() {
-        let cols = vec!["id", "name"];
-        let rows = vec![vec![sv("1"), None]];
-        let tsv = result_to_tsv(&cols, &rows);
-        assert_eq!(tsv, "id\tname\n1\t");
-    }
-
-    #[test]
-    fn result_to_tsv_should_produce_header_only_when_no_rows() {
-        let cols = vec!["id", "name"];
-        let rows: Vec<Vec<Option<String>>> = vec![];
-        let tsv = result_to_tsv(&cols, &rows);
-        assert_eq!(tsv, "id\tname");
-    }
-
-    // ── append_editor_text tests ──────────────────────────────────────────────
-
-    #[test]
-    fn append_editor_text_should_set_text_when_editor_is_empty() {
-        assert_eq!(append_editor_text("", "SELECT * FROM t"), "SELECT * FROM t");
-    }
-
-    #[test]
-    fn append_editor_text_should_prepend_newline_when_content_exists() {
-        assert_eq!(
-            append_editor_text("SELECT 1", "SELECT * FROM t"),
-            "SELECT 1\nSELECT * FROM t"
-        );
-    }
-
-    #[test]
-    fn append_editor_text_should_not_double_newline_when_content_ends_with_newline() {
-        assert_eq!(
-            append_editor_text("SELECT 1\n", "SELECT * FROM t"),
-            "SELECT 1\nSELECT * FROM t"
-        );
-    }
-}
+mod tests;

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -1,0 +1,367 @@
+use super::*;
+use wf_db::models::{DbConnection, DbMetadata, DbType, TableInfo};
+
+// ── find_prefix_start ────────────────────────────────────────────────────────
+
+#[test]
+fn find_prefix_start_should_return_word_start_before_cursor() {
+    assert_eq!(find_prefix_start("SELECT sel", 10), 7);
+}
+
+#[test]
+fn find_prefix_start_should_return_cursor_when_at_space() {
+    assert_eq!(find_prefix_start("SELECT ", 7), 7);
+}
+
+#[test]
+fn find_prefix_start_should_return_after_dot_for_qualified_name() {
+    assert_eq!(find_prefix_start("u.em", 4), 2);
+}
+
+#[test]
+fn find_prefix_start_should_return_cursor_when_no_prefix() {
+    assert_eq!(find_prefix_start("SELECT * FROM ", 14), 14);
+}
+
+// ── sql_has_from ─────────────────────────────────────────────────────────────
+
+#[test]
+fn sql_has_from_should_return_true_when_from_present() {
+    assert!(sql_has_from("SELECT id FROM users"));
+}
+
+#[test]
+fn sql_has_from_should_return_false_when_no_from() {
+    assert!(!sql_has_from("SELECT id, name"));
+}
+
+#[test]
+fn sql_has_from_should_return_true_for_multiline_from() {
+    assert!(sql_has_from("SELECT id\nFROM users"));
+}
+
+#[test]
+fn sql_has_from_should_return_false_for_from_in_column_name() {
+    // "from" inside a word like "transform" should not match
+    assert!(!sql_has_from("SELECT transform_id"));
+}
+
+// ── is_terminal_expression ────────────────────────────────────────────────────
+
+#[test]
+fn is_terminal_expression_should_return_true_for_is_not_null() {
+    assert!(is_terminal_expression(
+        "SELECT name FROM users WHERE deleted_at IS NOT NULL"
+    ));
+    assert!(is_terminal_expression("WHERE col IS NULL"));
+}
+
+#[test]
+fn is_terminal_expression_should_return_true_for_boolean_keywords() {
+    assert!(is_terminal_expression("WHERE active = TRUE"));
+    assert!(is_terminal_expression("WHERE active = FALSE"));
+}
+
+#[test]
+fn is_terminal_expression_should_return_true_for_direction_keywords() {
+    assert!(is_terminal_expression("ORDER BY id ASC"));
+    assert!(is_terminal_expression("ORDER BY id DESC"));
+}
+
+#[test]
+fn is_terminal_expression_should_return_true_for_string_literal() {
+    assert!(is_terminal_expression("WHERE name = 'alice'"));
+}
+
+#[test]
+fn is_terminal_expression_should_return_true_for_numeric_literal() {
+    assert!(is_terminal_expression("WHERE id = 5"));
+    assert!(is_terminal_expression("LIMIT 10"));
+}
+
+#[test]
+fn is_terminal_expression_should_return_false_for_non_terminal_positions() {
+    assert!(!is_terminal_expression("FROM users WHERE"));
+    assert!(!is_terminal_expression("SELECT * FROM users"));
+    assert!(!is_terminal_expression("SELECT id"));
+}
+
+#[test]
+fn is_terminal_expression_should_not_match_word_ending_with_null_suffix() {
+    // "nullify" last word is "NULLIFY" — not the keyword "NULL"
+    assert!(!is_terminal_expression("WHERE nullify"));
+    // "is_not_null_col" is a column name, not the keyword NULL
+    assert!(!is_terminal_expression("SELECT is_not_null_col"));
+}
+
+fn make_conn(id: &str, name: &str) -> DbConnection {
+    DbConnection {
+        id: id.to_string(),
+        name: name.to_string(),
+        db_type: DbType::SQLite,
+        connection_string: None,
+        host: None,
+        port: None,
+        user: None,
+        password_encrypted: None,
+        database: None,
+    }
+}
+
+fn make_meta(tables: &[&str]) -> DbMetadata {
+    DbMetadata {
+        tables: tables
+            .iter()
+            .map(|n| TableInfo {
+                name: n.to_string(),
+                columns: vec![],
+            })
+            .collect(),
+        views: vec![],
+        stored_procs: vec![],
+        indexes: vec![],
+    }
+}
+
+#[test]
+fn build_sidebar_tree_should_render_connection_nodes() {
+    let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
+    let nodes = build_sidebar_tree(&conns, "", &HashMap::new(), &HashSet::new());
+    assert_eq!(nodes.len(), 2);
+    assert_eq!(nodes[0].label.as_str(), "Alpha");
+    assert_eq!(nodes[0].level, 0);
+    assert_eq!(nodes[0].node_kind.as_str(), "connection");
+    assert_eq!(nodes[1].label.as_str(), "Beta");
+}
+
+#[test]
+fn build_sidebar_tree_should_show_categories_when_connection_expanded() {
+    let conns = vec![make_conn("a", "Alpha")];
+    let mut expanded = HashSet::new();
+    expanded.insert("conn:a".to_string());
+    let mut metadata = HashMap::new();
+    metadata.insert("a".to_string(), make_meta(&["users"]));
+    let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
+    // conn + Tables + Views + Stored Procedures + Indexes = 5 nodes
+    assert_eq!(nodes.len(), 5);
+    assert_eq!(nodes[1].label.as_str(), "Tables");
+    assert_eq!(nodes[1].level, 1);
+    assert_eq!(nodes[1].node_kind.as_str(), "category");
+}
+
+#[test]
+fn build_sidebar_tree_should_show_items_when_category_expanded() {
+    let conns = vec![make_conn("a", "Alpha")];
+    let mut expanded = HashSet::new();
+    expanded.insert("conn:a".to_string());
+    expanded.insert("cat:a:Tables".to_string());
+    let mut metadata = HashMap::new();
+    metadata.insert("a".to_string(), make_meta(&["users", "orders"]));
+    let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded);
+    // conn + Tables + users + orders + Views + Stored Procedures + Indexes = 7
+    assert_eq!(nodes.len(), 7);
+    assert_eq!(nodes[2].label.as_str(), "users");
+    assert_eq!(nodes[2].level, 2);
+    assert_eq!(nodes[2].node_kind.as_str(), "table");
+    assert_eq!(nodes[3].label.as_str(), "orders");
+}
+
+#[test]
+fn build_sidebar_tree_should_hide_children_when_collapsed() {
+    let conns = vec![make_conn("a", "Alpha")];
+    let nodes = build_sidebar_tree(&conns, "a", &HashMap::new(), &HashSet::new());
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0].level, 0);
+}
+
+#[test]
+fn build_sidebar_tree_should_mark_active_connection() {
+    let conns = vec![make_conn("a", "Alpha"), make_conn("b", "Beta")];
+    let nodes = build_sidebar_tree(&conns, "b", &HashMap::new(), &HashSet::new());
+    assert!(!nodes[0].is_active);
+    assert!(nodes[1].is_active);
+}
+
+// ── filter_rows tests ─────────────────────────────────────────────────────────
+
+fn ss(s: &str) -> slint::SharedString {
+    s.into()
+}
+
+fn sv(s: &str) -> Option<String> {
+    Some(s.to_string())
+}
+
+#[test]
+fn filter_rows_should_return_all_when_query_empty() {
+    let cols = vec![ss("id"), ss("name")];
+    let rows = vec![vec![sv("1"), sv("Alice")], vec![sv("2"), sv("Bob")]];
+    assert_eq!(filter_rows(&cols, &rows, "").len(), 2);
+    assert_eq!(filter_rows(&cols, &rows, "   ").len(), 2);
+}
+
+#[test]
+fn filter_rows_should_match_substring_across_all_columns() {
+    let cols = vec![ss("name"), ss("city")];
+    let rows = vec![
+        vec![sv("Alice"), sv("Tokyo")],
+        vec![sv("Bob"), sv("Osaka")],
+        vec![sv("Alice Smith"), sv("Kyoto")],
+    ];
+    let result = filter_rows(&cols, &rows, "alice");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0][0].as_deref(), Some("Alice"));
+    assert_eq!(result[1][0].as_deref(), Some("Alice Smith"));
+}
+
+#[test]
+fn filter_rows_should_match_exact_column_value() {
+    let cols = vec![ss("name"), ss("city")];
+    let rows = vec![vec![sv("Alice"), sv("Tokyo")], vec![sv("Bob"), sv("Osaka")]];
+    let result = filter_rows(&cols, &rows, "city = 'Tokyo'");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0][1].as_deref(), Some("Tokyo"));
+}
+
+#[test]
+fn filter_rows_should_return_empty_when_column_not_found() {
+    let cols = vec![ss("name")];
+    let rows = vec![vec![sv("Alice")]];
+    let result = filter_rows(&cols, &rows, "missing = 'x'");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn filter_rows_should_not_match_null_with_eq_predicate() {
+    let cols = vec![ss("name")];
+    let rows = vec![vec![None], vec![sv("Alice")]];
+    let result = filter_rows(&cols, &rows, "name = ''");
+    // NULL != '' — only the non-null empty string row should match, but here
+    // there is none, so result is empty.
+    assert!(result.is_empty());
+}
+
+#[test]
+fn filter_rows_should_treat_null_as_empty_for_substring_match() {
+    let cols = vec![ss("name")];
+    // NULL treated as "" for substring search — empty query prefix matches all.
+    let rows = vec![vec![None], vec![sv("Alice")]];
+    // Substring "" matches everything (but we trim, so empty query returns all).
+    let result = filter_rows(&cols, &rows, "Alice");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0][0].as_deref(), Some("Alice"));
+}
+
+// ── sort_rows tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn sort_rows_should_sort_strings_ascending() {
+    let mut rows = vec![vec![sv("banana")], vec![sv("apple")], vec![sv("cherry")]];
+    sort_rows(&mut rows, 0, true);
+    assert_eq!(rows[0][0].as_deref(), Some("apple"));
+    assert_eq!(rows[1][0].as_deref(), Some("banana"));
+    assert_eq!(rows[2][0].as_deref(), Some("cherry"));
+}
+
+#[test]
+fn sort_rows_should_sort_strings_descending() {
+    let mut rows = vec![vec![sv("banana")], vec![sv("apple")], vec![sv("cherry")]];
+    sort_rows(&mut rows, 0, false);
+    assert_eq!(rows[0][0].as_deref(), Some("cherry"));
+    assert_eq!(rows[1][0].as_deref(), Some("banana"));
+    assert_eq!(rows[2][0].as_deref(), Some("apple"));
+}
+
+#[test]
+fn sort_rows_should_sort_numerically_when_values_are_numbers() {
+    let mut rows = vec![vec![sv("10")], vec![sv("2")], vec![sv("20")]];
+    sort_rows(&mut rows, 0, true);
+    assert_eq!(rows[0][0].as_deref(), Some("2"));
+    assert_eq!(rows[1][0].as_deref(), Some("10"));
+    assert_eq!(rows[2][0].as_deref(), Some("20"));
+}
+
+#[test]
+fn sort_rows_should_put_nulls_last_ascending() {
+    let mut rows = vec![vec![None], vec![sv("b")], vec![sv("a")]];
+    sort_rows(&mut rows, 0, true);
+    assert_eq!(rows[0][0].as_deref(), Some("a"));
+    assert_eq!(rows[1][0].as_deref(), Some("b"));
+    assert!(rows[2][0].is_none());
+}
+
+#[test]
+fn sort_rows_should_put_nulls_last_descending() {
+    let mut rows = vec![vec![None], vec![sv("b")], vec![sv("a")]];
+    sort_rows(&mut rows, 0, false);
+    assert_eq!(rows[0][0].as_deref(), Some("b"));
+    assert_eq!(rows[1][0].as_deref(), Some("a"));
+    assert!(rows[2][0].is_none());
+}
+
+// ── cells_to_tsv / result_to_tsv tests ───────────────────────────────────────
+
+#[test]
+fn cells_to_tsv_should_join_values_with_tabs() {
+    let cells = vec![sv("a"), sv("b"), sv("c")];
+    assert_eq!(cells_to_tsv(&cells), "a\tb\tc");
+}
+
+#[test]
+fn cells_to_tsv_should_render_null_as_empty_string() {
+    let cells = vec![sv("a"), None, sv("c")];
+    assert_eq!(cells_to_tsv(&cells), "a\t\tc");
+}
+
+#[test]
+fn cells_to_tsv_should_handle_empty_row() {
+    let cells: Vec<Option<String>> = vec![];
+    assert_eq!(cells_to_tsv(&cells), "");
+}
+
+#[test]
+fn result_to_tsv_should_include_header_and_rows() {
+    let cols = vec!["id", "name"];
+    let rows = vec![vec![sv("1"), sv("Alice")], vec![sv("2"), sv("Bob")]];
+    let tsv = result_to_tsv(&cols, &rows);
+    assert_eq!(tsv, "id\tname\n1\tAlice\n2\tBob");
+}
+
+#[test]
+fn result_to_tsv_should_render_null_cells_as_empty_string() {
+    let cols = vec!["id", "name"];
+    let rows = vec![vec![sv("1"), None]];
+    let tsv = result_to_tsv(&cols, &rows);
+    assert_eq!(tsv, "id\tname\n1\t");
+}
+
+#[test]
+fn result_to_tsv_should_produce_header_only_when_no_rows() {
+    let cols = vec!["id", "name"];
+    let rows: Vec<Vec<Option<String>>> = vec![];
+    let tsv = result_to_tsv(&cols, &rows);
+    assert_eq!(tsv, "id\tname");
+}
+
+// ── append_editor_text tests ──────────────────────────────────────────────────
+
+#[test]
+fn append_editor_text_should_set_text_when_editor_is_empty() {
+    assert_eq!(append_editor_text("", "SELECT * FROM t"), "SELECT * FROM t");
+}
+
+#[test]
+fn append_editor_text_should_prepend_newline_when_content_exists() {
+    assert_eq!(
+        append_editor_text("SELECT 1", "SELECT * FROM t"),
+        "SELECT 1\nSELECT * FROM t"
+    );
+}
+
+#[test]
+fn append_editor_text_should_not_double_newline_when_content_ends_with_newline() {
+    assert_eq!(
+        append_editor_text("SELECT 1\n", "SELECT * FROM t"),
+        "SELECT 1\nSELECT * FROM t"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses two related refactors in one branch. T076 splits the 800-line `result_table.slint` into four focused sub-components so the composition root stays ≤150 lines. T077 introduces three helper functions (`with_ui`, `send_cmd`, `set_status`) in `mod.rs` to eliminate 30+ repeated patterns, and extracts the inline test module into a separate `tests.rs` file to bring `mod.rs` under the 1800-line acceptance criterion.

## Changes

- `result_table.slint` rewritten as a 150-line composition root importing four new sub-components
- `result_table_toolbar.slint` — toolbar strip with row-count display, Export dropdown, and page-size selector
- `result_table_header.slint` — sortable column headers with drag-to-resize handles
- `result_table_body.slint` — FocusScope keyboard handler, virtual row list, and right-click context menu
- `result_table_search.slint` — search bar and active-filter indicator banner
- `app/src/ui/mod.rs` reduced from 2171 → 1668 lines via `with_ui` / `send_cmd` / `set_status` helpers
- Inline `#[cfg(test)] mod tests { ... }` (374 lines) extracted to `app/src/ui/tests.rs`

## Related Issues

Resolves #166
Resolves #167

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes