### PR TITLE
feat(ui): Database tab and connection form keyboard navigation

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -89,6 +89,14 @@ msgid "Japanese"
 msgstr "Japanese"
 
 msgctxt "Sidebar"
+msgid "Schema"
+msgstr "Schema"
+
+msgctxt "Sidebar"
+msgid "DB"
+msgstr "DB"
+
+msgctxt "Sidebar"
 msgid "Loading…"
 msgstr "Loading…"
 

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -89,6 +89,14 @@ msgid "Japanese"
 msgstr "日本語"
 
 msgctxt "Sidebar"
+msgid "Schema"
+msgstr "スキーマ"
+
+msgctxt "Sidebar"
+msgid "DB"
+msgstr "DB"
+
+msgctxt "Sidebar"
 msgid "Loading…"
 msgstr "読み込み中…"
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -176,6 +176,8 @@ export global UiState {
     in-out property <bool> result-panel-open: false;
     callback connect(string);
     callback disconnect(string);
+    /// Connect to a saved connection from the DB tab by id.
+    callback connect-db(string);
 
     // ── Connection management callbacks ───────────────────────────────────────
     callback open-connection-form();
@@ -333,11 +335,13 @@ export component AppWindow inherits Window {
             y: menu-bar-height;
             width:  sidebar-width;
             height: content-height;
-            tree:       UiState.sidebar-tree;
-            is-loading: UiState.sidebar-loading;
+            tree:        UiState.sidebar-tree;
+            is-loading:  UiState.sidebar-loading;
+            connections: UiState.connection-list;
             toggle-node(id) => { UiState.toggle-sidebar-node(id); }
             table-double-clicked(name) => { UiState.table-double-clicked(name); }
             add-connection => { UiState.open-connection-form(); }
+            connect(id) => { UiState.connect-db(id); }
         }
 
         // ── Main content panel ────────────────────────────────────────────────

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -14,6 +14,10 @@ component FieldRow inherits HorizontalLayout {
     in property <bool>       is-password: false;
     in-out property <string> value;
 
+    // Fired with +1 (Down/Tab/Return) or -1 (Up/Shift+Tab) to move to the next/prev field.
+    callback move-focus(int);
+    public function grab-focus() { field-input.focus(); }
+
     spacing: 8px;
     Text {
         text: label-text;
@@ -39,7 +43,7 @@ component FieldRow inherits HorizontalLayout {
             vertical-alignment: center;
         }
         // TextInput rendered last → on top → receives all pointer/focus events.
-        TextInput {
+        field-input := TextInput {
             x: 6px;
             y: 0;
             width: parent.width - 12px;
@@ -48,6 +52,20 @@ component FieldRow inherits HorizontalLayout {
             text <=> value;
             color: Colors.text;
             input-type: is-password ? InputType.password : InputType.text;
+            key-pressed(event) => {
+                if (event.text == Key.DownArrow
+                        || (event.text == Key.Tab && !event.modifiers.shift)
+                        || event.text == Key.Return) {
+                    root.move-focus(1);
+                    EventResult.accept
+                } else if (event.text == Key.UpArrow
+                           || (event.text == Key.Tab && event.modifiers.shift)) {
+                    root.move-focus(-1);
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            }
         }
     }
 }
@@ -118,6 +136,10 @@ export component ConnectionForm inherits Rectangle {
     callback test-connection();
     callback add-connection();
 
+    // Auto-focus the Name field when the form opens and whenever the active tab changes.
+    init => { name-field.grab-focus(); }
+    changed tab-index => { name-field.grab-focus(); }
+
     // ── Layout ────────────────────────────────────────────────────────────────
     background: Colors.surface0;
     border-radius: 8px;
@@ -140,10 +162,17 @@ export component ConnectionForm inherits Rectangle {
         }
 
         // Name
-        FieldRow {
+        name-field := FieldRow {
             label-text: @tr("Name");
             placeholder: @tr("My Database");
             value <=> root.name;
+            move-focus(d) => {
+                if (d > 0) {
+                    if (root.tab-index == 0) { conn-string-input.focus(); }
+                    else { host-field.grab-focus(); }
+                }
+                // d < 0: Name is the first field — do nothing.
+            }
         }
 
         // DB type selector
@@ -180,58 +209,104 @@ export component ConnectionForm inherits Rectangle {
             }
         }
 
-        // Connection String tab
-        if root.tab-index == 0: Rectangle {
+        // ── Connection String panel ───────────────────────────────────────────
+        // Always instantiated (not `if`) so conn-string-input is accessible by ID
+        // from sibling elements (name-field.move-focus).
+        // height: 0 + clip collapses it to nothing when the Individual Fields tab is active.
+        Rectangle {
+            height: root.tab-index == 0 ? 28px : 0px;
+            clip: true;
             background: Colors.base;
             border-radius: 4px;
-            height: 28px;
+
             if root.conn-string == "": Text {
                 x: 6px;
                 y: 0;
                 width: parent.width - 12px;
-                height: parent.height;
+                height: 28px;
                 text: "postgres://user:pass@host:5432/db";
                 color: Colors.surface2;
                 vertical-alignment: center;
             }
-            TextInput {
+            conn-string-input := TextInput {
                 x: 6px;
                 y: 0;
                 width: parent.width - 12px;
-                height: parent.height;
+                height: 28px;
                 vertical-alignment: center;
                 text <=> root.conn-string;
                 color: Colors.text;
+                key-pressed(event) => {
+                    if (event.text == Key.UpArrow
+                            || (event.text == Key.Tab && event.modifiers.shift)) {
+                        name-field.grab-focus();
+                        EventResult.accept
+                    } else if (event.text == Key.Escape) {
+                        root.cancel();
+                        EventResult.accept
+                    } else {
+                        EventResult.reject
+                    }
+                    // Down/Tab from the last field in tab 0: no action (let default apply).
+                }
             }
         }
 
-        // Individual Fields tab
-        if root.tab-index == 1: VerticalLayout {
-            spacing: 6px;
-            FieldRow {
-                label-text: @tr("Host");
-                placeholder: "localhost";
-                value <=> root.host;
-            }
-            FieldRow {
-                label-text: @tr("Port");
-                placeholder: "5432";
-                value <=> root.port;
-            }
-            FieldRow {
-                label-text: @tr("User");
-                placeholder: @tr("username");
-                value <=> root.user;
-            }
-            FieldRow {
-                label-text: @tr("Password");
-                value <=> root.password;
-                is-password: true;
-            }
-            FieldRow {
-                label-text: @tr("Database");
-                placeholder: @tr("database name");
-                value <=> root.database;
+        // ── Individual Fields panel ───────────────────────────────────────────
+        // Always instantiated (not `if`) so host-field … db-field IDs are accessible.
+        // height driven by the inner layout's preferred-height; collapses to 0 on tab 0.
+        Rectangle {
+            height: root.tab-index == 1 ? fields-layout.preferred-height : 0px;
+            clip: true;
+
+            fields-layout := VerticalLayout {
+                spacing: 6px;
+
+                host-field := FieldRow {
+                    label-text: @tr("Host");
+                    placeholder: "localhost";
+                    value <=> root.host;
+                    move-focus(d) => {
+                        if (d > 0) { port-field.grab-focus(); }
+                        else { name-field.grab-focus(); }
+                    }
+                }
+                port-field := FieldRow {
+                    label-text: @tr("Port");
+                    placeholder: "5432";
+                    value <=> root.port;
+                    move-focus(d) => {
+                        if (d > 0) { user-field.grab-focus(); }
+                        else { host-field.grab-focus(); }
+                    }
+                }
+                user-field := FieldRow {
+                    label-text: @tr("User");
+                    placeholder: @tr("username");
+                    value <=> root.user;
+                    move-focus(d) => {
+                        if (d > 0) { pass-field.grab-focus(); }
+                        else { port-field.grab-focus(); }
+                    }
+                }
+                pass-field := FieldRow {
+                    label-text: @tr("Password");
+                    value <=> root.password;
+                    is-password: true;
+                    move-focus(d) => {
+                        if (d > 0) { db-field.grab-focus(); }
+                        else { user-field.grab-focus(); }
+                    }
+                }
+                db-field := FieldRow {
+                    label-text: @tr("Database");
+                    placeholder: @tr("database name");
+                    value <=> root.database;
+                    move-focus(d) => {
+                        // Last field: Up goes back, Down/Return does nothing.
+                        if (d < 0) { pass-field.grab-focus(); }
+                    }
+                }
             }
         }
 

--- a/app/src/ui/components/db_panel.slint
+++ b/app/src/ui/components/db_panel.slint
@@ -1,0 +1,117 @@
+import { ConnectionEntry } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
+
+/// Flat connection list for the Database tab.
+/// Each row shows an active indicator, name, and DB-type badge.
+/// Clicking an inactive row fires connect(id); active row is inert.
+export component DbPanel inherits Rectangle {
+    background: Colors.base;
+
+    in property <[ConnectionEntry]> connections: [];
+    callback connect(string);
+    callback add-connection();
+
+    panel-fs := FocusScope {
+        x: 0; y: 0;
+        width: parent.width; height: parent.height;
+        focus-on-click: false;
+
+        panel-scroll := Flickable {
+            x: 0; y: 0;
+            width: parent.width; height: parent.height;
+            interactive: true;
+            viewport-height: max(panel-content.preferred-height, self.height);
+
+            panel-content := VerticalLayout {
+                // ── Connection rows ───────────────────────────────────────────────
+                for conn in root.connections: Rectangle {
+                    height: 40px;
+                    clip: true;
+
+                    background: conn.is-active ? Colors.surface0 : transparent;
+
+                    row-ta := TouchArea {
+                        width: parent.width;
+                        height: parent.height;
+                        clicked => {
+                            if (!conn.is-active) {
+                                root.connect(conn.id);
+                            }
+                        }
+                    }
+
+                    // Hover overlay for inactive rows
+                    Rectangle {
+                        background: row-ta.has-hover && !conn.is-active
+                            ? Colors.hover-subtle : transparent;
+                        width: parent.width;
+                        height: parent.height;
+                    }
+
+                    HorizontalLayout {
+                        x: 0; y: 0;
+                        width: parent.width;
+                        height: parent.height;
+                        padding-left: 12px;
+                        padding-right: 8px;
+                        spacing: 6px;
+
+                        // Active / inactive indicator dot
+                        Text {
+                            text: conn.is-active ? "●" : "○";
+                            color: conn.is-active ? Colors.blue : Colors.surface2;
+                            font-size: Typography.size-sm;
+                            vertical-alignment: center;
+                            width: 12px;
+                        }
+
+                        // Connection name
+                        Text {
+                            text: conn.name;
+                            color: conn.is-active ? Colors.text : Colors.subtext1;
+                            font-size: Typography.size-lg;
+                            vertical-alignment: center;
+                            overflow: elide;
+                            horizontal-stretch: 1;
+                        }
+
+                        // DB-type badge
+                        Text {
+                            text: conn.db-type;
+                            color: Colors.surface2;
+                            font-size: Typography.size-sm;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // ── Divider ───────────────────────────────────────────────────────
+                Rectangle {
+                    height: 1px;
+                    background: Colors.surface0;
+                }
+
+                // ── Add connection button ─────────────────────────────────────────
+                Rectangle {
+                    height: 36px;
+                    background: transparent;
+
+                    HorizontalLayout {
+                        padding-left: 12px;
+                        Text {
+                            text: @tr("+ Add connection");
+                            color: Colors.blue;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    TouchArea {
+                        width: parent.width;
+                        height: parent.height;
+                        clicked => { root.add-connection(); }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -1,14 +1,17 @@
-import { SidebarNode } from "../globals.slint";
+import { SidebarNode, ConnectionEntry } from "../globals.slint";
 import { Colors, Typography } from "../theme.slint";
+import { DbPanel } from "db_panel.slint";
 
 export component Sidebar inherits Rectangle {
     background: Colors.base;
 
-    in property <[SidebarNode]> tree: [];
-    in property <bool> is-loading: false;
+    in property <[SidebarNode]>     tree:        [];
+    in property <bool>              is-loading:  false;
+    in property <[ConnectionEntry]> connections: [];
     callback toggle-node(string);
     callback table-double-clicked(string);
     callback add-connection();
+    callback connect(string);   // connect to a saved connection by id
 
     /// True while this sidebar holds keyboard focus (used by app.slint to sync focused-pane).
     out property <bool> sidebar-focused: sidebar-fs.has-focus;
@@ -19,6 +22,9 @@ export component Sidebar inherits Rectangle {
             root.kb-focus = 0;
         }
     }
+
+    // 0 = Schema (default), 1 = DB
+    property <int> active-tab: 0;
 
     /// Keyboard-navigation cursor (-1 = none selected).
     property <int> kb-focus: -1;
@@ -44,201 +50,299 @@ export component Sidebar inherits Rectangle {
         }
     }
 
-    sidebar-fs := FocusScope {
-        x: 0; y: 0;
-        width: parent.width; height: parent.height;
-        focus-on-click: true;
+    VerticalLayout {
+        // ── Tab bar ──────────────────────────────────────────────────────────
+        Rectangle {
+            height: 28px;
+            background: Colors.mantle;
 
-        key-pressed(event) => {
-            if (event.text == Key.UpArrow) {
-                if (root.kb-focus <= 0) {
-                    root.kb-focus = 0;
-                } else {
-                    root.kb-focus -= 1;
-                }
-                EventResult.accept
-            } else if (event.text == Key.DownArrow) {
-                if (root.kb-focus < 0) {
-                    root.kb-focus = 0;
-                } else if (root.kb-focus < root.tree.length - 1) {
-                    root.kb-focus += 1;
-                }
-                EventResult.accept
-            } else if (event.text == Key.RightArrow) {
-                if (root.kb-focus >= 0 && root.tree.length > 0) {
-                    let node = root.tree[root.kb-focus];
-                    if (node.level < 2) {
-                        if (!node.is-expanded) {
-                            root.toggle-node(node.id);
-                        } else if (root.kb-focus + 1 < root.tree.length) {
-                            root.kb-focus += 1;
-                        }
-                    }
-                }
-                EventResult.accept
-            } else if (event.text == Key.LeftArrow) {
-                if (root.kb-focus >= 0 && root.tree.length > 0) {
-                    let node = root.tree[root.kb-focus];
-                    if (node.is-expanded && node.level < 2) {
-                        root.toggle-node(node.id);
-                    } else if (node.parent-index >= 0) {
-                        root.kb-focus = node.parent-index;
-                    }
-                }
-                EventResult.accept
-            } else if (event.text == Key.Return) {
-                if (root.kb-focus >= 0 && root.tree.length > 0) {
-                    let node = root.tree[root.kb-focus];
-                    if (node.node-kind == "table" || node.node-kind == "view") {
-                        root.table-double-clicked(node.label);
-                    } else if (node.level < 2) {
-                        root.toggle-node(node.id);
-                    }
-                }
-                EventResult.accept
-            } else {
-                EventResult.reject
-            }
-        }
+            HorizontalLayout {
+                // Schema tab
+                schema-tab := Rectangle {
+                    width: parent.width / 2;
+                    height: parent.height;
+                    background: root.active-tab == 0 ? Colors.base : Colors.mantle;
 
-        sidebar-scroll := Flickable {
-            x: 0; y: 0;
-            width: parent.width; height: parent.height;
-            interactive: true;
-            viewport-height: max(sidebar-content.preferred-height, self.height);
-
-            sidebar-content := VerticalLayout {
-                // ── Schema tree ───────────────────────────────────────────────────────
-                for node[i] in root.tree : Rectangle {
-                    height: 32px;
-                    clip: true;
-
-                    background: i == root.kb-focus
-                        ? Colors.sidebar-sel
-                        : (node.is-active && node.level == 0 ? Colors.surface0 : transparent);
-
-                    ta := TouchArea {
+                    Text {
+                        text: @tr("Schema");
+                        color: root.active-tab == 0 ? Colors.text : Colors.subtext1;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
                         width: parent.width;
                         height: parent.height;
-                        clicked => {
-                            root.kb-focus = i;
-                            // Level-2 items (tables, views, etc.) have no children to
-                            // expand, so skip toggle-node to avoid rebuilding the VecModel
-                            // on the first click — a rebuild would destroy the element and
-                            // prevent Slint from recognising the second click as a
-                            // double-click.
-                            if (node.level < 2) {
-                                root.toggle-node(node.id);
-                            }
-                        }
-                        double-clicked => {
-                            if node.node-kind == "table" || node.node-kind == "view" {
-                                root.table-double-clicked(node.label);
-                            }
-                        }
                     }
-
-                    // Hover overlay (skipped for kb-focused and active-connection rows)
+                    // Active underline
                     Rectangle {
-                        background: ta.has-hover
-                            && i != root.kb-focus
-                            && !(node.is-active && node.level == 0)
-                            ? Colors.hover-subtle : transparent;
+                        y: parent.height - 2px;
+                        height: 2px;
                         width: parent.width;
-                        height: parent.height;
+                        background: root.active-tab == 0 ? Colors.blue : transparent;
                     }
-
-                    HorizontalLayout {
-                        x: 0; y: 0;
-                        width: parent.width;
-                        height: parent.height;
-                        padding-left: (8 + node.level * 14) * 1px;
-                        padding-right: 8px;
-                        spacing: 4px;
-
-                        // Expand/collapse toggle icon for connection and category nodes
-                        if node.level < 2 : Text {
-                            text: node.is-expanded ? "▼" : "▶";
-                            color: Colors.surface2;
-                            font-size: Typography.size-xs;
-                            vertical-alignment: center;
-                            width: 14px;
-                        }
-                        // Spacer for item nodes
-                        if node.level >= 2 : Rectangle { width: 14px; }
-
-                        // Connection status dot (● active / ○ inactive)
-                        if node.level == 0 : Text {
-                            text: node.is-active ? "●" : "○";
-                            color: node.is-active ? Colors.blue : Colors.surface2;
-                            font-size: Typography.size-sm;
-                            vertical-alignment: center;
-                        }
-
-                        // Main label
-                        Text {
-                            text: node.label;
-                            color: node.level == 0
-                                ? (node.is-active ? Colors.text : Colors.subtext1)
-                                : (node.level == 1 ? Colors.overlay1 : Colors.subtext0);
-                            font-size: node.level == 0 ? Typography.size-lg : Typography.size-base;
-                            vertical-alignment: center;
-                            overflow: elide;
-                            horizontal-stretch: 1;
-                        }
-
-                        // Sub-label badge (db-type for connection nodes)
-                        if node.sub-label != "" : Text {
-                            text: node.sub-label;
-                            color: Colors.surface2;
-                            font-size: Typography.size-sm;
-                            vertical-alignment: center;
-                        }
-                    }
-                }
-
-                // ── Metadata loading indicator ────────────────────────────────────────
-                if root.is-loading : Rectangle {
-                    height: 28px;
-                    HorizontalLayout {
-                        padding-left: 24px;
-                        Text {
-                            text: @tr("Loading\u{2026}");
-                            color: Colors.surface2;
-                            font-size: Typography.size-md;
-                            vertical-alignment: center;
-                            font-italic: true;
-                        }
-                    }
-                }
-
-                // ── Divider ───────────────────────────────────────────────────────────
-                Rectangle {
-                    height: 1px;
-                    background: Colors.surface0;
-                }
-
-                // ── Add connection button ─────────────────────────────────────────────
-                Rectangle {
-                    height: 36px;
-                    background: transparent;
-
-                    HorizontalLayout {
-                        padding-left: 12px;
-                        Text {
-                            text: @tr("+ Add connection");
-                            color: Colors.blue;
-                            vertical-alignment: center;
-                        }
-                    }
-
                     TouchArea {
                         width: parent.width;
                         height: parent.height;
-                        clicked => { root.add-connection(); }
+                        clicked => { root.active-tab = 0; }
+                    }
+                }
+
+                // DB tab
+                db-tab := Rectangle {
+                    width: parent.width / 2;
+                    height: parent.height;
+                    background: root.active-tab == 1 ? Colors.base : Colors.mantle;
+
+                    Text {
+                        text: @tr("DB");
+                        color: root.active-tab == 1 ? Colors.text : Colors.subtext1;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                        width: parent.width;
+                        height: parent.height;
+                    }
+                    // Active underline
+                    Rectangle {
+                        y: parent.height - 2px;
+                        height: 2px;
+                        width: parent.width;
+                        background: root.active-tab == 1 ? Colors.blue : transparent;
+                    }
+                    TouchArea {
+                        width: parent.width;
+                        height: parent.height;
+                        clicked => { root.active-tab = 1; }
                     }
                 }
             }
+
+            // Bottom border
+            Rectangle {
+                y: parent.height - 1px;
+                height: 1px;
+                width: parent.width;
+                background: Colors.surface0;
+            }
+        }
+
+        // ── Content area ─────────────────────────────────────────────────────
+        // Both panels share the same space; only one is visible at a time.
+        // Using visible: instead of if: so that sidebar-fs / sidebar-scroll IDs
+        // remain accessible at root scope (if-scoped IDs cannot be referenced outside).
+        Rectangle {
+            horizontal-stretch: 1;
+            vertical-stretch: 1;
+            clip: true;
+
+            // DB tab panel
+            DbPanel {
+                x: 0; y: 0;
+                width: parent.width; height: parent.height;
+                visible: root.active-tab == 1;
+                connections: root.connections;
+                connect(id) => { root.connect(id); }
+                add-connection => { root.add-connection(); }
+            }
+
+            // Schema tab (tree + add-connection)
+            sidebar-fs := FocusScope {
+                x: 0; y: 0;
+                width: parent.width; height: parent.height;
+                visible: root.active-tab == 0;
+                focus-on-click: true;
+
+            key-pressed(event) => {
+                if (event.text == Key.UpArrow) {
+                    if (root.kb-focus <= 0) {
+                        root.kb-focus = 0;
+                    } else {
+                        root.kb-focus -= 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.DownArrow) {
+                    if (root.kb-focus < 0) {
+                        root.kb-focus = 0;
+                    } else if (root.kb-focus < root.tree.length - 1) {
+                        root.kb-focus += 1;
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.RightArrow) {
+                    if (root.kb-focus >= 0 && root.tree.length > 0) {
+                        let node = root.tree[root.kb-focus];
+                        if (node.level < 2) {
+                            if (!node.is-expanded) {
+                                root.toggle-node(node.id);
+                            } else if (root.kb-focus + 1 < root.tree.length) {
+                                root.kb-focus += 1;
+                            }
+                        }
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.LeftArrow) {
+                    if (root.kb-focus >= 0 && root.tree.length > 0) {
+                        let node = root.tree[root.kb-focus];
+                        if (node.is-expanded && node.level < 2) {
+                            root.toggle-node(node.id);
+                        } else if (node.parent-index >= 0) {
+                            root.kb-focus = node.parent-index;
+                        }
+                    }
+                    EventResult.accept
+                } else if (event.text == Key.Return) {
+                    if (root.kb-focus >= 0 && root.tree.length > 0) {
+                        let node = root.tree[root.kb-focus];
+                        if (node.node-kind == "table" || node.node-kind == "view") {
+                            root.table-double-clicked(node.label);
+                        } else if (node.level < 2) {
+                            root.toggle-node(node.id);
+                        }
+                    }
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
+            }
+
+            sidebar-scroll := Flickable {
+                x: 0; y: 0;
+                width: parent.width; height: parent.height;
+                interactive: true;
+                viewport-height: max(sidebar-content.preferred-height, self.height);
+
+                sidebar-content := VerticalLayout {
+                    // ── Schema tree ───────────────────────────────────────────────────────
+                    for node[i] in root.tree : Rectangle {
+                        height: 32px;
+                        clip: true;
+
+                        background: i == root.kb-focus
+                            ? Colors.sidebar-sel
+                            : (node.is-active && node.level == 0 ? Colors.surface0 : transparent);
+
+                        ta := TouchArea {
+                            width: parent.width;
+                            height: parent.height;
+                            clicked => {
+                                root.kb-focus = i;
+                                // Level-2 items (tables, views, etc.) have no children to
+                                // expand, so skip toggle-node to avoid rebuilding the VecModel
+                                // on the first click — a rebuild would destroy the element and
+                                // prevent Slint from recognising the second click as a
+                                // double-click.
+                                if (node.level < 2) {
+                                    root.toggle-node(node.id);
+                                }
+                            }
+                            double-clicked => {
+                                if node.node-kind == "table" || node.node-kind == "view" {
+                                    root.table-double-clicked(node.label);
+                                }
+                            }
+                        }
+
+                        // Hover overlay (skipped for kb-focused and active-connection rows)
+                        Rectangle {
+                            background: ta.has-hover
+                                && i != root.kb-focus
+                                && !(node.is-active && node.level == 0)
+                                ? Colors.hover-subtle : transparent;
+                            width: parent.width;
+                            height: parent.height;
+                        }
+
+                        HorizontalLayout {
+                            x: 0; y: 0;
+                            width: parent.width;
+                            height: parent.height;
+                            padding-left: (8 + node.level * 14) * 1px;
+                            padding-right: 8px;
+                            spacing: 4px;
+
+                            // Expand/collapse toggle icon for connection and category nodes
+                            if node.level < 2 : Text {
+                                text: node.is-expanded ? "▼" : "▶";
+                                color: Colors.surface2;
+                                font-size: Typography.size-xs;
+                                vertical-alignment: center;
+                                width: 14px;
+                            }
+                            // Spacer for item nodes
+                            if node.level >= 2 : Rectangle { width: 14px; }
+
+                            // Connection status dot (● active / ○ inactive)
+                            if node.level == 0 : Text {
+                                text: node.is-active ? "●" : "○";
+                                color: node.is-active ? Colors.blue : Colors.surface2;
+                                font-size: Typography.size-sm;
+                                vertical-alignment: center;
+                            }
+
+                            // Main label
+                            Text {
+                                text: node.label;
+                                color: node.level == 0
+                                    ? (node.is-active ? Colors.text : Colors.subtext1)
+                                    : (node.level == 1 ? Colors.overlay1 : Colors.subtext0);
+                                font-size: node.level == 0 ? Typography.size-lg : Typography.size-base;
+                                vertical-alignment: center;
+                                overflow: elide;
+                                horizontal-stretch: 1;
+                            }
+
+                            // Sub-label badge (db-type for connection nodes)
+                            if node.sub-label != "" : Text {
+                                text: node.sub-label;
+                                color: Colors.surface2;
+                                font-size: Typography.size-sm;
+                                vertical-alignment: center;
+                            }
+                        }
+                    }
+
+                    // ── Metadata loading indicator ────────────────────────────────────────
+                    if root.is-loading : Rectangle {
+                        height: 28px;
+                        HorizontalLayout {
+                            padding-left: 24px;
+                            Text {
+                                text: @tr("Loading\u{2026}");
+                                color: Colors.surface2;
+                                font-size: Typography.size-md;
+                                vertical-alignment: center;
+                                font-italic: true;
+                            }
+                        }
+                    }
+
+                    // ── Divider ───────────────────────────────────────────────────────────
+                    Rectangle {
+                        height: 1px;
+                        background: Colors.surface0;
+                    }
+
+                    // ── Add connection button ─────────────────────────────────────────────
+                    Rectangle {
+                        height: 36px;
+                        background: transparent;
+
+                        HorizontalLayout {
+                            padding-left: 12px;
+                            Text {
+                                text: @tr("+ Add connection");
+                                color: Colors.blue;
+                                vertical-alignment: center;
+                            }
+                        }
+
+                        TouchArea {
+                            width: parent.width;
+                            height: parent.height;
+                            clicked => { root.add-connection(); }
+                        }
+                    }
+                }
+            }
+        }
         }
     }
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -801,6 +801,33 @@ impl UI {
             });
         }
 
+        // connect-db: connect to a saved connection from the DB tab by id.
+        // Mirrors the connection-switching logic in toggle-sidebar-node.
+        {
+            // clone required: callback closure needs owned captures
+            let tx_cmd = tx_cmd.clone();
+            let state = state.clone();
+            ui_state.on_connect_db(move |id| {
+                let id = id.to_string();
+                let active_id = state
+                    .conn
+                    .active()
+                    .map(|c| c.id.clone())
+                    .unwrap_or_default();
+                if id == active_id {
+                    return;
+                }
+                let conn = state.conn.all().into_iter().find(|c| c.id == id);
+                if let Some(conn) = conn {
+                    let password = conn
+                        .password_encrypted
+                        .as_ref()
+                        .and_then(|enc| crypto::decrypt(enc, &enc_key).ok());
+                    send_cmd(&tx_cmd, Command::Connect(conn, password));
+                }
+            });
+        }
+
         // table-double-clicked: insert SELECT * FROM <name> into the editor
         // and immediately execute it so the result appears without a manual
         // Ctrl+Enter.  tx_cmd is cloned here because the closure is 'static.


### PR DESCRIPTION
## Summary

Adds a Database tab to the sidebar that lists all saved connections with active/inactive indicators and enables one-click switching between connections. Also adds full keyboard navigation (Up/Down/Tab/Return) to the connection form fields, with auto-focus on open, to support the goal of keyboard-only operation.

## Changes

- `db_panel.slint` (new): flat connection list component — ●/○ dot, name, db-type badge, hover effect, inactive-row click fires `connect(id)`
- `sidebar.slint`: tab bar (Schema | DB) with blue active underline; both panels always rendered via `visible + height` (instead of `if`) to keep IDs accessible across tabs; `connections` property and `connect` callback wired through
- `app.slint`: added `callback connect-db(string)` to `UiState`; bound `connections` and `connect` on `sidebar-inst`
- `mod.rs`: `on_connect_db` handler — reuses `Command::Connect` logic from `toggle-sidebar-node`, skips no-op if already active
- `connection_form.slint`: `FieldRow` gains `callback move-focus(int)` and `public function grab-focus()`; Down/Tab/Return advance to next field, Up/Shift+Tab go back; `init =>` auto-focuses Name on open; `changed tab-index` refocuses Name on tab switch; Escape in Connection String field closes the form
- `.po` files (en + ja): added `"Schema"` and `"DB"` translations under `Sidebar` context

## Related Issues

Closes #189

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes