### PR TITLE
feat(ui): make window resizable and fix connection form layout

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -213,14 +213,14 @@ export global UiState {
 export component AppWindow inherits Window {
     title: "wellfeather";
     default-font-family: "Inter, Noto Sans JP, Segoe UI, SF Pro, system-ui";
-    // Explicit width/height fix root.width/root.height as constants, which are then
-    // used in arithmetic expressions below to position all children absolutely.
-    // VerticalLayout + vertical-stretch proved unreliable when height: parent.height
-    // is set on a layout — the stretch distribution ignores the explicit height and
-    // falls back to preferred-height (~61px). Absolute positioning with arithmetic
-    // avoids all layout-engine ambiguity.
-    width:  1280px;
-    height: 800px;
+    // preferred-width/height set the initial window size; the window is resizable.
+    // All children are positioned with arithmetic derived from root.width/root.height,
+    // so they track resize automatically.  min-width/min-height prevent the window
+    // from shrinking below a usable size (dialogs are up to 560px wide).
+    preferred-width:  1280px;
+    preferred-height: 800px;
+    min-width:  900px;
+    min-height: 560px;
 
     // ── Theme sync ───────────────────────────────────────────────────────────
     // Mirror UiState.is-dark into Colors.is-dark so all reactive color bindings update.
@@ -246,6 +246,11 @@ export component AppWindow inherits Window {
     property <length> panel-height:        250px;
     // Height of the tab-bar strip at the top of the panel (below the drag handle).
     property <length> panel-header-height: 28px;
+
+    // Re-clamp panel-height when the window is resized to avoid the editor area going negative.
+    changed content-height => {
+        root.panel-height = clamp(root.panel-height, 80px, root.content-height - 40px);
+    }
 
     // ── Pane focus tracking ───────────────────────────────────────────────────
     // 0=sidebar  1=editor  2=result

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -149,7 +149,9 @@ export component ConnectionForm inherits Rectangle {
     border-color: Colors.surface2;
     drop-shadow-blur: 24px;
     drop-shadow-color: Colors.shadow-light;
-    width: 480px;
+    width: 660px;
+    height: 520px;
+    clip: true;
 
     VerticalLayout {
         padding: 20px;
@@ -211,57 +213,63 @@ export component ConnectionForm inherits Rectangle {
             }
         }
 
-        // ── Connection String panel ───────────────────────────────────────────
-        // Always instantiated (not `if`) so conn-string-input is accessible by ID
-        // from sibling elements (name-field.move-focus).
-        // height: 0 + clip collapses it to nothing when the Individual Fields tab is active.
-        Rectangle {
-            height: root.tab-index == 0 ? 28px : 0px;
-            clip: true;
-            background: Colors.base;
-            border-radius: 4px;
+        // Spacer — pushes tab content + status + buttons toward the bottom of the dialog.
+        Rectangle { vertical-stretch: 1; }
 
-            if root.conn-string == "": Text {
-                x: 6px;
-                y: 0;
-                width: parent.width - 12px;
+        // ── Tab content (single panel for both tabs) ─────────────────────────
+        // Using one panel instead of two eliminates the phantom 10px spacing that
+        // a 0-height sibling would introduce, moving the conn-string input lower.
+        // Height always equals the Individual Fields preferred height so the flex
+        // spacer above distributes equally for both tabs.
+        Rectangle {
+            height: fields-layout.preferred-height;
+            clip: true;
+
+            // Connection String tab — input pinned to the bottom of the panel,
+            // aligned with the Database field in the Individual Fields tab.
+            Rectangle {
+                visible: root.tab-index == 0;
+                background: Colors.base;
+                border-radius: 4px;
+                width: parent.width;
                 height: 28px;
-                text: "postgres://user:pass@host:5432/db";
-                color: Colors.surface2;
-                vertical-alignment: center;
-            }
-            conn-string-input := TextInput {
-                x: 6px;
-                y: 0;
-                width: parent.width - 12px;
-                height: 28px;
-                vertical-alignment: center;
-                text <=> root.conn-string;
-                color: Colors.text;
-                key-pressed(event) => {
-                    if (event.text == Key.UpArrow
-                            || (event.text == Key.Tab && event.modifiers.shift)) {
-                        name-field.grab-focus();
-                        EventResult.accept
-                    } else if (event.text == Key.Escape) {
-                        root.cancel();
-                        EventResult.accept
-                    } else {
-                        EventResult.reject
+                y: parent.height - 28px;
+
+                if root.conn-string == "": Text {
+                    x: 6px;
+                    y: 0;
+                    width: parent.width - 12px;
+                    height: 28px;
+                    text: "postgres://user:pass@host:5432/db";
+                    color: Colors.surface2;
+                    vertical-alignment: center;
+                }
+                conn-string-input := TextInput {
+                    x: 6px;
+                    y: 0;
+                    width: parent.width - 12px;
+                    height: 28px;
+                    vertical-alignment: center;
+                    text <=> root.conn-string;
+                    color: Colors.text;
+                    key-pressed(event) => {
+                        if (event.text == Key.UpArrow
+                                || (event.text == Key.Tab && event.modifiers.shift)) {
+                            name-field.grab-focus();
+                            EventResult.accept
+                        } else if (event.text == Key.Escape) {
+                            root.cancel();
+                            EventResult.accept
+                        } else {
+                            EventResult.reject
+                        }
                     }
-                    // Down/Tab from the last field in tab 0: no action (let default apply).
                 }
             }
-        }
 
-        // ── Individual Fields panel ───────────────────────────────────────────
-        // Always instantiated (not `if`) so host-field … db-field IDs are accessible.
-        // height driven by the inner layout's preferred-height; collapses to 0 on tab 0.
-        Rectangle {
-            height: root.tab-index == 1 ? fields-layout.preferred-height : 0px;
-            clip: true;
-
+            // Individual Fields tab
             fields-layout := VerticalLayout {
+                visible: root.tab-index == 1;
                 spacing: 6px;
 
                 host-field := FieldRow {
@@ -305,7 +313,6 @@ export component ConnectionForm inherits Rectangle {
                     placeholder: @tr("database name");
                     value <=> root.database;
                     move-focus(d) => {
-                        // Last field: Up goes back, Down/Return does nothing.
                         if (d < 0) { pass-field.grab-focus(); }
                     }
                 }


### PR DESCRIPTION
## Summary

Makes the application window freely resizable (previously fixed at 1280×800px) and improves the connection form's visual layout. The window now supports drag-to-resize with a minimum size to prevent unusable states. The connection form dialog is sized consistently with the DB Manager dialog and its input field positions are now stable across both tabs.

## Changes

- **Responsive window** (`app.slint`): replace fixed `width`/`height` with `preferred-width`/`preferred-height` (initial size 1280×800) and add `min-width: 900px` / `min-height: 560px`; add `changed content-height` handler to clamp `panel-height` when the window is resized smaller than the current panel height
- **Connection form size** (`connection_form.slint`): fix dialog at 660×520px (560px DB Manager width + 100px, same height) so both modals feel visually consistent
- **Connection form tab layout**: merge the two height-toggled panels (Connection String + Individual Fields) into a single panel; this eliminates the phantom 10px spacing a zero-height sibling introduced, moving the connection string input to align with the Database field row in the Individual Fields tab; buttons are pinned to the bottom via a flex spacer

## Related Issues

No linked issue (UI polish follow-up to #192).

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes