### PR TITLE
feat(i18n): add en/ja localization with runtime language switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +783,16 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2158,6 +2183,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,6 +2817,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2954,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3416,6 +3490,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4696,6 +4779,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-i18n"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21031bf5e6f2c0ae745d831791c403608e99a8bd3776c7e5e5535acd70c3b7ba"
+dependencies = [
+ "globwalk",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fe5295763b358606f7ca26a564e20f4469775a57ec1f09431249a33849ff52"
+dependencies = [
+ "glob",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bcc115c8eea2803aa3d85362e339776f4988a0349f2f475af572e497443f6f"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools 0.11.0",
+ "lazy_static",
+ "normpath",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "toml 0.8.23",
+ "triomphe",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4875,6 +5009,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4892,6 +5035,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5827,13 +5983,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5848,11 +6016,20 @@ checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5871,6 +6048,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5906,6 +6097,12 @@ checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5973,6 +6170,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6125,6 +6333,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unty"
@@ -6552,6 +6766,7 @@ dependencies = [
  "arboard",
  "chrono",
  "rfd",
+ "rust-i18n",
  "slint",
  "slint-build",
  "tempfile",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 arboard             = "3.6.1"
 rfd                 = { version = "0.15", features = ["tokio"] }
 uuid               = { workspace = true }
+rust-i18n          = "4.0.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/app/build.rs
+++ b/app/build.rs
@@ -21,5 +21,21 @@ fn main() {
         }
     }
 
-    slint_build::compile("src/ui/app.slint").expect("Failed to compile Slint UI");
+    // Watch .po translation files
+    println!("cargo:rerun-if-changed=lang");
+
+    // Watch all .slint files under src/ui/components/dialogs/
+    if let Ok(entries) = std::fs::read_dir("src/ui/components/dialogs") {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "slint") {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+
+    let config = slint_build::CompilerConfiguration::new()
+        .with_bundled_translations(std::path::Path::new("lang"));
+    slint_build::compile_with_config("src/ui/app.slint", config)
+        .expect("Failed to compile Slint UI");
 }

--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -1,0 +1,245 @@
+# English translations for Wellfeather UI
+msgid ""
+msgstr ""
+"Project-Id-Version: wellfeather 0.1.0\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "AppWindow"
+msgid "Select a cell to preview its value"
+msgstr "Select a cell to preview its value"
+
+msgctxt "AppWindow"
+msgid "NULL"
+msgstr "NULL"
+
+msgctxt "AppWindow"
+msgid "Error"
+msgstr "Error"
+
+msgctxt "AppWindow"
+msgid "Results"
+msgstr "Results"
+
+msgctxt "ResultTable"
+msgid "Running…"
+msgstr "Running…"
+
+msgctxt "ResultTable"
+msgid "Query Error"
+msgstr "Query Error"
+
+msgctxt "MenuBar"
+msgid "File"
+msgstr "File"
+
+msgctxt "MenuBar"
+msgid "Export CSV"
+msgstr "Export CSV"
+
+msgctxt "MenuBar"
+msgid "Export JSON"
+msgstr "Export JSON"
+
+msgctxt "MenuBar"
+msgid "Quit"
+msgstr "Quit"
+
+msgctxt "MenuBar"
+msgid "Edit"
+msgstr "Edit"
+
+msgctxt "MenuBar"
+msgid "Toggle Theme"
+msgstr "Toggle Theme"
+
+msgctxt "MenuBar"
+msgid "Query"
+msgstr "Query"
+
+msgctxt "MenuBar"
+msgid "Run (Ctrl+Enter)"
+msgstr "Run (Ctrl+Enter)"
+
+msgctxt "MenuBar"
+msgid "Run All (Ctrl+Shift+Enter)"
+msgstr "Run All (Ctrl+Shift+Enter)"
+
+msgctxt "MenuBar"
+msgid "Cancel (Esc)"
+msgstr "Cancel (Esc)"
+
+msgctxt "MenuBar"
+msgid "Settings"
+msgstr "Settings"
+
+msgctxt "MenuBar"
+msgid "Font Settings (coming soon)"
+msgstr "Font Settings (coming soon)"
+
+msgctxt "MenuBar"
+msgid "English"
+msgstr "English"
+
+msgctxt "MenuBar"
+msgid "Japanese"
+msgstr "Japanese"
+
+msgctxt "Sidebar"
+msgid "Loading…"
+msgstr "Loading…"
+
+msgctxt "Sidebar"
+msgid "＋ Add connection"
+msgstr "＋ Add connection"
+
+msgctxt "ResultTableBody"
+msgid "Copy cell value"
+msgstr "Copy cell value"
+
+msgctxt "ResultTableBody"
+msgid "Copy row (tab-separated)"
+msgstr "Copy row (tab-separated)"
+
+msgctxt "ResultTableBody"
+msgid "Copy as TSV (with headers)"
+msgstr "Copy as TSV (with headers)"
+
+msgctxt "ResultTableBody"
+msgid "NULL"
+msgstr "NULL"
+
+msgctxt "ResultTableBody"
+msgid "0 rows"
+msgstr "0 rows"
+
+msgctxt "ResultTableSearch"
+msgid "Filter:"
+msgstr "Filter:"
+
+msgctxt "ResultTableSearch"
+msgid "[Esc to clear]"
+msgstr "[Esc to clear]"
+
+msgctxt "ConnectionForm"
+msgid "Add Connection"
+msgstr "Add Connection"
+
+msgctxt "ConnectionForm"
+msgid "Name"
+msgstr "Name"
+
+msgctxt "ConnectionForm"
+msgid "Connection String"
+msgstr "Connection String"
+
+msgctxt "ConnectionForm"
+msgid "Individual Fields"
+msgstr "Individual Fields"
+
+msgctxt "ConnectionForm"
+msgid "Host"
+msgstr "Host"
+
+msgctxt "ConnectionForm"
+msgid "Port"
+msgstr "Port"
+
+msgctxt "ConnectionForm"
+msgid "User"
+msgstr "User"
+
+msgctxt "ConnectionForm"
+msgid "Password"
+msgstr "Password"
+
+msgctxt "ConnectionForm"
+msgid "Database"
+msgstr "Database"
+
+msgctxt "ConnectionForm"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "ConnectionForm"
+msgid "Testing…"
+msgstr "Testing…"
+
+msgctxt "ConnectionForm"
+msgid "Test Connection"
+msgstr "Test Connection"
+
+msgctxt "ConnectionForm"
+msgid "Add"
+msgstr "Add"
+
+msgctxt "ResultTableToolbar"
+msgid "Export"
+msgstr "Export"
+
+msgctxt "ResultTableToolbar"
+msgid "ALL"
+msgstr "ALL"
+
+msgctxt "ResultTableToolbar"
+msgid "Export CSV"
+msgstr "Export CSV"
+
+msgctxt "ResultTableToolbar"
+msgid "Export JSON"
+msgstr "Export JSON"
+
+msgctxt "ResultTableToolbar"
+msgid "{0} rows"
+msgstr "{0} rows"
+
+msgctxt "ResultTableToolbar"
+msgid "{0} / {1} rows"
+msgstr "{0} / {1} rows"
+
+msgctxt "AddConnectionDialog"
+msgid "Warning"
+msgstr "Warning"
+
+msgctxt "AddConnectionDialog"
+msgid "Connection test was not successful. Add anyway?"
+msgstr "Connection test was not successful. Add anyway?"
+
+msgctxt "AddConnectionDialog"
+msgid "No"
+msgstr "No"
+
+msgctxt "AddConnectionDialog"
+msgid "Yes"
+msgstr "Yes"
+
+msgctxt "AllRowsDialog"
+msgid "Fetch all rows?"
+msgstr "Fetch all rows?"
+
+msgctxt "AllRowsDialog"
+msgid "No LIMIT will be applied. This may take a long time for large tables."
+msgstr "No LIMIT will be applied. This may take a long time for large tables."
+
+msgctxt "AllRowsDialog"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "AllRowsDialog"
+msgid "Fetch"
+msgstr "Fetch"
+
+msgctxt "TestResultDialog"
+msgid "Connection Successful"
+msgstr "Connection Successful"
+
+msgctxt "TestResultDialog"
+msgid "Connection Failed"
+msgstr "Connection Failed"
+
+msgctxt "TestResultDialog"
+msgid "OK"
+msgstr "OK"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -1,0 +1,245 @@
+# Japanese translations for Wellfeather UI
+msgid ""
+msgstr ""
+"Project-Id-Version: wellfeather 0.1.0\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "AppWindow"
+msgid "Select a cell to preview its value"
+msgstr "セルを選択して値をプレビュー"
+
+msgctxt "AppWindow"
+msgid "NULL"
+msgstr "NULL"
+
+msgctxt "AppWindow"
+msgid "Error"
+msgstr "エラー"
+
+msgctxt "AppWindow"
+msgid "Results"
+msgstr "結果"
+
+msgctxt "ResultTable"
+msgid "Running…"
+msgstr "実行中…"
+
+msgctxt "ResultTable"
+msgid "Query Error"
+msgstr "クエリエラー"
+
+msgctxt "MenuBar"
+msgid "File"
+msgstr "ファイル"
+
+msgctxt "MenuBar"
+msgid "Export CSV"
+msgstr "CSV エクスポート"
+
+msgctxt "MenuBar"
+msgid "Export JSON"
+msgstr "JSON エクスポート"
+
+msgctxt "MenuBar"
+msgid "Quit"
+msgstr "終了"
+
+msgctxt "MenuBar"
+msgid "Edit"
+msgstr "編集"
+
+msgctxt "MenuBar"
+msgid "Toggle Theme"
+msgstr "テーマ切り替え"
+
+msgctxt "MenuBar"
+msgid "Query"
+msgstr "クエリ"
+
+msgctxt "MenuBar"
+msgid "Run (Ctrl+Enter)"
+msgstr "実行 (Ctrl+Enter)"
+
+msgctxt "MenuBar"
+msgid "Run All (Ctrl+Shift+Enter)"
+msgstr "全実行 (Ctrl+Shift+Enter)"
+
+msgctxt "MenuBar"
+msgid "Cancel (Esc)"
+msgstr "キャンセル (Esc)"
+
+msgctxt "MenuBar"
+msgid "Settings"
+msgstr "設定"
+
+msgctxt "MenuBar"
+msgid "Font Settings (coming soon)"
+msgstr "フォント設定（近日公開）"
+
+msgctxt "MenuBar"
+msgid "English"
+msgstr "English"
+
+msgctxt "MenuBar"
+msgid "Japanese"
+msgstr "日本語"
+
+msgctxt "Sidebar"
+msgid "Loading…"
+msgstr "読み込み中…"
+
+msgctxt "Sidebar"
+msgid "＋ Add connection"
+msgstr "＋ 接続を追加"
+
+msgctxt "ResultTableBody"
+msgid "Copy cell value"
+msgstr "セル値をコピー"
+
+msgctxt "ResultTableBody"
+msgid "Copy row (tab-separated)"
+msgstr "行をコピー（タブ区切り）"
+
+msgctxt "ResultTableBody"
+msgid "Copy as TSV (with headers)"
+msgstr "TSV でコピー（ヘッダー付き）"
+
+msgctxt "ResultTableBody"
+msgid "NULL"
+msgstr "NULL"
+
+msgctxt "ResultTableBody"
+msgid "0 rows"
+msgstr "0 行"
+
+msgctxt "ResultTableSearch"
+msgid "Filter:"
+msgstr "フィルター:"
+
+msgctxt "ResultTableSearch"
+msgid "[Esc to clear]"
+msgstr "[Esc でクリア]"
+
+msgctxt "ConnectionForm"
+msgid "Add Connection"
+msgstr "接続を追加"
+
+msgctxt "ConnectionForm"
+msgid "Name"
+msgstr "名前"
+
+msgctxt "ConnectionForm"
+msgid "Connection String"
+msgstr "接続文字列"
+
+msgctxt "ConnectionForm"
+msgid "Individual Fields"
+msgstr "個別フィールド"
+
+msgctxt "ConnectionForm"
+msgid "Host"
+msgstr "ホスト"
+
+msgctxt "ConnectionForm"
+msgid "Port"
+msgstr "ポート"
+
+msgctxt "ConnectionForm"
+msgid "User"
+msgstr "ユーザー"
+
+msgctxt "ConnectionForm"
+msgid "Password"
+msgstr "パスワード"
+
+msgctxt "ConnectionForm"
+msgid "Database"
+msgstr "データベース"
+
+msgctxt "ConnectionForm"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "ConnectionForm"
+msgid "Testing…"
+msgstr "テスト中…"
+
+msgctxt "ConnectionForm"
+msgid "Test Connection"
+msgstr "接続テスト"
+
+msgctxt "ConnectionForm"
+msgid "Add"
+msgstr "追加"
+
+msgctxt "ResultTableToolbar"
+msgid "Export"
+msgstr "エクスポート"
+
+msgctxt "ResultTableToolbar"
+msgid "ALL"
+msgstr "全件"
+
+msgctxt "ResultTableToolbar"
+msgid "Export CSV"
+msgstr "CSV エクスポート"
+
+msgctxt "ResultTableToolbar"
+msgid "Export JSON"
+msgstr "JSON エクスポート"
+
+msgctxt "ResultTableToolbar"
+msgid "{0} rows"
+msgstr "{0} 行"
+
+msgctxt "ResultTableToolbar"
+msgid "{0} / {1} rows"
+msgstr "{0} / {1} 行"
+
+msgctxt "AddConnectionDialog"
+msgid "Warning"
+msgstr "警告"
+
+msgctxt "AddConnectionDialog"
+msgid "Connection test was not successful. Add anyway?"
+msgstr "接続テストに失敗しました。それでも追加しますか？"
+
+msgctxt "AddConnectionDialog"
+msgid "No"
+msgstr "いいえ"
+
+msgctxt "AddConnectionDialog"
+msgid "Yes"
+msgstr "はい"
+
+msgctxt "AllRowsDialog"
+msgid "Fetch all rows?"
+msgstr "全件取得しますか？"
+
+msgctxt "AllRowsDialog"
+msgid "No LIMIT will be applied. This may take a long time for large tables."
+msgstr "LIMIT なしで実行されます。大きなテーブルでは時間がかかる場合があります。"
+
+msgctxt "AllRowsDialog"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "AllRowsDialog"
+msgid "Fetch"
+msgstr "取得"
+
+msgctxt "TestResultDialog"
+msgid "Connection Successful"
+msgstr "接続成功"
+
+msgctxt "TestResultDialog"
+msgid "Connection Failed"
+msgstr "接続失敗"
+
+msgctxt "TestResultDialog"
+msgid "OK"
+msgstr "OK"

--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -1,0 +1,16 @@
+en:
+  status:
+    running: "Running…"
+    query_finished: "%{ms} ms  ·  %{rows} rows"
+    cancelled: "Cancelled"
+    error: "Error: %{msg}"
+    disconnected: "Disconnected: %{id}"
+    not_connected: "Not connected"
+    connect_failed: "Connection failed: %{msg}"
+    metadata_unavailable: "Metadata unavailable: %{msg}"
+  error:
+    no_active_connection: "No active connection"
+    db_connect_failed: "Failed to connect: %{reason}"
+    query_failed: "Query error: %{reason}"
+    query_cancelled: "Query cancelled"
+    db_error: "Database error: %{reason}"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  status:
+    running: "実行中…"
+    query_finished: "%{ms} ms  ·  %{rows} 行"
+    cancelled: "キャンセルしました"
+    error: "エラー: %{msg}"
+    disconnected: "切断しました: %{id}"
+    not_connected: "未接続"
+    connect_failed: "接続に失敗しました: %{msg}"
+    metadata_unavailable: "メタデータを取得できませんでした: %{msg}"
+  error:
+    no_active_connection: "接続がありません"
+    db_connect_failed: "接続に失敗しました: %{reason}"
+    query_failed: "クエリエラー: %{reason}"
+    query_cancelled: "クエリをキャンセルしました"
+    db_error: "データベースエラー: %{reason}"

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -16,6 +16,7 @@
 use std::path::PathBuf;
 
 use chrono::Utc;
+use rust_i18n::t;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -25,6 +26,7 @@ use wf_history::service::HistoryService;
 
 use crate::{
     app::{
+        LocalizedMessage,
         command::{Command, ConfigUpdate},
         event::{Event, StateEvent},
         session::SessionManager,
@@ -183,7 +185,10 @@ impl AppController {
             }
             Err(e) => {
                 warn!(conn_id = %id, error = %e, "connection failed");
-                let _ = self.tx_event.send(Event::ConnectError(e.to_string())).await;
+                let _ = self
+                    .tx_event
+                    .send(Event::ConnectError(e.localized_message()))
+                    .await;
             }
         }
     }
@@ -208,7 +213,7 @@ impl AppController {
                 warn!(conn_id = %id, error = %e, "test connection failed");
                 let _ = self
                     .tx_event
-                    .send(Event::TestConnectionFailed(e.to_string()))
+                    .send(Event::TestConnectionFailed(e.localized_message()))
                     .await;
             }
         }
@@ -243,7 +248,9 @@ impl AppController {
                 warn!("RunQuery: no active connection");
                 let _ = self
                     .tx_event
-                    .send(Event::QueryError("no active connection".to_string()))
+                    .send(Event::QueryError(
+                        t!("error.no_active_connection").to_string(),
+                    ))
                     .await;
                 return;
             }
@@ -306,7 +313,7 @@ impl AppController {
                         }
                     }
                     debug!("sending event: QueryError");
-                    let _ = tx.send(Event::QueryError(e.to_string())).await;
+                    let _ = tx.send(Event::QueryError(e.localized_message())).await;
                 }
             }
         });
@@ -335,6 +342,11 @@ impl AppController {
                     warn!(error = %e, "failed to persist page_size to config");
                 }
                 let _ = self.tx_event.send(Event::ConfigUpdated).await;
+            }
+            ConfigUpdate::Language(lang) => {
+                if let Err(e) = self.session.save_language(&lang) {
+                    warn!(error = %e, "failed to persist language to config");
+                }
             }
             _ => {}
         }

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -1,0 +1,17 @@
+use rust_i18n::t;
+use wf_db::error::DbError;
+
+pub trait LocalizedMessage {
+    fn localized_message(&self) -> String;
+}
+
+impl LocalizedMessage for DbError {
+    fn localized_message(&self) -> String {
+        match self {
+            DbError::ConnectionFailed(s) => t!("error.db_connect_failed", reason = s).to_string(),
+            DbError::QueryError(s) => t!("error.query_failed", reason = s).to_string(),
+            DbError::Cancelled => t!("error.query_cancelled").to_string(),
+            DbError::Sqlx(e) => t!("error.db_error", reason = e.to_string()).to_string(),
+        }
+    }
+}

--- a/app/src/app/mod.rs
+++ b/app/src/app/mod.rs
@@ -3,4 +3,7 @@
 pub mod command;
 pub mod controller;
 pub mod event;
+pub mod localized_message;
 pub mod session;
+
+pub use localized_message::LocalizedMessage;

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -96,6 +96,26 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Persist `lang` as `[ui].language` in `config.toml`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config file cannot be loaded or written.
+    pub fn save_language(&self, lang: &str) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for language save")?;
+
+        config.ui.language = lang.to_string();
+
+        self.config_manager
+            .save(&config)
+            .context("failed to save language")?;
+        info!(%lang, "language saved");
+        Ok(())
+    }
+
     /// Persist `theme` as `[appearance].theme` in `config.toml`.
     ///
     /// # Errors

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -16,6 +16,7 @@
 //! ```
 
 slint::include_modules!();
+rust_i18n::i18n!("locales", fallback = "en");
 
 mod app;
 mod state;
@@ -49,6 +50,8 @@ fn main() -> anyhow::Result<()> {
     let state = Arc::new(AppState::new());
 
     // Load persisted page_size and theme from config so the first launch uses the user's last settings.
+    // Language locale is applied in UI::new() after the Slint component is created — Slint requires
+    // a live component to exist before select_bundled_translation() takes effect.
     {
         let config = ConfigManager::new().load().unwrap_or_default();
         state

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -143,6 +143,12 @@ export global UiState {
     /// Toggle between dark and light theme; Rust persists the choice.
     callback toggle-theme();
 
+    // ── Language ──────────────────────────────────────────────────────────────
+    /// Active locale code ("en" or "ja"). Initialised from config.toml by Rust.
+    in-out property <string> language: "en";
+    /// Switch locale; Rust calls select_bundled_translation + set_locale and persists.
+    callback set-language(string);
+
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
     callback run-all(string);
@@ -294,6 +300,7 @@ export component AppWindow inherits Window {
             y: 0;
             width:        root.width;
             editor-text:  UiState.editor-text;
+            language:     UiState.language;
             export-csv   => { UiState.export-csv(); }
             export-json  => { UiState.export-json(); }
             quit         => { UiState.quit(); }
@@ -301,6 +308,7 @@ export component AppWindow inherits Window {
             run-query(sql) => { UiState.run-query(sql); }
             run-all(sql)   => { UiState.run-all(sql); }
             cancel-query   => { UiState.cancel-query(); }
+            set-language(lang) => { UiState.set-language(lang); }
         }
 
         // ── Sidebar ───────────────────────────────────────────────────────────

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -16,7 +16,9 @@ export component MenuBar inherits Rectangle {
     callback run-query(string);
     callback run-all(string);
     callback cancel-query();
+    callback set-language(string);
     in property <string> editor-text;
+    in property <string> language: "en";
 
     // Bottom border separating menu bar from content area
     Rectangle {
@@ -194,12 +196,12 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  220px;
-                height: 30px;
+                height: 91px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  220px;
-                    height: 30px;
+                    height: 91px;
                     background:    Colors.surface0;
                     border-radius: 4px;
                     border-width:  1px;
@@ -211,6 +213,15 @@ export component MenuBar inherits Rectangle {
                     VerticalLayout {
                         spacing: 0;
                         MenuItem { text: @tr("Font Settings (coming soon)"); }
+                        Rectangle { height: 1px; background: Colors.surface1; }
+                        MenuItem {
+                            text: (root.language == "en" ? "✓ " : "  ") + @tr("English");
+                            clicked => { root.set-language("en"); }
+                        }
+                        MenuItem {
+                            text: (root.language == "ja" ? "✓ " : "  ") + @tr("Japanese");
+                            clicked => { root.set-language("ja"); }
+                        }
                     }
                 }
             }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use rust_i18n::t;
 use slint::ComponentHandle;
 use slint::Model as _;
 use tokio::sync::mpsc;
@@ -270,6 +271,12 @@ impl UI {
             .unwrap_or_default();
         ui_global.set_font_family(config.appearance.font_family.into());
         ui_global.set_font_size(config.appearance.font_size as i32);
+        // Apply locale after the Slint component exists — select_bundled_translation
+        // requires a live component and is a no-op if called before one is created.
+        let lang = &config.ui.language;
+        let _ = slint::select_bundled_translation(lang);
+        rust_i18n::set_locale(lang);
+        ui_global.set_language(lang.clone().into());
         // Restore last editor query from previous session (last_query.sql).
         if let Ok(Some(query)) = SessionManager::new().restore_query_file() {
             ui_global.set_editor_text(query.into());
@@ -281,6 +288,7 @@ impl UI {
             Arc::clone(&original_data),
             tx_cmd.clone(),
         );
+        Self::register_language_callback(&window, tx_cmd.clone());
         Self::register_status_callbacks(&window, state.clone());
         Self::spawn_event_handler(
             &window,
@@ -444,7 +452,7 @@ impl UI {
             with_ui(&ww, |ui| {
                 ui.set_form_testing(false);
                 ui.set_form_status(msg.clone().into());
-                ui.set_status_message(format!("Connection failed: {msg}").into());
+                ui.set_status_message(t!("status.connect_failed", msg = msg).to_string().into());
                 ui.set_sidebar_loading(false);
             });
         });
@@ -456,7 +464,7 @@ impl UI {
             with_ui(&ww, |ui| {
                 ui.set_is_loading(true);
                 ui.set_error_message("".into());
-                ui.set_status_message("Running\u{2026}".into());
+                ui.set_status_message(t!("status.running").to_string().into());
                 ui.set_result_panel_open(true);
             });
         });
@@ -500,7 +508,11 @@ impl UI {
                 let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
                 ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
                 ui.set_result_total_col_width(total_w);
-                ui.set_status_message(format!("{exec_ms} ms  ·  {row_count} rows").into());
+                ui.set_status_message(
+                    t!("status.query_finished", ms = exec_ms, rows = row_count)
+                        .to_string()
+                        .into(),
+                );
                 ui.set_result_panel_open(true);
             });
         });
@@ -511,7 +523,7 @@ impl UI {
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, |ui| {
                 ui.set_is_loading(false);
-                ui.set_status_message("Cancelled".into());
+                ui.set_status_message(t!("status.cancelled").to_string().into());
             });
         });
     }
@@ -531,7 +543,7 @@ impl UI {
                 ui.set_form_status(msg.clone().into());
                 ui.set_form_testing(false);
                 ui.set_error_message(msg.into());
-                ui.set_status_message(format!("Error: {summary}").into());
+                ui.set_status_message(t!("status.error", msg = summary).to_string().into());
                 ui.set_result_panel_open(true);
             });
         });
@@ -541,8 +553,8 @@ impl UI {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, move |ui| {
-                ui.set_status_message(format!("Disconnected: {id}").into());
-                ui.set_status_connection("Not connected".into());
+                ui.set_status_message(t!("status.disconnected", id = id).to_string().into());
+                ui.set_status_connection(t!("status.not_connected").to_string().into());
             });
         });
     }
@@ -582,7 +594,11 @@ impl UI {
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, move |ui| {
                 ui.set_sidebar_loading(false);
-                ui.set_status_message(format!("Metadata unavailable: {msg}").into());
+                ui.set_status_message(
+                    t!("status.metadata_unavailable", msg = msg)
+                        .to_string()
+                        .into(),
+                );
             });
         });
     }
@@ -1477,6 +1493,23 @@ impl UI {
                 });
             });
         }
+    }
+
+    // ── Language callback ─────────────────────────────────────────────────────
+
+    fn register_language_callback(window: &crate::AppWindow, tx_cmd: mpsc::Sender<Command>) {
+        let ui = window.global::<crate::UiState>();
+        let window_weak = window.as_weak(); // clone required: on_set_language closure
+        ui.on_set_language(move |lang| {
+            let lang = lang.to_string();
+            // Immediate locale switch on the UI thread — all @tr() bindings re-evaluate.
+            let _ = slint::select_bundled_translation(&lang);
+            rust_i18n::set_locale(&lang);
+            // Update UiState.language so the checkmarks in the menu update.
+            with_ui(&window_weak, |ui| ui.set_language(lang.clone().into()));
+            // Persist to config.toml via controller.
+            send_cmd(&tx_cmd, Command::UpdateConfig(ConfigUpdate::Language(lang)));
+        });
     }
 
     // ── Status callbacks (TODO) ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements hybrid i18n support (issue #79): Slint bundled translations (`@tr()` + `.po` files) for all UI strings, and `rust-i18n` (`t!()` + `.yml` files) for Rust-side status and error messages. Language can be switched at runtime via Settings → Language menu and persists to `config.toml` across restarts.

## Changes

- `app/build.rs`: use `compile_with_config` with `with_bundled_translations("lang")` so `.po` files are compiled into the binary
- `app/src/main.rs`: add `rust_i18n::i18n!("locales", fallback = "en")` at crate root
- `app/src/ui/mod.rs`: call `select_bundled_translation` + `set_locale` after `AppWindow::new()`, replace 8 hardcoded status strings with `t!()`, add `register_language_callback`
- `app/src/app/localized_message.rs` (new): `LocalizedMessage` trait + `DbError` impl using `t!()`
- `app/src/app/controller.rs`: use `t!("error.no_active_connection")` and `.localized_message()` for typed errors; handle `ConfigUpdate::Language`
- `app/src/app/session.rs`: add `save_language()` to persist locale choice to config
- `app/src/ui/app.slint`: expose `language` property + `set-language` callback on `UiState` global
- `app/src/ui/components/menu_bar.slint`: Settings popup with English / Japanese selectors (checkmark on active)
- `app/lang/en/LC_MESSAGES/wellfeather.po` + `app/lang/ja/LC_MESSAGES/wellfeather.po` (new): full UI string translations for all 11 components
- `app/locales/en.yml` + `app/locales/ja.yml` (new): `status.*` and `error.*` keys for rust-i18n

## Related Issues

Closes #79

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes