### PR TITLE
feat(ui): apply font-family and font-size config to editor and result table

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -533,6 +533,8 @@ export component AppWindow inherits Window {
                     col-widths:       UiState.result-col-widths;
                     total-col-width:  UiState.result-total-col-width;
                     active-filter:    UiState.result-active-filter;
+                    font-family:      UiState.font-family;
+                    font-size-px:     UiState.font-size;
                     resize-column(i, w)  => { UiState.resize-result-column(i, w); }
                     filter-rows(q)       => { UiState.filter-result-rows(q); }
                     clear-filter         => { UiState.clear-result-filter(); }

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -22,6 +22,8 @@ export component ResultTable inherits Rectangle {
     in property <int>       total-rows:      0;
     in property <int>       sort-col:        -1;
     in property <bool>      sort-asc:        true;
+    in property <string>    font-family:     "JetBrains Mono";
+    in property <int>       font-size-px:    12;
     callback resize-column(int, float);
     callback filter-rows(string);
     callback clear-filter();
@@ -91,6 +93,8 @@ export component ResultTable inherits Rectangle {
             active-filter: root.active-filter;
             is-loading:    root.is-loading;
             error-message: root.error-message;
+            font-family:   root.font-family;
+            font-size-px:  root.font-size-px;
             search-query  <=> root.search-query;
             filter-rows(q) => { root.filter-rows(q); }
             clear-filter   => { root.clear-filter(); }

--- a/app/src/ui/components/result_table_body.slint
+++ b/app/src/ui/components/result_table_body.slint
@@ -19,6 +19,8 @@ export component ResultTableBody inherits Rectangle {
     in property <string>    active-filter: "";
     in property <bool>      is-loading:    false;
     in property <string>    error-message: "";
+    in property <string>    font-family:   "JetBrains Mono";
+    in property <int>       font-size-px:  12;
 
     in-out property <string> search-query: "";
     in-out property <length> body-vp-x:    0;
@@ -321,7 +323,8 @@ export component ResultTableBody inherits Rectangle {
                             width: parent.width - 16px;
                             text: cell.value;
                             color: i == root.selected-row ? Colors.selected-text : Colors.subtext0;
-                            font-size: Typography.size-base;
+                            font-family: root.font-family;
+                            font-size: root.font-size-px * 1px;
                             overflow: elide;
                         }
 

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -259,12 +259,14 @@ impl UI {
         Self::register_export_callbacks(&window, Arc::clone(&original_data));
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
         // Set initial page size and theme on the Slint window from shared state.
-        window
-            .global::<crate::UiState>()
-            .set_page_size(state.ui.page_size() as i32);
-        window
-            .global::<crate::UiState>()
-            .set_is_dark(state.ui.theme() == Theme::Dark);
+        let ui_global = window.global::<crate::UiState>();
+        ui_global.set_page_size(state.ui.page_size() as i32);
+        ui_global.set_is_dark(state.ui.theme() == Theme::Dark);
+        let config = wf_config::manager::ConfigManager::new()
+            .load()
+            .unwrap_or_default();
+        ui_global.set_font_family(config.appearance.font_family.into());
+        ui_global.set_font_size(config.appearance.font_size as i32);
 
         Self::register_result_callbacks(
             &window,


### PR DESCRIPTION
## Summary

Propagates `font_family` and `font_size` from `config.toml` into the result table row cells. The SQL editor was already bound to `UiState.font-family` / `UiState.font-size`; this PR adds the same bindings to `ResultTableBody` and `ResultTable`, and initialises both properties from config at startup in `UI::new`.

## Changes

- `result_table_body.slint`: added `font-family` and `font-size-px` in-properties; applied to cell value `Text` element
- `result_table.slint`: added `font-family` and `font-size-px` in-properties; passed through to `body-inst`
- `app.slint`: wired `UiState.font-family` / `UiState.font-size` into `result-table-inst`
- `app/src/ui/mod.rs`: reads `config.appearance.font_family` and `config.appearance.font_size` from `ConfigManager` on startup and sets them on `UiState`

## Related Issues

Closes #48

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes