### PR TITLE
fix(i18n): remove locale root key from yml files so t!() resolves translations

### DIFF
--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -1,16 +1,15 @@
-en:
-  status:
-    running: "Running…"
-    query_finished: "%{ms} ms  ·  %{rows} rows"
-    cancelled: "Cancelled"
-    error: "Error: %{msg}"
-    disconnected: "Disconnected: %{id}"
-    not_connected: "Not connected"
-    connect_failed: "Connection failed: %{msg}"
-    metadata_unavailable: "Metadata unavailable: %{msg}"
-  error:
-    no_active_connection: "No active connection"
-    db_connect_failed: "Failed to connect: %{reason}"
-    query_failed: "Query error: %{reason}"
-    query_cancelled: "Query cancelled"
-    db_error: "Database error: %{reason}"
+status:
+  running: "Running…"
+  query_finished: "%{ms} ms  ·  %{rows} rows"
+  cancelled: "Cancelled"
+  error: "Error: %{msg}"
+  disconnected: "Disconnected: %{id}"
+  not_connected: "Not connected"
+  connect_failed: "Connection failed: %{msg}"
+  metadata_unavailable: "Metadata unavailable: %{msg}"
+error:
+  no_active_connection: "No active connection"
+  db_connect_failed: "Failed to connect: %{reason}"
+  query_failed: "Query error: %{reason}"
+  query_cancelled: "Query cancelled"
+  db_error: "Database error: %{reason}"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -1,16 +1,15 @@
-ja:
-  status:
-    running: "実行中…"
-    query_finished: "%{ms} ms  ·  %{rows} 行"
-    cancelled: "キャンセルしました"
-    error: "エラー: %{msg}"
-    disconnected: "切断しました: %{id}"
-    not_connected: "未接続"
-    connect_failed: "接続に失敗しました: %{msg}"
-    metadata_unavailable: "メタデータを取得できませんでした: %{msg}"
-  error:
-    no_active_connection: "接続がありません"
-    db_connect_failed: "接続に失敗しました: %{reason}"
-    query_failed: "クエリエラー: %{reason}"
-    query_cancelled: "クエリをキャンセルしました"
-    db_error: "データベースエラー: %{reason}"
+status:
+  running: "実行中…"
+  query_finished: "%{ms} ms  ·  %{rows} 行"
+  cancelled: "キャンセルしました"
+  error: "エラー: %{msg}"
+  disconnected: "切断しました: %{id}"
+  not_connected: "未接続"
+  connect_failed: "接続に失敗しました: %{msg}"
+  metadata_unavailable: "メタデータを取得できませんでした: %{msg}"
+error:
+  no_active_connection: "接続がありません"
+  db_connect_failed: "接続に失敗しました: %{reason}"
+  query_failed: "クエリエラー: %{reason}"
+  query_cancelled: "クエリをキャンセルしました"
+  db_error: "データベースエラー: %{reason}"

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -15,3 +15,30 @@ impl LocalizedMessage for DbError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rust_i18n::t;
+
+    #[test]
+    fn t_macro_should_resolve_error_db_error_key() {
+        let result = t!("error.db_error", reason = "test reason").to_string();
+        assert_ne!(
+            result, "error.db_error",
+            "t!() returned raw key — translations not compiled in"
+        );
+        assert!(
+            result.contains("test reason"),
+            "placeholder not interpolated: {result}"
+        );
+    }
+
+    #[test]
+    fn t_macro_should_resolve_status_running_key() {
+        let result = t!("status.running").to_string();
+        assert_ne!(
+            result, "status.running",
+            "t!() returned raw key — translations not compiled in"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`t!()` was returning raw keys at runtime because `app/locales/en.yml` and `ja.yml` wrapped all content under an `en:` / `ja:` root key (Rails-style i18n convention). In rust-i18n v1 format the locale is derived from the filename, so wrapping content caused every key to be stored as `"en.status.running"` instead of `"status.running"`, making all lookups silently fail.

## Changes

- Remove top-level `en:` key from `app/locales/en.yml`
- Remove top-level `ja:` key from `app/locales/ja.yml`
- Add two regression tests in `localized_message.rs` that assert `t!()` returns translated text and interpolates placeholders correctly

## Related Issues

Fixes #79

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes