### PR TITLE
fix: replace rust-i18n with locale module; fix partial SQL execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,15 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,12 +649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base62"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,16 +768,6 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
  "cfg_aliases",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -2183,30 +2158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
-dependencies = [
- "bitflags 1.3.2",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,22 +2768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,15 +2889,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3490,15 +3416,6 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "normpath"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4779,57 +4696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-i18n"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21031bf5e6f2c0ae745d831791c403608e99a8bd3776c7e5e5535acd70c3b7ba"
-dependencies = [
- "globwalk",
- "regex",
- "rust-i18n-macro",
- "rust-i18n-support",
- "smallvec",
-]
-
-[[package]]
-name = "rust-i18n-macro"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fe5295763b358606f7ca26a564e20f4469775a57ec1f09431249a33849ff52"
-dependencies = [
- "glob",
- "proc-macro2",
- "quote",
- "rust-i18n-support",
- "serde",
- "serde_json",
- "serde_yaml",
- "syn",
-]
-
-[[package]]
-name = "rust-i18n-support"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69bcc115c8eea2803aa3d85362e339776f4988a0349f2f475af572e497443f6f"
-dependencies = [
- "arc-swap",
- "base62",
- "globwalk",
- "itertools 0.11.0",
- "lazy_static",
- "normpath",
- "proc-macro2",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "siphasher",
- "toml 0.8.23",
- "triomphe",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,15 +4875,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -5035,19 +4892,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5983,25 +5827,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6016,20 +5848,11 @@ checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6048,20 +5871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -6097,12 +5906,6 @@ checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow 1.0.1",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6170,17 +5973,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
-dependencies = [
- "arc-swap",
- "serde",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -6333,12 +6125,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unty"
@@ -6766,7 +6552,6 @@ dependencies = [
  "arboard",
  "chrono",
  "rfd",
- "rust-i18n",
  "slint",
  "slint-build",
  "tempfile",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -19,7 +19,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 arboard             = "3.6.1"
 rfd                 = { version = "0.15", features = ["tokio"] }
 uuid               = { workspace = true }
-rust-i18n          = "4.0.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -16,7 +16,6 @@
 use std::path::PathBuf;
 
 use chrono::Utc;
-use rust_i18n::t;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -248,9 +247,10 @@ impl AppController {
                 warn!("RunQuery: no active connection");
                 let _ = self
                     .tx_event
-                    .send(Event::QueryError(
-                        t!("error.no_active_connection").to_string(),
-                    ))
+                    .send(Event::QueryError(crate::app::locale::tr(
+                        "error.no_active_connection",
+                        &[],
+                    )))
                     .await;
                 return;
             }
@@ -393,6 +393,11 @@ fn apply_limit(sql: &str, limit: usize) -> String {
         return sql.to_string();
     }
     let trimmed = sql.trim().trim_end_matches(';').trim_end();
+    // Multi-statement SQL (semicolon in the middle) must not have LIMIT injected;
+    // the caller is responsible for splitting statements before calling apply_limit.
+    if trimmed.contains(';') {
+        return sql.to_string();
+    }
     let upper = trimmed.to_uppercase();
     if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") {
         format!("{} LIMIT {}", trimmed, limit)
@@ -504,6 +509,12 @@ mod tests {
     #[test]
     fn apply_limit_should_not_apply_when_limit_is_zero() {
         assert_eq!(apply_limit("SELECT * FROM t", 0), "SELECT * FROM t");
+    }
+
+    #[test]
+    fn apply_limit_should_not_apply_to_multi_statement_sql() {
+        let multi = "SELECT * FROM a;\nSELECT * FROM b";
+        assert_eq!(apply_limit(multi, 500), multi);
     }
 
     // ── TestConnection ────────────────────────────────────────────────────────

--- a/app/src/app/locale.rs
+++ b/app/src/app/locale.rs
@@ -1,0 +1,124 @@
+/// Simple locale module — replaces rust-i18n for Rust-side messages.
+///
+/// rust-i18n v4.0.0 fails silently on Windows because normpath converts
+/// the locales directory to a Windows path, which globwalk cannot glob
+/// against correctly.  This module provides the same interface with a
+/// plain match-table approach that is guaranteed to work on all platforms.
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static IS_JA: AtomicBool = AtomicBool::new(false);
+
+pub fn set_locale(lang: &str) {
+    IS_JA.store(lang == "ja", Ordering::SeqCst);
+}
+
+/// Look up a translation key with optional `%{name}` interpolation.
+///
+/// Returns the English string when the locale is not Japanese, or when the
+/// key is not found in either table (returns the key itself as fallback).
+pub fn tr(key: &str, params: &[(&str, &str)]) -> String {
+    let template = if IS_JA.load(Ordering::SeqCst) {
+        ja(key).unwrap_or(key)
+    } else {
+        en(key).unwrap_or(key)
+    };
+    if params.is_empty() {
+        return template.to_string();
+    }
+    let mut s = template.to_string();
+    for (name, val) in params {
+        s = s.replace(&format!("%{{{name}}}"), val);
+    }
+    s
+}
+
+fn en(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "status.running" => "Running\u{2026}",
+        "status.query_finished" => "%{ms} ms  \u{00b7}  %{rows} rows",
+        "status.cancelled" => "Cancelled",
+        "status.error" => "Error: %{msg}",
+        "status.disconnected" => "Disconnected: %{id}",
+        "status.not_connected" => "Not connected",
+        "status.connect_failed" => "Connection failed: %{msg}",
+        "status.metadata_unavailable" => "Metadata unavailable: %{msg}",
+        "error.no_active_connection" => "No active connection",
+        "error.db_connect_failed" => "Failed to connect: %{reason}",
+        "error.query_failed" => "Query error: %{reason}",
+        "error.query_cancelled" => "Query cancelled",
+        "error.db_error" => "Database error: %{reason}",
+        _ => return None,
+    })
+}
+
+fn ja(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "status.running" => "\u{5b9f}\u{884c}\u{4e2d}\u{2026}",
+        "status.query_finished" => "%{ms} ms  \u{00b7}  %{rows} \u{884c}",
+        "status.cancelled" => {
+            "\u{30ad}\u{30e3}\u{30f3}\u{30bb}\u{30eb}\u{3057}\u{307e}\u{3057}\u{305f}"
+        }
+        "status.error" => "\u{30a8}\u{30e9}\u{30fc}: %{msg}",
+        "status.disconnected" => "\u{5207}\u{65ad}\u{3057}\u{307e}\u{3057}\u{305f}: %{id}",
+        "status.not_connected" => "\u{672a}\u{63a5}\u{7d9a}",
+        "status.connect_failed" => {
+            "\u{63a5}\u{7d9a}\u{306b}\u{5931}\u{6557}\u{3057}\u{307e}\u{3057}\u{305f}: %{msg}"
+        }
+        "status.metadata_unavailable" => {
+            "\u{30e1}\u{30bf}\u{30c7}\u{30fc}\u{30bf}\u{3092}\u{53d6}\u{5f97}\u{3067}\u{304d}\u{307e}\u{305b}\u{3093}\u{3067}\u{3057}\u{305f}: %{msg}"
+        }
+        "error.no_active_connection" => {
+            "\u{63a5}\u{7d9a}\u{304c}\u{3042}\u{308a}\u{307e}\u{305b}\u{3093}"
+        }
+        "error.db_connect_failed" => {
+            "\u{63a5}\u{7d9a}\u{306b}\u{5931}\u{6557}\u{3057}\u{307e}\u{3057}\u{305f}: %{reason}"
+        }
+        "error.query_failed" => "\u{30af}\u{30a8}\u{30ea}\u{30a8}\u{30e9}\u{30fc}: %{reason}",
+        "error.query_cancelled" => {
+            "\u{30af}\u{30a8}\u{30ea}\u{3092}\u{30ad}\u{30e3}\u{30f3}\u{30bb}\u{30eb}\u{3057}\u{307e}\u{3057}\u{305f}"
+        }
+        "error.db_error" => {
+            "\u{30c7}\u{30fc}\u{30bf}\u{30d9}\u{30fc}\u{30b9}\u{30a8}\u{30e9}\u{30fc}: %{reason}"
+        }
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tr_should_return_english_by_default() {
+        set_locale("en");
+        assert_eq!(tr("status.running", &[]), "Running\u{2026}");
+        assert_eq!(
+            tr("error.no_active_connection", &[]),
+            "No active connection"
+        );
+    }
+
+    #[test]
+    fn tr_should_interpolate_params() {
+        set_locale("en");
+        let result = tr("error.db_error", &[("reason", "conn refused")]);
+        assert_eq!(result, "Database error: conn refused");
+    }
+
+    #[test]
+    fn tr_should_return_japanese_when_locale_is_ja() {
+        set_locale("ja");
+        assert_eq!(
+            tr("status.cancelled", &[]),
+            "\u{30ad}\u{30e3}\u{30f3}\u{30bb}\u{30eb}\u{3057}\u{307e}\u{3057}\u{305f}"
+        );
+        assert_eq!(tr("status.not_connected", &[]), "\u{672a}\u{63a5}\u{7d9a}");
+        set_locale("en"); // restore
+    }
+
+    #[test]
+    fn tr_should_return_key_for_unknown_keys() {
+        set_locale("en");
+        assert_eq!(tr("nonexistent.key", &[]), "nonexistent.key");
+    }
+}

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -1,4 +1,4 @@
-use rust_i18n::t;
+use crate::app::locale;
 use wf_db::error::DbError;
 
 pub trait LocalizedMessage {
@@ -8,10 +8,38 @@ pub trait LocalizedMessage {
 impl LocalizedMessage for DbError {
     fn localized_message(&self) -> String {
         match self {
-            DbError::ConnectionFailed(s) => t!("error.db_connect_failed", reason = s).to_string(),
-            DbError::QueryError(s) => t!("error.query_failed", reason = s).to_string(),
-            DbError::Cancelled => t!("error.query_cancelled").to_string(),
-            DbError::Sqlx(e) => t!("error.db_error", reason = e.to_string()).to_string(),
+            DbError::ConnectionFailed(s) => {
+                locale::tr("error.db_connect_failed", &[("reason", s.as_str())])
+            }
+            DbError::QueryError(s) => locale::tr("error.query_failed", &[("reason", s.as_str())]),
+            DbError::Cancelled => locale::tr("error.query_cancelled", &[]),
+            DbError::Sqlx(e) => {
+                let reason = e.to_string();
+                locale::tr("error.db_error", &[("reason", &reason)])
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::locale;
+
+    #[test]
+    fn tr_should_resolve_error_db_error_key() {
+        locale::set_locale("en");
+        let result = locale::tr("error.db_error", &[("reason", "test reason")]);
+        assert_ne!(result, "error.db_error", "tr() returned raw key");
+        assert!(
+            result.contains("test reason"),
+            "placeholder not interpolated: {result}"
+        );
+    }
+
+    #[test]
+    fn tr_should_resolve_status_running_key() {
+        locale::set_locale("en");
+        let result = locale::tr("status.running", &[]);
+        assert_ne!(result, "status.running", "tr() returned raw key");
     }
 }

--- a/app/src/app/mod.rs
+++ b/app/src/app/mod.rs
@@ -3,6 +3,7 @@
 pub mod command;
 pub mod controller;
 pub mod event;
+pub mod locale;
 pub mod localized_message;
 pub mod session;
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -16,7 +16,6 @@
 //! ```
 
 slint::include_modules!();
-rust_i18n::i18n!("locales", fallback = "en");
 
 mod app;
 mod state;

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -152,6 +152,9 @@ export global UiState {
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
     callback run-all(string);
+    /// Fired by Ctrl+Enter in the editor. Rust extracts the statement at cursor
+    /// or the selected text and sends Command::RunSelection.
+    callback run-query-at-cursor(string, int, int, int);
     callback cancel-query();
     callback quit();
 
@@ -379,7 +382,9 @@ export component AppWindow inherits Window {
                 line-count:      UiState.count-lines(UiState.editor-text);
                 cursor-line(text, pos) => { UiState.cursor-line(text, pos); }
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
-                run-query => { UiState.run-query(UiState.editor-text); }
+                run-query(sql, cursor, sel-start, sel-end) => {
+                    UiState.run-query-at-cursor(sql, cursor, sel-start, sel-end);
+                }
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -65,8 +65,9 @@ export component Editor inherits Rectangle {
     pure callback move-cursor-line(string, int, int) -> int;
 
     /// Fired when the user presses Ctrl+Enter to run the current SQL.
-    /// Implemented in app.slint by forwarding to UiState.run-query.
-    callback run-query();
+    /// Carries (text, cursor-pos, selection-start, selection-end) so Rust
+    /// can extract the statement at cursor or the selected text.
+    callback run-query(string, int, int, int);
 
     /// Fired when the user presses Ctrl+J to toggle the result panel.
     /// Implemented in app.slint by toggling UiState.result-panel-open.
@@ -336,7 +337,12 @@ export component Editor inherits Rectangle {
                     }
                     EventResult.accept
                 } else if (event.text == Key.Return && event.modifiers.control) {
-                    root.run-query();
+                    root.run-query(
+                        inner-input.text,
+                        inner-input.cursor-position-byte-offset,
+                        inner-input.anchor-position-byte-offset,
+                        inner-input.cursor-position-byte-offset
+                    );
                     EventResult.accept
                 } else if (event.text == "j" && event.modifiers.control) {
                     root.toggle-panel();

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use crate::app::locale;
 use anyhow::Result;
-use rust_i18n::t;
 use slint::ComponentHandle;
 use slint::Model as _;
 use tokio::sync::mpsc;
@@ -275,7 +275,7 @@ impl UI {
         // requires a live component and is a no-op if called before one is created.
         let lang = &config.ui.language;
         let _ = slint::select_bundled_translation(lang);
-        rust_i18n::set_locale(lang);
+        locale::set_locale(lang);
         ui_global.set_language(lang.clone().into());
         // Restore last editor query from previous session (last_query.sql).
         if let Ok(Some(query)) = SessionManager::new().restore_query_file() {
@@ -452,7 +452,7 @@ impl UI {
             with_ui(&ww, |ui| {
                 ui.set_form_testing(false);
                 ui.set_form_status(msg.clone().into());
-                ui.set_status_message(t!("status.connect_failed", msg = msg).to_string().into());
+                ui.set_status_message(locale::tr("status.connect_failed", &[("msg", &msg)]).into());
                 ui.set_sidebar_loading(false);
             });
         });
@@ -464,7 +464,7 @@ impl UI {
             with_ui(&ww, |ui| {
                 ui.set_is_loading(true);
                 ui.set_error_message("".into());
-                ui.set_status_message(t!("status.running").to_string().into());
+                ui.set_status_message(locale::tr("status.running", &[]).into());
                 ui.set_result_panel_open(true);
             });
         });
@@ -508,10 +508,14 @@ impl UI {
                 let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
                 ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
                 ui.set_result_total_col_width(total_w);
+                let ms_str = exec_ms.to_string();
+                let rows_str = row_count.to_string();
                 ui.set_status_message(
-                    t!("status.query_finished", ms = exec_ms, rows = row_count)
-                        .to_string()
-                        .into(),
+                    locale::tr(
+                        "status.query_finished",
+                        &[("ms", &ms_str), ("rows", &rows_str)],
+                    )
+                    .into(),
                 );
                 ui.set_result_panel_open(true);
             });
@@ -523,7 +527,7 @@ impl UI {
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, |ui| {
                 ui.set_is_loading(false);
-                ui.set_status_message(t!("status.cancelled").to_string().into());
+                ui.set_status_message(locale::tr("status.cancelled", &[]).into());
             });
         });
     }
@@ -543,7 +547,7 @@ impl UI {
                 ui.set_form_status(msg.clone().into());
                 ui.set_form_testing(false);
                 ui.set_error_message(msg.into());
-                ui.set_status_message(t!("status.error", msg = summary).to_string().into());
+                ui.set_status_message(locale::tr("status.error", &[("msg", &summary)]).into());
                 ui.set_result_panel_open(true);
             });
         });
@@ -553,8 +557,8 @@ impl UI {
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, move |ui| {
-                ui.set_status_message(t!("status.disconnected", id = id).to_string().into());
-                ui.set_status_connection(t!("status.not_connected").to_string().into());
+                ui.set_status_message(locale::tr("status.disconnected", &[("id", &id)]).into());
+                ui.set_status_connection(locale::tr("status.not_connected", &[]).into());
             });
         });
     }
@@ -595,9 +599,7 @@ impl UI {
             with_ui(&ww, move |ui| {
                 ui.set_sidebar_loading(false);
                 ui.set_status_message(
-                    t!("status.metadata_unavailable", msg = msg)
-                        .to_string()
-                        .into(),
+                    locale::tr("status.metadata_unavailable", &[("msg", &msg)]).into(),
                 );
             });
         });
@@ -963,6 +965,22 @@ impl UI {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui.on_run_query(move |sql| {
                 send_cmd(&tx_cmd, Command::RunQuery(sql.to_string()));
+            });
+        }
+        {
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            ui.on_run_query_at_cursor(move |sql, cursor_pos, sel_start, sel_end| {
+                let sql = sql.to_string();
+                let sel_s = sel_start as usize;
+                let sel_e = sel_end as usize;
+                let stmt = if sel_s != sel_e {
+                    wf_query::analyzer::extract_selection(&sql, sel_s, sel_e).to_string()
+                } else {
+                    wf_query::analyzer::extract_statement_at(&sql, cursor_pos as usize).to_string()
+                };
+                if !stmt.trim().is_empty() {
+                    send_cmd(&tx_cmd, Command::RunSelection(stmt));
+                }
             });
         }
         {
@@ -1504,7 +1522,7 @@ impl UI {
             let lang = lang.to_string();
             // Immediate locale switch on the UI thread — all @tr() bindings re-evaluate.
             let _ = slint::select_bundled_translation(&lang);
-            rust_i18n::set_locale(&lang);
+            locale::set_locale(&lang);
             // Update UiState.language so the checkmarks in the menu update.
             with_ui(&window_weak, |ui| ui.set_language(lang.clone().into()));
             // Persist to config.toml via controller.


### PR DESCRIPTION
## Summary

Two bug fixes implemented together in this PR:

1. **Rust-side i18n broken on Windows**: `rust-i18n` v4.0.0 uses `normpath` to normalize the locales directory path, producing Windows-format backslash paths. `globwalk` then fails to find any `.yml` files because it expects forward-slash separators. The translation map is silently empty, so every `t!()` call returns the raw key string (e.g. `error.db_error` instead of `Database error: …`).

2. **Partial SQL execution (Ctrl+Enter)**: Running Ctrl+Enter on a multi-statement editor sent the full text to the database instead of the statement at the cursor, causing syntax errors. Also, `apply_limit` would incorrectly append `LIMIT N` to multi-statement SQL.

## Changes

**Localization fix (`rust-i18n` → custom `locale` module)**
- Add `app/src/app/locale.rs`: simple `AtomicBool` + match-table approach with no file I/O — guaranteed to work on all platforms
- Replace all `rust_i18n::t!()` / `rust_i18n::set_locale()` call sites in `controller.rs`, `ui/mod.rs`, and `localized_message.rs` with `locale::tr()` / `locale::set_locale()`
- Remove `rust-i18n = "4.0.0"` from `app/Cargo.toml` and the `i18n!()` macro from `main.rs`
- Slint built-in `@tr()` strings are unaffected (separate mechanism, was already working)

**Partial SQL execution**
- `editor.slint`: `run-query` callback now passes `cursor-position-byte-offset` and `anchor-position-byte-offset` alongside the full text
- `app.slint`: wire `run-query-at-cursor(sql, cursor, sel-start, sel-end)` through `UiState`
- `ui/mod.rs`: `on_run_query_at_cursor` handler uses `extract_selection` when text is selected, otherwise `extract_statement_at` for the statement under the cursor
- `controller.rs`: guard in `apply_limit` rejects multi-statement SQL (internal `;`) to prevent malformed `LIMIT` injection

## Related Issues

Follows up #79 (localization feature — Rust-side messages were silently broken on Windows after that PR merged)

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes