### PR TITLE
feat(editor): run statement at cursor on Ctrl+Enter

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -123,7 +123,7 @@ impl AppController {
                 Command::TestConnection(conn, pw) => self.handle_test_connection(conn, pw).await,
                 Command::Disconnect(id) => self.handle_disconnect(id).await,
                 Command::RunQuery(sql) => self.handle_run_query(sql).await,
-                Command::RunAll(sql) => self.handle_run_query(sql).await,
+                Command::RunAll(sql) => self.handle_run_all(sql).await,
                 Command::RunSelection(sql) => self.handle_run_query(sql).await,
                 Command::CancelQuery => self.handle_cancel_query().await,
                 Command::UpdateConfig(update) => self.handle_update_config(update).await,
@@ -314,6 +314,112 @@ impl AppController {
                     }
                     debug!("sending event: QueryError");
                     let _ = tx.send(Event::QueryError(e.localized_message())).await;
+                }
+            }
+        });
+    }
+
+    /// Handle a `RunAll` command.
+    ///
+    /// Splits the SQL on semicolons and executes each non-empty statement
+    /// sequentially using a single cancellation token.  Only the result of the
+    /// last statement is surfaced to the UI so the result panel is not spammed.
+    /// This approach is DB-agnostic and does not require any special driver flags
+    /// (e.g. MySQL `CLIENT_MULTI_STATEMENTS`).
+    async fn handle_run_all(&self, sql: String) {
+        self.state.query.cancel();
+
+        let conn_id = match self.state.conn.active() {
+            Some(c) => c.id.clone(),
+            None => {
+                warn!("RunAll: no active connection");
+                let _ = self
+                    .tx_event
+                    .send(Event::QueryError(
+                        t!("error.no_active_connection").to_string(),
+                    ))
+                    .await;
+                return;
+            }
+        };
+
+        let stmts: Vec<String> = wf_query::analyzer::extract_all_statements(&sql)
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+
+        if stmts.is_empty() {
+            return;
+        }
+
+        self.state.query.set_last_sql(sql.clone());
+
+        let token = CancellationToken::new();
+        self.state.query.set_cancel_token(token.clone());
+        let _ = self.tx_event.send(Event::QueryStarted).await;
+
+        let page_size = self.state.ui.page_size();
+        let db = self.db.clone(); // clone required: tokio::spawn needs 'static
+        let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
+        let history = self.history.clone(); // clone required: tokio::spawn needs 'static
+        let conn_id_hist = conn_id.clone(); // clone required: history record needs owned id
+
+        tokio::spawn(async move {
+            let now = Utc::now().timestamp();
+
+            for (i, stmt) in stmts.iter().enumerate() {
+                let sql_to_run = apply_limit(stmt, page_size);
+                let is_last = i == stmts.len() - 1;
+
+                match db
+                    .execute_with_cancel(&conn_id, &sql_to_run, token.clone())
+                    .await
+                {
+                    Ok(result) => {
+                        if is_last {
+                            if let Some(ref h) = history {
+                                let exec = wf_db::models::QueryExecution {
+                                    id: 0,
+                                    sql: stmt.clone(),
+                                    duration_ms: result.execution_time_ms,
+                                    success: true,
+                                    error_message: None,
+                                    timestamp: now,
+                                    connection_id: conn_id_hist.clone(),
+                                };
+                                if let Err(e) = h.insert(&exec).await {
+                                    warn!("failed to save history: {e}");
+                                }
+                            }
+                            debug!("sending event: QueryFinished (run-all last stmt)");
+                            let _ = tx.send(Event::QueryFinished(result)).await;
+                        }
+                    }
+                    Err(DbError::Cancelled) => {
+                        debug!("sending event: QueryCancelled");
+                        let _ = tx.send(Event::QueryCancelled).await;
+                        return;
+                    }
+                    Err(e) => {
+                        error!(error = %e, "run-all statement failed");
+                        if let Some(ref h) = history {
+                            let exec = wf_db::models::QueryExecution {
+                                id: 0,
+                                sql: stmt.clone(),
+                                duration_ms: 0,
+                                success: false,
+                                error_message: Some(e.to_string()),
+                                timestamp: now,
+                                connection_id: conn_id_hist.clone(),
+                            };
+                            if let Err(he) = h.insert(&exec).await {
+                                warn!("failed to save history: {he}");
+                            }
+                        }
+                        debug!("sending event: QueryError");
+                        let _ = tx.send(Event::QueryError(e.localized_message())).await;
+                        return;
+                    }
                 }
             }
         });

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -394,7 +394,7 @@ fn apply_limit(sql: &str, limit: usize) -> String {
     }
     let trimmed = sql.trim().trim_end_matches(';').trim_end();
     let upper = trimmed.to_uppercase();
-    if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") {
+    if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") && !trimmed.contains(';') {
         format!("{} LIMIT {}", trimmed, limit)
     } else {
         sql.to_string()
@@ -504,6 +504,12 @@ mod tests {
     #[test]
     fn apply_limit_should_not_apply_when_limit_is_zero() {
         assert_eq!(apply_limit("SELECT * FROM t", 0), "SELECT * FROM t");
+    }
+
+    #[test]
+    fn apply_limit_should_not_apply_to_multi_statement_sql() {
+        let sql = "SELECT 1; SELECT 2";
+        assert_eq!(apply_limit(sql, 500), sql);
     }
 
     // ── TestConnection ────────────────────────────────────────────────────────

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -151,6 +151,9 @@ export global UiState {
 
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
+    /// Ctrl+Enter from the editor: carries full text + cursor + anchor so Rust
+    /// can extract the statement under the cursor or the selected range.
+    callback run-query-at-cursor(string, int, int);
     callback run-all(string);
     callback cancel-query();
     callback quit();
@@ -379,7 +382,7 @@ export component AppWindow inherits Window {
                 line-count:      UiState.count-lines(UiState.editor-text);
                 cursor-line(text, pos) => { UiState.cursor-line(text, pos); }
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
-                run-query => { UiState.run-query(UiState.editor-text); }
+                run-query(cursor, anchor) => { UiState.run-query-at-cursor(UiState.editor-text, cursor, anchor); }
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -383,6 +383,7 @@ export component AppWindow inherits Window {
                 cursor-line(text, pos) => { UiState.cursor-line(text, pos); }
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
                 run-query(cursor) => { UiState.run-query-at-cursor(UiState.editor-text, cursor); }
+                run-all => { UiState.run-all(UiState.editor-text); }
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -151,9 +151,9 @@ export global UiState {
 
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
-    /// Ctrl+Enter from the editor: carries full text + cursor + anchor so Rust
-    /// can extract the statement under the cursor or the selected range.
-    callback run-query-at-cursor(string, int, int);
+    /// Ctrl+Enter from the editor: carries full text + cursor position so Rust
+    /// can extract the statement at the cursor.
+    callback run-query-at-cursor(string, int);
     callback run-all(string);
     callback cancel-query();
     callback quit();
@@ -382,7 +382,7 @@ export component AppWindow inherits Window {
                 line-count:      UiState.count-lines(UiState.editor-text);
                 cursor-line(text, pos) => { UiState.cursor-line(text, pos); }
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
-                run-query(cursor, anchor) => { UiState.run-query-at-cursor(UiState.editor-text, cursor, anchor); }
+                run-query(cursor) => { UiState.run-query-at-cursor(UiState.editor-text, cursor); }
                 toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -65,10 +65,10 @@ export component Editor inherits Rectangle {
     pure callback move-cursor-line(string, int, int) -> int;
 
     /// Fired when the user presses Ctrl+Enter to run the current SQL.
-    /// Carries the cursor byte offset and anchor byte offset so the handler
-    /// can extract the statement under the cursor or the selected range.
-    /// Implemented in app.slint by forwarding to UiState.run-query-at-cursor.
-    callback run-query(int, int);
+    /// Carries the cursor byte offset so the handler can extract the statement
+    /// at the cursor position.  Implemented in app.slint by forwarding to
+    /// UiState.run-query-at-cursor.
+    callback run-query(int);
 
     /// Fired when the user presses Ctrl+J to toggle the result panel.
     /// Implemented in app.slint by toggling UiState.result-panel-open.
@@ -338,10 +338,7 @@ export component Editor inherits Rectangle {
                     }
                     EventResult.accept
                 } else if (event.text == Key.Return && event.modifiers.control) {
-                    root.run-query(
-                        inner-input.cursor-position-byte-offset,
-                        inner-input.anchor-position-byte-offset
-                    );
+                    root.run-query(inner-input.cursor-position-byte-offset);
                     EventResult.accept
                 } else if (event.text == "j" && event.modifiers.control) {
                     root.toggle-panel();

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -110,6 +110,10 @@ export component Editor inherits Rectangle {
     // ── Key-hold state for timer-based UP/DOWN navigation ────────────────────
     property <bool> up-held:   false;
     property <bool> down-held: false;
+    // Armed after the initial-delay timer fires; gates the repeat timer so a
+    // brief tap never triggers more than one movement.
+    property <bool> up-repeat-ready:   false;
+    property <bool> down-repeat-ready: false;
 
     // ── Cursor-line poll timer ────────────────────────────────────────────────
     // NOT a reactive binding — polling at 60 fps keeps key-event processing to
@@ -134,12 +138,27 @@ export component Editor inherits Rectangle {
         }
     }
 
+    // ── Initial-delay timers ──────────────────────────────────────────────────
+    // Fire once ~250 ms after the key is first held.  Setting repeat-ready arms
+    // the sustained-movement timer, matching the OS key-repeat initial delay.
+    // The timer stops itself because the running condition becomes false once
+    // repeat-ready is true.
+    Timer {
+        interval: 250ms;
+        running: root.up-held && !root.up-repeat-ready;
+        triggered => { root.up-repeat-ready = true; }
+    }
+    Timer {
+        interval: 250ms;
+        running: root.down-held && !root.down-repeat-ready;
+        triggered => { root.down-repeat-ready = true; }
+    }
+
     // ── Sustained UP movement timer ───────────────────────────────────────────
-    // Fires while the up arrow is held (after the initial press handled by
-    // capture-key-pressed).  Interval matches a typical OS key-repeat rate.
+    // Only fires after the initial delay has elapsed (up-repeat-ready = true).
     Timer {
         interval: 50ms;
-        running: root.up-held;
+        running: root.up-held && root.up-repeat-ready;
         triggered => {
             let new-pos = root.move-cursor-line(
                 inner-input.text,
@@ -153,7 +172,7 @@ export component Editor inherits Rectangle {
     // ── Sustained DOWN movement timer ─────────────────────────────────────────
     Timer {
         interval: 50ms;
-        running: root.down-held;
+        running: root.down-held && root.down-repeat-ready;
         triggered => {
             let new-pos = root.move-cursor-line(
                 inner-input.text,
@@ -369,8 +388,14 @@ export component Editor inherits Rectangle {
             }
 
             capture-key-released(event) => {
-                if (event.text == Key.UpArrow)   { root.up-held   = false; }
-                if (event.text == Key.DownArrow)  { root.down-held = false; }
+                if (event.text == Key.UpArrow) {
+                    root.up-held         = false;
+                    root.up-repeat-ready = false;
+                }
+                if (event.text == Key.DownArrow) {
+                    root.down-held         = false;
+                    root.down-repeat-ready = false;
+                }
                 EventResult.reject
             }
 

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -65,8 +65,10 @@ export component Editor inherits Rectangle {
     pure callback move-cursor-line(string, int, int) -> int;
 
     /// Fired when the user presses Ctrl+Enter to run the current SQL.
-    /// Implemented in app.slint by forwarding to UiState.run-query.
-    callback run-query();
+    /// Carries the cursor byte offset and anchor byte offset so the handler
+    /// can extract the statement under the cursor or the selected range.
+    /// Implemented in app.slint by forwarding to UiState.run-query-at-cursor.
+    callback run-query(int, int);
 
     /// Fired when the user presses Ctrl+J to toggle the result panel.
     /// Implemented in app.slint by toggling UiState.result-panel-open.
@@ -336,7 +338,10 @@ export component Editor inherits Rectangle {
                     }
                     EventResult.accept
                 } else if (event.text == Key.Return && event.modifiers.control) {
-                    root.run-query();
+                    root.run-query(
+                        inner-input.cursor-position-byte-offset,
+                        inner-input.anchor-position-byte-offset
+                    );
                     EventResult.accept
                 } else if (event.text == "j" && event.modifiers.control) {
                     root.toggle-panel();

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -19,8 +19,9 @@ import { Colors } from "../theme.slint";
 //   intercepts UP/DOWN arrow key events in the capture phase (before TextInput
 //   processes them), preventing OS key-repeat events from piling up in the queue.
 //   Timer-based cursor movement replaces key-repeat for UP/DOWN.
-//   All other keys (text entry, Shift+arrows, Ctrl+arrows, etc.) pass through to
-//   TextInput unchanged.
+//   Shift+UP/DOWN are also intercepted for range selection using the same
+//   timer pattern.  All other keys (text entry, Ctrl+arrows, etc.) pass through
+//   to TextInput unchanged.
 //
 // Key-repeat queue problem (why the FocusScope approach is necessary):
 //   Holding an arrow key causes the OS to enqueue ~33 WM_KEYDOWN/s.  If each
@@ -115,6 +116,16 @@ export component Editor inherits Rectangle {
     property <bool> up-repeat-ready:   false;
     property <bool> down-repeat-ready: false;
 
+    // ── Key-hold state for Shift+UP/DOWN range selection ──────────────────
+    property <bool> up-shift-held:   false;
+    property <bool> down-shift-held: false;
+    property <bool> up-shift-repeat-ready:   false;
+    property <bool> down-shift-repeat-ready: false;
+    // Byte offset of the fixed end of an active shift-selection.
+    // -1 = no active selection.  Set on first Shift+arrow press; reset when
+    // the cursor moves outside of a shift-selection context (plain nav or click).
+    property <int>  sel-anchor: -1;
+
     // ── Cursor-line poll timer ────────────────────────────────────────────────
     // NOT a reactive binding — polling at 60 fps keeps key-event processing to
     // pure TextInput internals (essentially free) so rapid key-repeat bursts do
@@ -180,6 +191,46 @@ export component Editor inherits Rectangle {
                 1
             );
             inner-input.set-selection-offsets(new-pos, new-pos);
+        }
+    }
+
+    // ── Initial-delay timers for Shift+UP/DOWN selection ─────────────────────
+    Timer {
+        interval: 250ms;
+        running: root.up-shift-held && !root.up-shift-repeat-ready;
+        triggered => { root.up-shift-repeat-ready = true; }
+    }
+    Timer {
+        interval: 250ms;
+        running: root.down-shift-held && !root.down-shift-repeat-ready;
+        triggered => { root.down-shift-repeat-ready = true; }
+    }
+
+    // ── Sustained Shift+UP selection timer ───────────────────────────────────
+    Timer {
+        interval: 50ms;
+        running: root.up-shift-held && root.up-shift-repeat-ready;
+        triggered => {
+            let new-pos = root.move-cursor-line(
+                inner-input.text,
+                inner-input.cursor-position-byte-offset,
+                -1
+            );
+            inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+        }
+    }
+
+    // ── Sustained Shift+DOWN selection timer ─────────────────────────────────
+    Timer {
+        interval: 50ms;
+        running: root.down-shift-held && root.down-shift-repeat-ready;
+        triggered => {
+            let new-pos = root.move-cursor-line(
+                inner-input.text,
+                inner-input.cursor-position-byte-offset,
+                1
+            );
+            inner-input.set-selection-offsets(root.sel-anchor, new-pos);
         }
     }
 
@@ -331,6 +382,44 @@ export component Editor inherits Rectangle {
                         EventResult.reject
                     }
                 } else if (event.text == Key.UpArrow
+                        && event.modifiers.shift
+                        && !event.modifiers.control
+                        && !event.modifiers.alt) {
+                    if (!root.up-shift-held) {
+                        // Set held flag BEFORE set-selection-offsets so that
+                        // cursor-position-changed does not reset sel-anchor.
+                        root.up-shift-held = true;
+                        if (root.sel-anchor < 0) {
+                            root.sel-anchor = inner-input.cursor-position-byte-offset;
+                        }
+                        let new-pos = root.move-cursor-line(
+                            inner-input.text,
+                            inner-input.cursor-position-byte-offset,
+                            -1
+                        );
+                        inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.DownArrow
+                        && event.modifiers.shift
+                        && !event.modifiers.control
+                        && !event.modifiers.alt) {
+                    if (!root.down-shift-held) {
+                        // Set held flag BEFORE set-selection-offsets so that
+                        // cursor-position-changed does not reset sel-anchor.
+                        root.down-shift-held = true;
+                        if (root.sel-anchor < 0) {
+                            root.sel-anchor = inner-input.cursor-position-byte-offset;
+                        }
+                        let new-pos = root.move-cursor-line(
+                            inner-input.text,
+                            inner-input.cursor-position-byte-offset,
+                            1
+                        );
+                        inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.UpArrow
                         && !event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
@@ -389,12 +478,16 @@ export component Editor inherits Rectangle {
 
             capture-key-released(event) => {
                 if (event.text == Key.UpArrow) {
-                    root.up-held         = false;
-                    root.up-repeat-ready = false;
+                    root.up-held               = false;
+                    root.up-repeat-ready       = false;
+                    root.up-shift-held         = false;
+                    root.up-shift-repeat-ready = false;
                 }
                 if (event.text == Key.DownArrow) {
-                    root.down-held         = false;
-                    root.down-repeat-ready = false;
+                    root.down-held               = false;
+                    root.down-repeat-ready       = false;
+                    root.down-shift-held         = false;
+                    root.down-shift-repeat-ready = false;
                 }
                 EventResult.reject
             }
@@ -427,6 +520,13 @@ export component Editor inherits Rectangle {
                 // viewport-x is ≤ 0; visible content spans
                 //   [-viewport-x, -viewport-x + editor-scroll.width].
                 cursor-position-changed(pos) => {
+                    // Reset shift-selection anchor whenever the cursor moves
+                    // outside of an active Shift+arrow sequence (plain nav,
+                    // mouse click, typing, etc.).
+                    if (!root.down-shift-held && !root.up-shift-held) {
+                        root.sel-anchor = -1;
+                    }
+
                     let margin    = 40px;
                     let vis-left  = -editor-scroll.viewport-x;
                     let vis-right = vis-left + editor-scroll.width;

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -83,6 +83,10 @@ export component Editor inherits Rectangle {
     /// Carries the current SQL text and cursor byte offset.
     callback trigger-completion(string, int);
 
+    /// Fired when the user presses Ctrl+Shift+Enter to run all SQL statements.
+    /// Implemented in app.slint by forwarding to UiState.run-all.
+    callback run-all();
+
     /// Fired when the user presses Ctrl+Shift+F to reformat the SQL.
     callback format-sql();
 
@@ -337,7 +341,14 @@ export component Editor inherits Rectangle {
                         root.down-held = true;
                     }
                     EventResult.accept
-                } else if (event.text == Key.Return && event.modifiers.control) {
+                } else if (event.text == Key.Return
+                        && event.modifiers.control
+                        && event.modifiers.shift) {
+                    root.run-all();
+                    EventResult.accept
+                } else if (event.text == Key.Return
+                        && event.modifiers.control
+                        && !event.modifiers.shift) {
                     root.run-query(inner-input.cursor-position-byte-offset);
                     EventResult.accept
                 } else if (event.text == "j" && event.modifiers.control) {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -947,7 +947,7 @@ impl UI {
             } else {
                 // Move down: target the next line.
                 match s[pos..].find('\n') {
-                    None => pos as i32, // Already on last line — stay.
+                    None => s.len() as i32, // Extend to end of text on last line.
                     Some(off) => {
                         let next_start = pos + off + 1;
                         let next_end = s[next_start..]

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 use wf_completion::CompletionItem;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
-use wf_query::analyzer::{extract_selection, extract_statement_at};
+use wf_query::analyzer::extract_statement_at;
 
 const COMPLETION_DEBOUNCE_MS: u64 = 300;
 const ERROR_TRUNCATION_CHARS: usize = 80;
@@ -968,22 +968,10 @@ impl UI {
         }
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
-            ui.on_run_query_at_cursor(move |sql, cursor, anchor| {
-                let sql = sql.as_str();
-                let cursor = cursor as usize;
-                let anchor = anchor as usize;
-                let stmt = if cursor != anchor {
-                    let (start, end) = if cursor <= anchor {
-                        (cursor, anchor)
-                    } else {
-                        (anchor, cursor)
-                    };
-                    extract_selection(sql, start, end).to_owned()
-                } else {
-                    extract_statement_at(sql, cursor).to_owned()
-                };
+            ui.on_run_query_at_cursor(move |sql, cursor| {
+                let stmt = extract_statement_at(sql.as_str(), cursor as usize);
                 if !stmt.is_empty() {
-                    send_cmd(&tx_cmd, Command::RunQuery(stmt));
+                    send_cmd(&tx_cmd, Command::RunQuery(stmt.to_owned()));
                 }
             });
         }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc;
 use wf_completion::CompletionItem;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
+use wf_query::analyzer::{extract_selection, extract_statement_at};
 
 const COMPLETION_DEBOUNCE_MS: u64 = 300;
 const ERROR_TRUNCATION_CHARS: usize = 80;
@@ -963,6 +964,27 @@ impl UI {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
             ui.on_run_query(move |sql| {
                 send_cmd(&tx_cmd, Command::RunQuery(sql.to_string()));
+            });
+        }
+        {
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            ui.on_run_query_at_cursor(move |sql, cursor, anchor| {
+                let sql = sql.as_str();
+                let cursor = cursor as usize;
+                let anchor = anchor as usize;
+                let stmt = if cursor != anchor {
+                    let (start, end) = if cursor <= anchor {
+                        (cursor, anchor)
+                    } else {
+                        (anchor, cursor)
+                    };
+                    extract_selection(sql, start, end).to_owned()
+                } else {
+                    extract_statement_at(sql, cursor).to_owned()
+                };
+                if !stmt.is_empty() {
+                    send_cmd(&tx_cmd, Command::RunQuery(stmt));
+                }
             });
         }
         {

--- a/crates/wf-query/src/analyzer.rs
+++ b/crates/wf-query/src/analyzer.rs
@@ -8,15 +8,42 @@
 /// If the input has no semicolon the whole string is returned trimmed.
 pub fn extract_statement_at(sql: &str, cursor_pos: usize) -> &str {
     let mut pos: usize = 0;
+    let mut last: &str = "";
     for segment in sql.split(';') {
         let end = pos + segment.len();
         if cursor_pos <= end {
-            return segment.trim();
+            let trimmed = segment.trim();
+            if trimmed.is_empty() {
+                return last;
+            }
+            // A cursor that lands within the leading newline whitespace of a segment
+            // is visually "at end of the previous line" — attribute it to the
+            // preceding statement rather than this one.
+            let prefix_len = segment.len() - segment.trim_start().len();
+            if cursor_pos < pos + prefix_len && segment[..prefix_len].contains('\n') {
+                return last;
+            }
+            return trimmed;
+        }
+        let t = segment.trim();
+        if !t.is_empty() {
+            last = t;
         }
         pos = end + 1; // skip the ';'
     }
-    // cursor_pos is past the end of the string — return the whole text trimmed
-    sql.trim()
+    // cursor_pos is past the end of the string
+    if last.is_empty() { sql.trim() } else { last }
+}
+
+/// Splits `sql` on semicolons and returns all non-empty, trimmed statements.
+///
+/// Suitable for "run all" operations: each returned string is a single
+/// statement ready to send to the database individually.
+pub fn extract_all_statements(sql: &str) -> Vec<&str> {
+    sql.split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 /// Returns the substring of `sql` for the byte range `start..end`.
@@ -51,8 +78,8 @@ mod tests {
         assert_eq!(extract_statement_at("SELECT 1;", 7), "SELECT 1");
         // cursor ON the semicolon (byte 8) — belongs to the preceding statement
         assert_eq!(extract_statement_at("SELECT 1;", 8), "SELECT 1");
-        // cursor after the semicolon — empty trailing segment
-        assert_eq!(extract_statement_at("SELECT 1;", 9), "");
+        // cursor after the semicolon — empty trailing segment returns preceding statement
+        assert_eq!(extract_statement_at("SELECT 1;", 9), "SELECT 1");
     }
 
     #[test]
@@ -91,6 +118,27 @@ mod tests {
         assert_eq!(extract_statement_at(sql, 0), "SELECT 1");
         assert_eq!(extract_statement_at(sql, 10), "SELECT 2");
         assert_eq!(extract_statement_at(sql, 20), "SELECT 3");
+    }
+
+    #[test]
+    fn extract_statement_at_should_attribute_newline_to_preceding_statement() {
+        let sql = "SELECT 1;\nSELECT 2;\nSELECT 3";
+        //                    9^         19^
+        // Cursor at '\n' after ';' is visually end-of-line — belongs to preceding stmt.
+        assert_eq!(extract_statement_at(sql, 9), "SELECT 1");
+        assert_eq!(extract_statement_at(sql, 19), "SELECT 2");
+        // Cursor at first char of the next statement belongs to that statement.
+        assert_eq!(extract_statement_at(sql, 10), "SELECT 2");
+    }
+
+    #[test]
+    fn extract_statement_at_should_return_last_statement_when_cursor_past_end() {
+        // Trailing semicolon — cursor one past the ';'
+        assert_eq!(extract_statement_at("SELECT 1;", 9), "SELECT 1");
+        // Trailing semicolon + newline — cursor at/past the newline
+        let sql = "SELECT 1;\nSELECT 2;\n";
+        assert_eq!(extract_statement_at(sql, 19), "SELECT 2");
+        assert_eq!(extract_statement_at(sql, 20), "SELECT 2");
     }
 
     // ── extract_selection ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements partial SQL execution UX: Ctrl+Enter runs the statement at the cursor position, Ctrl+Shift+Enter runs all statements sequentially, UP/DOWN arrow key-repeat uses an OS-style initial delay, and Shift+Up/Down extends or shrinks the selection line by line with key-repeat support.

## Changes

- `editor.slint`: `run-query(cursor)` carries cursor byte offset; new `run-all()` callback fires on Ctrl+Shift+Enter; Ctrl+Enter handler now guards `!event.modifiers.shift` so the two shortcuts are mutually exclusive
- `editor.slint`: UP/DOWN key-repeat uses a two-timer model — 250 ms initial-delay timer arms `up/down-repeat-ready`; the 50 ms repeat timer only runs after the flag is set, preventing a brief tap from advancing two lines
- `editor.slint`: Shift+Up/Down range selection with key-repeat — manually tracked `sel-anchor` property ensures the anchor stays fixed across repeated events; `set-selection-offsets(anchor, cursor)` drives the highlight; `held` flag is set before calling `set-selection-offsets` to prevent `cursor-position-changed` from resetting the anchor
- `app.slint`: `run-query-at-cursor(sql, cursor)` on `UiState`; `run-all` wired to `UiState.run-all(editor-text)`
- `ui/mod.rs`: `on_run_query_at_cursor` calls `extract_statement_at` to run only the statement under the cursor; `on_move_cursor_line` now returns `s.len()` instead of `pos` when the cursor is already on the last line, so Shift+Down from the last line extends the selection to end of text
- `controller.rs`: new `handle_run_all` splits SQL on semicolons via `extract_all_statements` and executes each statement in order — only the last result is surfaced to the UI; stops on first error or cancellation
- `controller.rs`: `apply_limit` skips `LIMIT` injection when the SQL contains an internal semicolon
- `wf-query/analyzer.rs`: `extract_statement_at` fixed for two edge cases — cursor past a trailing semicolon now returns the last non-empty statement; cursor on a leading newline is attributed to the preceding statement
- `wf-query/analyzer.rs`: new `extract_all_statements` splits SQL into individual trimmed, non-empty statements for run-all use

## Related Issues

Closes #79

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes