### PR TITLE
feat(tracing): structured logging with RUST_LOG control

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, error, info, warn};
 use wf_completion::{cache::MetadataCache, service::CompletionService};
 use wf_db::{error::DbError, models::DbConnection, service::DbService};
 use wf_history::service::HistoryService;
@@ -115,6 +115,7 @@ impl AppController {
         self.metadata_cache = Some(cache);
 
         while let Some(cmd) = self.rx_cmd.recv().await {
+            debug!("received command: {:?}", cmd);
             match cmd {
                 Command::Connect(conn, pw) => self.handle_connect(conn, pw).await,
                 Command::TestConnection(conn, pw) => self.handle_test_connection(conn, pw).await,
@@ -252,6 +253,7 @@ impl AppController {
 
         let token = CancellationToken::new();
         self.state.query.set_cancel_token(token.clone());
+        debug!("sending event: QueryStarted");
         let _ = self.tx_event.send(Event::QueryStarted).await;
 
         let page_size = self.state.ui.page_size();
@@ -280,12 +282,15 @@ impl AppController {
                             warn!("failed to save history: {e}");
                         }
                     }
+                    debug!("sending event: QueryFinished");
                     let _ = tx.send(Event::QueryFinished(result)).await;
                 }
                 Err(DbError::Cancelled) => {
+                    debug!("sending event: QueryCancelled");
                     let _ = tx.send(Event::QueryCancelled).await;
                 }
                 Err(e) => {
+                    error!(error = %e, "query execution failed");
                     if let Some(ref h) = history {
                         let exec = wf_db::models::QueryExecution {
                             id: 0,
@@ -300,6 +305,7 @@ impl AppController {
                             warn!("failed to save history: {he}");
                         }
                     }
+                    debug!("sending event: QueryError");
                     let _ = tx.send(Event::QueryError(e.to_string())).await;
                 }
             }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -31,7 +31,9 @@ use wf_db::service::DbService;
 
 /// Entry point. Runs on the main OS thread; the Slint event loop must stay here.
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/wf-db/src/service.rs
+++ b/crates/wf-db/src/service.rs
@@ -73,6 +73,7 @@ impl DbService {
     ///
     /// Returns `Err(DbError::Cancelled)` if the token fires first.
     /// Returns `Err(DbError::ConnectionFailed)` if `conn_id` is not in the pool map.
+    #[tracing::instrument(skip(self, token))]
     pub async fn execute_with_cancel(
         &self,
         conn_id: &str,
@@ -80,10 +81,18 @@ impl DbService {
         token: CancellationToken,
     ) -> Result<QueryResult, DbError> {
         let pool = self.pool_for(conn_id)?;
-        tokio::select! {
+        let result = tokio::select! {
             result = pool.execute(sql) => result,
             _ = token.cancelled() => Err(DbError::Cancelled),
+        };
+        match &result {
+            Ok(r) => {
+                tracing::info!(conn_id = %conn_id, duration_ms = r.execution_time_ms, "query executed")
+            }
+            Err(DbError::Cancelled) => {}
+            Err(e) => tracing::error!(conn_id = %conn_id, error = %e, "query error"),
         }
+        result
     }
 
     /// Fetch schema metadata for the connection identified by `conn_id`.


### PR DESCRIPTION
## Summary

Adds structured logging throughout the app layer and `wf-db` so that verbosity can be controlled at runtime via `RUST_LOG`. Previously the tracing subscriber was initialized without an explicit `EnvFilter`, and the DB execution path had no instrumentation at all.

## Changes

- `main.rs`: initialize `tracing_subscriber` with `EnvFilter::from_default_env()` to honour `RUST_LOG`
- `controller.rs`: `debug!` on every received command in the run loop; `debug!` before sending `QueryStarted`, `QueryFinished`, and `QueryCancelled` events; `error!` for non-cancelled query execution failures
- `service.rs`: `#[tracing::instrument(skip(self, token))]` on `execute_with_cancel`; `info!` with `conn_id` and `duration_ms` on success; `error!` with `conn_id` and error on failure (cancellations are silent)

## Related Issues

Closes #51

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes