### PR TITLE
feat(session): persist and restore editor query text via last_query.sql

### DIFF
--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -116,6 +116,39 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Write the current editor query to `last_query.sql` in the app config directory.
+    ///
+    /// An empty query writes an empty file (not an error); `restore_query_file`
+    /// treats an empty or absent file as "no saved query".
+    pub fn save_query_file(&self, query: &str) -> anyhow::Result<()> {
+        let path = self.config_manager.dir().join("last_query.sql");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory {}", parent.display()))?;
+        }
+        std::fs::write(&path, query.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        info!(len = query.len(), "last_query.sql saved");
+        Ok(())
+    }
+
+    /// Read `last_query.sql` from the app config directory.
+    ///
+    /// Returns `Ok(None)` when the file does not exist or is empty.
+    pub fn restore_query_file(&self) -> anyhow::Result<Option<String>> {
+        let path = self.config_manager.dir().join("last_query.sql");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let query = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        if query.is_empty() {
+            return Ok(None);
+        }
+        info!(len = query.len(), "last_query.sql restored");
+        Ok(Some(query))
+    }
+
     /// Load the last session and return the connection to auto-connect to.
     ///
     /// Returns `Ok(None)` when:
@@ -302,5 +335,35 @@ mod tests {
             .load()
             .unwrap();
         assert_eq!(cfg.connections.len(), 1, "should not duplicate");
+    }
+
+    #[test]
+    fn save_query_file_should_persist_and_restore_query() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_query_file("SELECT 1").unwrap();
+
+        let restored = sm.restore_query_file().unwrap();
+        assert_eq!(restored, Some("SELECT 1".to_string()));
+        assert!(dir.path().join("last_query.sql").exists());
+    }
+
+    #[test]
+    fn save_query_file_should_not_affect_config_toml() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_connection(&sqlite_conn("c1")).unwrap();
+        sm.save_query_file("SELECT 2").unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        assert_eq!(cfg.session.last_connection_id, Some("c1".to_string()));
+        assert_eq!(cfg.session.last_query, None);
+        assert_eq!(cfg.connections.len(), 1);
     }
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -63,6 +63,7 @@ use crate::{
     app::{
         command::{Command, ConfigUpdate},
         event::{Event, StateEvent},
+        session::SessionManager,
     },
     state::SharedState,
 };
@@ -258,6 +259,7 @@ impl UI {
         Self::register_formatter_callback(&window);
         Self::register_export_callbacks(&window, Arc::clone(&original_data));
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
+        Self::register_close_handler(&window);
         // Set initial page size and theme on the Slint window from shared state.
         let ui_global = window.global::<crate::UiState>();
         ui_global.set_page_size(state.ui.page_size() as i32);
@@ -267,6 +269,10 @@ impl UI {
             .unwrap_or_default();
         ui_global.set_font_family(config.appearance.font_family.into());
         ui_global.set_font_size(config.appearance.font_size as i32);
+        // Restore last editor query from previous session (last_query.sql).
+        if let Ok(Some(query)) = SessionManager::new().restore_query_file() {
+            ui_global.set_editor_text(query.into());
+        }
 
         Self::register_result_callbacks(
             &window,
@@ -647,6 +653,23 @@ impl UI {
                     Command::UpdateConfig(ConfigUpdate::Theme(new_theme)),
                 );
             });
+        });
+    }
+
+    // ── Window lifecycle ──────────────────────────────────────────────────────
+
+    fn register_close_handler(window: &crate::AppWindow) {
+        let window_weak = window.as_weak(); // clone required: on_close_requested closure
+        window.window().on_close_requested(move || {
+            let text = window_weak
+                .upgrade()
+                .map(|w| w.global::<crate::UiState>().get_editor_text().to_string())
+                .unwrap_or_default();
+            let sm = SessionManager::new();
+            if let Err(e) = sm.save_query_file(&text) {
+                tracing::warn!(error = %e, "failed to save last_query.sql on close");
+            }
+            slint::CloseRequestResponse::HideWindow
         });
     }
 

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -44,6 +44,18 @@ impl ConfigManager {
             .to_path_buf()
     }
 
+    /// Returns the directory that contains `config.toml`.
+    ///
+    /// Equivalent to `app_dir()` for the default instance; when created with
+    /// [`ConfigManager::with_path`] the directory of the supplied path is returned
+    /// instead — useful for tests that point at a temp directory.
+    pub fn dir(&self) -> PathBuf {
+        self.path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf()
+    }
+
     /// Loads configuration from `config.toml`.
     ///
     /// Returns `Config::default()` when the file does not exist.


### PR DESCRIPTION
## Summary

On window close, the editor's current query text is saved to `last_query.sql` in the app config directory. On next startup that file is read and the editor is pre-filled with the saved query, so in-progress work is never lost between sessions. Query text is stored in a dedicated file rather than embedded in `config.toml` to keep the config clean and handle arbitrarily large SQL without any size constraint.

## Changes

- `crates/wf-config/src/manager.rs`: add `ConfigManager::dir()` returning the directory that contains `config.toml` (also resolves correctly for test instances using `with_path`)
- `app/src/app/session.rs`: add `SessionManager::save_query_file` (writes `last_query.sql`) and `restore_query_file` (reads it back, returns `None` when absent or empty); 2 unit tests covering roundtrip and config.toml isolation
- `app/src/ui/mod.rs`: register `on_close_requested` handler that reads `UiState.editor-text` and calls `save_query_file`; restore saved query into `editor-text` during `UI::new` startup init

File layout after this change:
```
~/.config/wellfeather/
├── config.toml        ← connections / settings (unchanged)
└── last_query.sql     ← auto-saved editor content
```

## Related Issues

Closes #49

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes