### PR TITLE
feat(ui): polish focus borders, gutter, result panel, and drag handle

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -388,7 +388,7 @@ export component AppWindow inherits Window {
                 y: 0;
                 width:  root.gutter-col-width;
                 height: parent.height;
-                background: Colors.base;
+                background: Colors.mantle;
                 clip: true;
 
                 for i in editor-inst.gutter-vis-count: Text {
@@ -420,7 +420,11 @@ export component AppWindow inherits Window {
                 move-cursor-line(text, pos, delta) => { UiState.move-cursor-line(text, pos, delta); }
                 run-query(cursor) => { UiState.run-query-at-cursor(UiState.editor-text, cursor); }
                 run-all => { UiState.run-all(UiState.editor-text); }
-                toggle-panel => { UiState.result-panel-open = !UiState.result-panel-open; }
+                toggle-panel => {
+                    if (UiState.result-columns.length > 0 || UiState.error-message != "") {
+                        UiState.result-panel-open = !UiState.result-panel-open;
+                    }
+                }
                 text-edited(sql, pos) => { UiState.fetch-completion(sql, pos); }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }
                 format-sql => { UiState.format-sql(); }
@@ -431,15 +435,40 @@ export component AppWindow inherits Window {
                 accept-completion(text, pos, offset, tname) => { UiState.accept-completion(text, pos, offset, tname); }
             }
 
+            // ── Panel drag handle ─────────────────────────────────────────────
+            // Sits at the top boundary of the preview strip (the thin separator
+            // between the editor and the preview area).  Dragging grows/shrinks
+            // panel-height upward.  Rendered after the result panel so it is on
+            // top and receives pointer events without being clipped.
+            if UiState.result-panel-open: Rectangle {
+                x: 0;
+                y: parent.height - root.panel-height - root.preview-strip-h;
+                width:  parent.width;
+                height: root.divider-thickness;
+                background: panel-drag-ta.has-hover || panel-drag-ta.pressed
+                    ? Colors.surface2 : transparent;
+
+                panel-drag-ta := TouchArea {
+                    mouse-cursor: ns-resize;
+                    moved => {
+                        root.panel-height = clamp(
+                            root.panel-height + (self.pressed-y - self.mouse-y),
+                            80px,
+                            root.content-height - 40px
+                        );
+                    }
+                }
+            }
+
             // ── Cell-value preview strip ──────────────────────────────────────
             // Fixed-height strip placed above the result panel; shows the full
             // value of the last clicked cell with word-wrap and vertical scroll.
             // Rendered as a sibling of the result panel so it never reduces the
             // table body height.
             Rectangle {
-                x: root.gutter-col-width;
+                x: 0;
                 y: parent.height - root.panel-height - root.preview-strip-h;
-                width:  parent.width - root.gutter-col-width;
+                width:  parent.width;
                 height: root.preview-strip-h;
                 background: Colors.mantle;
                 clip: true;
@@ -493,57 +522,18 @@ export component AppWindow inherits Window {
             // Always instantiated (so result-table-inst is accessible from AppWindow
             // scope for focus tracking and grab-focus); hidden via `visible:` when closed.
             Rectangle {
-                x: root.gutter-col-width;
+                x: 0;
                 y: parent.height - root.panel-height;
-                width:  parent.width - root.gutter-col-width;
+                width:  parent.width;
                 height: root.panel-height;
                 background: Colors.base;
                 clip: true;
                 visible: UiState.result-panel-open;
 
-                // ── Top drag handle ───────────────────────────────────────────
-                // Dragging this edge adjusts panel-height (panel grows/shrinks upward).
-                Rectangle {
-                    x: 0;
-                    y: 0;
-                    width:  parent.width;
-                    height: root.divider-thickness;
-                    background: Colors.surface0;
-
-                    states [
-                        active when panel-drag-ta.has-hover || panel-drag-ta.pressed: {
-                            background: Colors.surface2;
-                        }
-                    ]
-
-                    panel-drag-ta := TouchArea {
-                        mouse-cursor: ns-resize;
-
-                        // Each `moved` event: mouse-y is relative to the current element
-                        // position, which itself moves as panel-height changes.  Using the
-                        // snapshot-and-delta approach would accumulate drift.  Instead we
-                        // compute the incremental correction each frame:
-                        //
-                        //   cursor_abs = (container_height - ph) + mouse_y_rel
-                        //   desired panel_top = cursor_abs - pressed_y
-                        //   → ph_new = ph_current + (pressed_y - mouse_y_rel)
-                        //
-                        // After the update the element repositions so that mouse_y_rel
-                        // equals pressed_y when the cursor is stationary — zero drift.
-                        moved => {
-                            root.panel-height = clamp(
-                                root.panel-height + (self.pressed-y - self.mouse-y),
-                                80px,
-                                root.content-height - 40px
-                            );
-                        }
-                    }
-                }
-
                 // ── Panel header (tab label + close button) ───────────────────
                 Rectangle {
                     x: 0;
-                    y: root.divider-thickness;
+                    y: 0;
                     width:  parent.width;
                     height: root.panel-header-height;
                     background: Colors.surface0;
@@ -589,9 +579,9 @@ export component AppWindow inherits Window {
                 // ── Result table content ──────────────────────────────────────
                 result-table-inst := ResultTable {
                     x: 0;
-                    y: root.divider-thickness + root.panel-header-height;
+                    y: root.panel-header-height;
                     width:  parent.width;
-                    height: root.panel-height - root.divider-thickness - root.panel-header-height;
+                    height: root.panel-height - root.panel-header-height;
                     columns:          UiState.result-columns;
                     rows:             UiState.result-rows;
                     row-count:        UiState.result-row-count;
@@ -657,7 +647,7 @@ export component AppWindow inherits Window {
             y: menu-bar-height;
             width:  sidebar-width;
             height: content-height;
-            border-width: 2px;
+            border-width: 1px;
             border-color: Colors.blue;
             background: transparent;
         }
@@ -668,7 +658,7 @@ export component AppWindow inherits Window {
             y: menu-bar-height;
             width:  main-width;
             height: content-height;
-            border-width: 2px;
+            border-width: 1px;
             border-color: Colors.blue;
             background: transparent;
         }
@@ -679,7 +669,7 @@ export component AppWindow inherits Window {
             y: menu-bar-height + content-height - panel-height - preview-strip-h;
             width:  main-width;
             height: panel-height + preview-strip-h;
-            border-width: 2px;
+            border-width: 1px;
             border-color: Colors.blue;
             background: transparent;
         }
@@ -763,6 +753,20 @@ export component AppWindow inherits Window {
                 UiState.reopen-db-manager-on-form-close = true;
                 UiState.open-connection-form();
             }
+        }
+
+        // ── Inner edge lines ──────────────────────────────────────────────────
+        // Subtle 1px vertical accents on the left and right sides of the client area.
+        // Dark mode: surface0 (#313244), light mode: surface0 (#ccd0da).
+        Rectangle {
+            x: 0; y: 0;
+            width: 1px; height: root.height;
+            background: Colors.surface0;
+        }
+        Rectangle {
+            x: root.width - 1px; y: 0;
+            width: 1px; height: root.height;
+            background: Colors.surface0;
         }
     }
 }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -243,7 +243,7 @@ export component AppWindow inherits Window {
     // The result/error panel overlays the editor from the bottom (VSCode style).
     // panel-height controls how tall the overlay is; the editor always fills the
     // full content-height behind it.
-    property <length> panel-height:        250px;
+    property <length> panel-height:        content-height * 2 / 3;
     // Height of the tab-bar strip at the top of the panel (below the drag handle).
     property <length> panel-header-height: 28px;
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -381,13 +381,20 @@ export component AppWindow inherits Window {
             clip: true;
 
             // ── Shared gutter column ──────────────────────────────────────────
-            // Spans the full content height so the gutter visually extends through
-            // the divider and result area, giving a consistent left anchor.
+            // Height is capped to the portion above the result panel when the panel
+            // is open.  The panel's opaque background already hides any gutter content
+            // below its top edge, but more importantly: gutter line-number colors
+            // depend on current-line (active-line highlight).  When the gutter's
+            // bounding box overlaps the result panel, every cursor-movement dirty mark
+            // causes Slint to repaint the result cells too.  Clipping the gutter to
+            // the area above the panel eliminates that dirty-region overlap.
             Rectangle {
                 x: 0;
                 y: 0;
                 width:  root.gutter-col-width;
-                height: parent.height;
+                height: UiState.result-panel-open
+                    ? parent.height - root.panel-height
+                    : parent.height;
                 background: Colors.mantle;
                 clip: true;
 
@@ -406,12 +413,19 @@ export component AppWindow inherits Window {
             }
 
             // ── SQL editor (text area only — gutter is the sibling above) ─────────
-            // Always fills the full content height; the result panel overlays it.
+            // Height is capped to the portion of the content area that is NOT covered
+            // by the result panel.  This is the key performance constraint: keeping
+            // the editor's bounds out of the result panel's screen region means Slint's
+            // dirty-region tracker never needs to repaint the result cells when cursor
+            // movement (current-line highlight, TextInput cursor blink, etc.) marks the
+            // editor dirty.  When the panel is closed the editor fills the full height.
             editor-inst := Editor {
                 x: root.gutter-col-width;
                 y: 0;
                 width:  parent.width - root.gutter-col-width;
-                height: parent.height;
+                height: UiState.result-panel-open
+                    ? parent.height - root.panel-height
+                    : parent.height;
                 text         <=> UiState.editor-text;
                 font-family:     UiState.font-family;
                 font-size-px:    UiState.font-size;

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -436,13 +436,12 @@ export component AppWindow inherits Window {
             }
 
             // ── Panel drag handle ─────────────────────────────────────────────
-            // Sits at the top boundary of the preview strip (the thin separator
-            // between the editor and the preview area).  Dragging grows/shrinks
+            // Sits at the top boundary of the result panel.  Dragging grows/shrinks
             // panel-height upward.  Rendered after the result panel so it is on
             // top and receives pointer events without being clipped.
             if UiState.result-panel-open: Rectangle {
                 x: 0;
-                y: parent.height - root.panel-height - root.preview-strip-h;
+                y: parent.height - root.panel-height;
                 width:  parent.width;
                 height: root.divider-thickness;
                 background: panel-drag-ta.has-hover || panel-drag-ta.pressed
@@ -456,63 +455,6 @@ export component AppWindow inherits Window {
                             80px,
                             root.content-height - 40px
                         );
-                    }
-                }
-            }
-
-            // ── Cell-value preview strip ──────────────────────────────────────
-            // Fixed-height strip placed above the result panel; shows the full
-            // value of the last clicked cell with word-wrap and vertical scroll.
-            // Rendered as a sibling of the result panel so it never reduces the
-            // table body height.
-            Rectangle {
-                x: 0;
-                y: parent.height - root.panel-height - root.preview-strip-h;
-                width:  parent.width;
-                height: root.preview-strip-h;
-                background: Colors.mantle;
-                clip: true;
-                visible: UiState.result-panel-open;
-
-                // Top separator
-                Rectangle {
-                    x: 0; y: 0;
-                    width: parent.width; height: 1px;
-                    background: Colors.surface1;
-                }
-
-                // Placeholder — nothing selected or row-only selection
-                if !result-table-inst.selected-cell-is-null
-                        && result-table-inst.selected-cell-value == "": Text {
-                    x: 10px; y: 8px;
-                    color: Colors.surface1;
-                    font-size: Typography.size-base;
-                    text: @tr("Select a cell to preview its value");
-                }
-
-                // NULL indicator
-                if result-table-inst.selected-cell-is-null: Text {
-                    x: 10px; y: 8px;
-                    color: Colors.overlay2;
-                    font-size: Typography.size-base;
-                    text: @tr("NULL");
-                }
-
-                // Cell value — word-wrapped, vertically scrollable
-                if !result-table-inst.selected-cell-is-null
-                        && result-table-inst.selected-cell-value != "": Flickable {
-                    x: 0; y: 4px;
-                    width:  parent.width;
-                    height: parent.height - 4px;
-                    viewport-height: preview-val-text.preferred-height + 8px;
-
-                    preview-val-text := Text {
-                        x: 10px; y: 4px;
-                        width: parent.width - 20px;
-                        text: result-table-inst.selected-cell-value;
-                        color: Colors.text;
-                        font-size: Typography.size-base;
-                        wrap: word-wrap;
                     }
                 }
             }
@@ -581,7 +523,7 @@ export component AppWindow inherits Window {
                     x: 0;
                     y: root.panel-header-height;
                     width:  parent.width;
-                    height: root.panel-height - root.panel-header-height;
+                    height: root.panel-height - root.panel-header-height - root.preview-strip-h;
                     columns:          UiState.result-columns;
                     rows:             UiState.result-rows;
                     row-count:        UiState.result-row-count;
@@ -614,6 +556,60 @@ export component AppWindow inherits Window {
                         }
                     }
                 }
+
+                // ── Cell-value preview strip ──────────────────────────────────
+                // Fixed-height strip at the bottom of the result panel; shows the
+                // full value of the last clicked cell with word-wrap and vertical scroll.
+                Rectangle {
+                    x: 0;
+                    y: root.panel-height - root.preview-strip-h;
+                    width:  parent.width;
+                    height: root.preview-strip-h;
+                    background: Colors.mantle;
+                    clip: true;
+
+                    // Top separator
+                    Rectangle {
+                        x: 0; y: 0;
+                        width: parent.width; height: 1px;
+                        background: Colors.surface1;
+                    }
+
+                    // Placeholder — nothing selected or row-only selection
+                    if !result-table-inst.selected-cell-is-null
+                            && result-table-inst.selected-cell-value == "": Text {
+                        x: 10px; y: 8px;
+                        color: Colors.surface1;
+                        font-size: Typography.size-base;
+                        text: @tr("Select a cell to preview its value");
+                    }
+
+                    // NULL indicator
+                    if result-table-inst.selected-cell-is-null: Text {
+                        x: 10px; y: 8px;
+                        color: Colors.overlay2;
+                        font-size: Typography.size-base;
+                        text: @tr("NULL");
+                    }
+
+                    // Cell value — word-wrapped, vertically scrollable
+                    if !result-table-inst.selected-cell-is-null
+                            && result-table-inst.selected-cell-value != "": Flickable {
+                        x: 0; y: 4px;
+                        width:  parent.width;
+                        height: parent.height - 4px;
+                        viewport-height: preview-val-text.preferred-height + 8px;
+
+                        preview-val-text := Text {
+                            x: 10px; y: 4px;
+                            width: parent.width - 20px;
+                            text: result-table-inst.selected-cell-value;
+                            color: Colors.text;
+                            font-size: Typography.size-base;
+                            wrap: word-wrap;
+                        }
+                    }
+                }
             }
         }
 
@@ -637,9 +633,26 @@ export component AppWindow inherits Window {
             query-status:    UiState.status-message;
         }
 
+        // ── Inner edge lines ──────────────────────────────────────────────────
+        // Subtle 1px vertical accents on the left and right sides of the client area.
+        // Rendered before focus borders so the focus border draws on top and remains
+        // fully visible when it aligns with a window edge.
+        // Dark mode: surface0 (#313244), light mode: surface0 (#ccd0da).
+        Rectangle {
+            x: 0; y: 0;
+            width: 1px; height: root.height;
+            background: Colors.surface0;
+        }
+        Rectangle {
+            x: root.width - 1px; y: 0;
+            width: 1px; height: root.height;
+            background: Colors.surface0;
+        }
+
         // ── Pane focus border indicators ──────────────────────────────────────
-        // Rendered after the main content so they appear on top of the panes,
-        // but before the modal overlays so modals cover the borders.
+        // Rendered after the inner edge lines so focus borders always appear on top
+        // and are not obscured at the window edges.
+        // Rendered before modal overlays so modals cover the borders.
 
         // Sidebar focus border
         if root.focused-pane == 0: Rectangle {
@@ -663,12 +676,12 @@ export component AppWindow inherits Window {
             background: transparent;
         }
 
-        // Result-table pane focus border (covers result panel + preview strip above it)
+        // Result-table pane focus border
         if root.focused-pane == 2 && UiState.result-panel-open: Rectangle {
             x: sidebar-width;
-            y: menu-bar-height + content-height - panel-height - preview-strip-h;
+            y: menu-bar-height + content-height - panel-height;
             width:  main-width;
-            height: panel-height + preview-strip-h;
+            height: panel-height;
             border-width: 1px;
             border-color: Colors.blue;
             background: transparent;
@@ -755,18 +768,5 @@ export component AppWindow inherits Window {
             }
         }
 
-        // ── Inner edge lines ──────────────────────────────────────────────────
-        // Subtle 1px vertical accents on the left and right sides of the client area.
-        // Dark mode: surface0 (#313244), light mode: surface0 (#ccd0da).
-        Rectangle {
-            x: 0; y: 0;
-            width: 1px; height: root.height;
-            background: Colors.surface0;
-        }
-        Rectangle {
-            x: root.width - 1px; y: 0;
-            width: 1px; height: root.height;
-            background: Colors.surface0;
-        }
     }
 }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -103,14 +103,6 @@ export component Editor inherits Rectangle {
     out property <length> popup-x: 0px;
     out property <length> popup-y: 0px;
 
-    /// Height of an overlay panel that covers the bottom of this editor (e.g. the
-    /// result panel when open).  Auto-scroll uses `eff-height = height - overlay-height`
-    /// so the cursor stays in the actually-visible portion.  This prevents the
-    /// current-line highlight from entering the overlay region on every 16 ms tick,
-    /// which would force Slint to repaint all the overlay's cells as a side-effect of
-    /// the dirty-region overlap.
-    in property <length> overlay-height: 0px;
-
     // ── Key-hold state for timer-based UP/DOWN navigation ────────────────────
     property <bool> up-held:   false;
     property <bool> down-held: false;
@@ -157,16 +149,6 @@ export component Editor inherits Rectangle {
     // -1 = no active selection.  Set on first Shift+arrow press; reset when
     // the cursor moves outside of a shift-selection context.
     property <int>  sel-anchor: -1;
-
-    /// True while the repeat timer is armed (after the 250 ms initial-delay
-    /// fires).  app.slint hides the result panel while this is true so that
-    /// navigation renders are cheap (no 150+ result cells to evaluate).
-    /// Activates only on sustained holds — single key taps never set it.
-    out property <bool> is-navigating:
-        (root.up-held   && root.up-repeat-ready)
-        || (root.down-held && root.down-repeat-ready)
-        || (root.up-shift-held   && root.up-shift-repeat-ready)
-        || (root.down-shift-held && root.down-shift-repeat-ready);
 
     // current-line is updated inside cursor-position-changed (see below).
     // It is NOT driven by a poll timer — that would dirty the window at 60 fps
@@ -302,10 +284,6 @@ export component Editor inherits Rectangle {
     // viewport-y so the cursor stays within the visible area.
     // viewport-y is 0 at top and becomes negative as content scrolls up.
     // Visible content spans [-viewport-y, -viewport-y + eff-height].
-    //
-    // eff-height (= height - overlay-height) is used instead of editor-scroll.height
-    // so the cursor is kept in the portion of the editor that is NOT obscured by the
-    // result panel overlay.
     changed current-line => {
         if (root.current-line * root.line-h < -editor-scroll.viewport-y) {
             editor-scroll.viewport-y = -(root.current-line * root.line-h);
@@ -330,14 +308,11 @@ export component Editor inherits Rectangle {
         ? inner-input.preferred-height / root.line-count
         : root.font-size-px * 1px + 5px;
 
-    // Effective visible height — the portion of the editor not obscured by the
-    // overlay panel (result panel when open).  Clamped to at least 80 px so
-    // auto-scroll always has room to operate even when the panel is very tall.
-    property <length> eff-height: max(80px, editor-scroll.height - root.overlay-height);
+    // Effective visible height — clamped to at least 80 px so auto-scroll has
+    // room to operate even when the editor is very short.
+    property <length> eff-height: max(80px, editor-scroll.height);
 
     // Visible line range — used by the external gutter via out properties.
-    // Uses eff-height so the gutter only renders line numbers for lines that are
-    // actually visible above the overlay panel.
     property <int> vis-first: max(0, floor(-editor-scroll.viewport-y / root.line-h) - 1);
     property <int> vis-count: min(
         root.line-count - root.vis-first,

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -16,24 +16,19 @@ import { Colors } from "../theme.slint";
 //
 // Scroll architecture:
 //   TextInput is wrapped in a FocusScope inside a Flickable.  The FocusScope
-//   intercepts UP/DOWN arrow key events in the capture phase (before TextInput
-//   processes them), preventing OS key-repeat events from piling up in the queue.
-//   Timer-based cursor movement replaces key-repeat for UP/DOWN.
-//   Shift+UP/DOWN are also intercepted for range selection using the same
-//   timer pattern.  All other keys (text entry, Ctrl+arrows, etc.) pass through
-//   to TextInput unchanged.
+//   intercepts UP/DOWN (plain and Shift) in the capture phase and drives cursor
+//   movement via 50 ms timers to prevent OS key-repeat queue overflow when the
+//   result panel is open (Slint full-scene renders can block the event loop, delaying
+//   WM_KEYUP and causing overshoot with native OS repeat).
 //
-// Key-repeat queue problem (why the FocusScope approach is necessary):
-//   Holding an arrow key causes the OS to enqueue ~33 WM_KEYDOWN/s.  If each
-//   event triggers TextInput processing + a render, events accumulate faster than
-//   they are drained, so releasing the key does not stop cursor movement immediately.
-//   By consuming repeats in the capture phase we ensure the queue never grows, and
-//   cursor movement stops the instant capture-key-released clears the held flag.
-//
-// Source evidence: i-slint-core/window.rs:804 — capture_key_event is dispatched
-// root→focused (reverse item_list) before key_event is dispatched focused→root.
-// i-slint-core/items/flickable.rs:155 — Flickable.capture_key_event always returns
-// EventIgnored, so it does not interfere.
+//   Two-phase heartbeat stop mechanism:
+//     Phase 1 (*-repeat-received == false): timer moves unconditionally; stopping
+//       relies on capture-key-released / key-released (OS hasn't started auto-repeating
+//       yet, so no heartbeat signal is available).
+//     Phase 2 (*-repeat-received == true): timer checks *-key-seen each fire; if the
+//       flag is clear no OS repeat arrived since the last fire → key was released → stop.
+//   *-repeat-received is set on the first OS auto-repeat event (identified by *-held
+//   already being true when capture-key-pressed fires) and cleared on key-released.
 //
 // All UiState values arrive as `in` properties forwarded from app.slint.
 // This component does NOT import app.slint to avoid circular dependencies.
@@ -108,6 +103,14 @@ export component Editor inherits Rectangle {
     out property <length> popup-x: 0px;
     out property <length> popup-y: 0px;
 
+    /// Height of an overlay panel that covers the bottom of this editor (e.g. the
+    /// result panel when open).  Auto-scroll uses `eff-height = height - overlay-height`
+    /// so the cursor stays in the actually-visible portion.  This prevents the
+    /// current-line highlight from entering the overlay region on every 16 ms tick,
+    /// which would force Slint to repaint all the overlay's cells as a side-effect of
+    /// the dirty-region overlap.
+    in property <length> overlay-height: 0px;
+
     // ── Key-hold state for timer-based UP/DOWN navigation ────────────────────
     property <bool> up-held:   false;
     property <bool> down-held: false;
@@ -116,20 +119,59 @@ export component Editor inherits Rectangle {
     property <bool> up-repeat-ready:   false;
     property <bool> down-repeat-ready: false;
 
-    // ── Key-hold state for Shift+UP/DOWN range selection ──────────────────
+    // ── Heartbeat flags ───────────────────────────────────────────────────────
+    // Two-phase stop mechanism that works even when slow renders block the event
+    // loop and delay capture-key-released / WM_KEYUP processing.
+    //
+    // *-key-seen : set true by every key-press event (initial + OS repeats);
+    //              reset by the 50ms timer after each move.
+    // *-repeat-received : set true the first time an OS auto-repeat event for
+    //              that direction arrives (identified by down-held already being
+    //              true on entry to capture-key-pressed).
+    //
+    // Pre-OS-repeat phase (*-repeat-received == false):
+    //   The OS hasn't started auto-repeating yet (OS initial delay ~500 ms).
+    //   The timer moves unconditionally on every fire — heartbeat is not usable
+    //   because no OS repeats are coming.  Stopping relies on capture-key-released.
+    //
+    // Post-OS-repeat phase (*-repeat-received == true):
+    //   OS repeats are arriving at ~33 ms.  On each timer fire: if *-key-seen is
+    //   true, a repeat arrived since the last fire → keep moving; if false, no
+    //   repeat arrived → key released → stop.  This detects release within one
+    //   timer interval regardless of render blocking.
+    property <bool> up-key-seen:           false;
+    property <bool> down-key-seen:         false;
+    property <bool> up-shift-key-seen:     false;
+    property <bool> down-shift-key-seen:   false;
+    property <bool> up-repeat-received:       false;
+    property <bool> down-repeat-received:     false;
+    property <bool> up-shift-repeat-received:   false;
+    property <bool> down-shift-repeat-received: false;
+
+    // ── Key-hold state for Shift+UP/DOWN range selection ─────────────────────
     property <bool> up-shift-held:   false;
     property <bool> down-shift-held: false;
     property <bool> up-shift-repeat-ready:   false;
     property <bool> down-shift-repeat-ready: false;
     // Byte offset of the fixed end of an active shift-selection.
     // -1 = no active selection.  Set on first Shift+arrow press; reset when
-    // the cursor moves outside of a shift-selection context (plain nav or click).
+    // the cursor moves outside of a shift-selection context.
     property <int>  sel-anchor: -1;
 
-    // ── Cursor-line poll timer ────────────────────────────────────────────────
-    // NOT a reactive binding — polling at 60 fps keeps key-event processing to
-    // pure TextInput internals (essentially free) so rapid key-repeat bursts do
-    // not stall behind our property computations.
+    /// True while the repeat timer is armed (after the 250 ms initial-delay
+    /// fires).  app.slint hides the result panel while this is true so that
+    /// navigation renders are cheap (no 150+ result cells to evaluate).
+    /// Activates only on sustained holds — single key taps never set it.
+    out property <bool> is-navigating:
+        (root.up-held   && root.up-repeat-ready)
+        || (root.down-held && root.down-repeat-ready)
+        || (root.up-shift-held   && root.up-shift-repeat-ready)
+        || (root.down-shift-held && root.down-shift-repeat-ready);
+
+    // current-line is updated inside cursor-position-changed (see below).
+    // It is NOT driven by a poll timer — that would dirty the window at 60 fps
+    // regardless of cursor movement.  Updating only inside cursor-position-changed
+    // means a dirty mark is issued only when the cursor actually moves.
     in-out property <int> current-line: 0;
 
     /// Exposes TextInput focus state so app.slint can sync its focused-pane property.
@@ -138,22 +180,9 @@ export component Editor inherits Rectangle {
     /// Programmatic focus: called by app.slint when Alt+Arrow navigates to the editor.
     public function grab-focus() { inner-input.focus(); }
 
-    Timer {
-        interval: 16ms;
-        running: inner-input.has-focus;
-        triggered => {
-            root.current-line = root.cursor-line(
-                inner-input.text,
-                inner-input.cursor-position-byte-offset
-            );
-        }
-    }
-
     // ── Initial-delay timers ──────────────────────────────────────────────────
     // Fire once ~250 ms after the key is first held.  Setting repeat-ready arms
     // the sustained-movement timer, matching the OS key-repeat initial delay.
-    // The timer stops itself because the running condition becomes false once
-    // repeat-ready is true.
     Timer {
         interval: 250ms;
         running: root.up-held && !root.up-repeat-ready;
@@ -164,37 +193,6 @@ export component Editor inherits Rectangle {
         running: root.down-held && !root.down-repeat-ready;
         triggered => { root.down-repeat-ready = true; }
     }
-
-    // ── Sustained UP movement timer ───────────────────────────────────────────
-    // Only fires after the initial delay has elapsed (up-repeat-ready = true).
-    Timer {
-        interval: 50ms;
-        running: root.up-held && root.up-repeat-ready;
-        triggered => {
-            let new-pos = root.move-cursor-line(
-                inner-input.text,
-                inner-input.cursor-position-byte-offset,
-                -1
-            );
-            inner-input.set-selection-offsets(new-pos, new-pos);
-        }
-    }
-
-    // ── Sustained DOWN movement timer ─────────────────────────────────────────
-    Timer {
-        interval: 50ms;
-        running: root.down-held && root.down-repeat-ready;
-        triggered => {
-            let new-pos = root.move-cursor-line(
-                inner-input.text,
-                inner-input.cursor-position-byte-offset,
-                1
-            );
-            inner-input.set-selection-offsets(new-pos, new-pos);
-        }
-    }
-
-    // ── Initial-delay timers for Shift+UP/DOWN selection ─────────────────────
     Timer {
         interval: 250ms;
         running: root.up-shift-held && !root.up-shift-repeat-ready;
@@ -206,44 +204,113 @@ export component Editor inherits Rectangle {
         triggered => { root.down-shift-repeat-ready = true; }
     }
 
-    // ── Sustained Shift+UP selection timer ───────────────────────────────────
+    // ── Sustained movement timers ─────────────────────────────────────────────
+    // Two-phase heartbeat:
+    //   Phase 1 (*-repeat-received == false): OS hasn't started auto-repeating yet.
+    //     Move unconditionally — no heartbeat possible without OS repeats.
+    //     Stopping relies on capture-key-released / key-released.
+    //   Phase 2 (*-repeat-received == true): OS auto-repeats are arriving.
+    //     If *-key-seen is false, no repeat arrived since last fire → key released → stop.
+    //     If *-key-seen is true, a repeat arrived → keep moving.
+    Timer {
+        interval: 50ms;
+        running: root.up-held && root.up-repeat-ready;
+        triggered => {
+            if (!root.up-repeat-received) {
+                root.up-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, -1);
+                inner-input.set-selection-offsets(new-pos, new-pos);
+            } else if (!root.up-key-seen) {
+                root.up-held = false;
+                root.up-repeat-ready = false;
+                root.up-repeat-received = false;
+            } else {
+                root.up-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, -1);
+                inner-input.set-selection-offsets(new-pos, new-pos);
+            }
+        }
+    }
+    Timer {
+        interval: 50ms;
+        running: root.down-held && root.down-repeat-ready;
+        triggered => {
+            if (!root.down-repeat-received) {
+                root.down-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, 1);
+                inner-input.set-selection-offsets(new-pos, new-pos);
+            } else if (!root.down-key-seen) {
+                root.down-held = false;
+                root.down-repeat-ready = false;
+                root.down-repeat-received = false;
+            } else {
+                root.down-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, 1);
+                inner-input.set-selection-offsets(new-pos, new-pos);
+            }
+        }
+    }
     Timer {
         interval: 50ms;
         running: root.up-shift-held && root.up-shift-repeat-ready;
         triggered => {
-            let new-pos = root.move-cursor-line(
-                inner-input.text,
-                inner-input.cursor-position-byte-offset,
-                -1
-            );
-            inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            if (!root.up-shift-repeat-received) {
+                root.up-shift-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, -1);
+                inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            } else if (!root.up-shift-key-seen) {
+                root.up-shift-held = false;
+                root.up-shift-repeat-ready = false;
+                root.up-shift-repeat-received = false;
+            } else {
+                root.up-shift-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, -1);
+                inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            }
         }
     }
-
-    // ── Sustained Shift+DOWN selection timer ─────────────────────────────────
     Timer {
         interval: 50ms;
         running: root.down-shift-held && root.down-shift-repeat-ready;
         triggered => {
-            let new-pos = root.move-cursor-line(
-                inner-input.text,
-                inner-input.cursor-position-byte-offset,
-                1
-            );
-            inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            if (!root.down-shift-repeat-received) {
+                root.down-shift-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, 1);
+                inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            } else if (!root.down-shift-key-seen) {
+                root.down-shift-held = false;
+                root.down-shift-repeat-ready = false;
+                root.down-shift-repeat-received = false;
+            } else {
+                root.down-shift-key-seen = false;
+                let new-pos = root.move-cursor-line(inner-input.text,
+                    inner-input.cursor-position-byte-offset, 1);
+                inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+            }
         }
     }
 
     // ── Auto-scroll ───────────────────────────────────────────────────────────
-    // When the cursor line changes (from poll timer or key timer), adjust
+    // When the cursor line changes (updated in cursor-position-changed), adjust
     // viewport-y so the cursor stays within the visible area.
     // viewport-y is 0 at top and becomes negative as content scrolls up.
-    // Visible content spans [-viewport-y, -viewport-y + height].
+    // Visible content spans [-viewport-y, -viewport-y + eff-height].
+    //
+    // eff-height (= height - overlay-height) is used instead of editor-scroll.height
+    // so the cursor is kept in the portion of the editor that is NOT obscured by the
+    // result panel overlay.
     changed current-line => {
         if (root.current-line * root.line-h < -editor-scroll.viewport-y) {
             editor-scroll.viewport-y = -(root.current-line * root.line-h);
-        } else if ((root.current-line + 1) * root.line-h > -editor-scroll.viewport-y + editor-scroll.height) {
-            editor-scroll.viewport-y = -((root.current-line + 1) * root.line-h - editor-scroll.height);
+        } else if ((root.current-line + 1) * root.line-h > -editor-scroll.viewport-y + root.eff-height) {
+            editor-scroll.viewport-y = -((root.current-line + 1) * root.line-h - root.eff-height);
         }
     }
 
@@ -263,11 +330,18 @@ export component Editor inherits Rectangle {
         ? inner-input.preferred-height / root.line-count
         : root.font-size-px * 1px + 5px;
 
+    // Effective visible height — the portion of the editor not obscured by the
+    // overlay panel (result panel when open).  Clamped to at least 80 px so
+    // auto-scroll always has room to operate even when the panel is very tall.
+    property <length> eff-height: max(80px, editor-scroll.height - root.overlay-height);
+
     // Visible line range — used by the external gutter via out properties.
+    // Uses eff-height so the gutter only renders line numbers for lines that are
+    // actually visible above the overlay panel.
     property <int> vis-first: max(0, floor(-editor-scroll.viewport-y / root.line-h) - 1);
     property <int> vis-count: min(
         root.line-count - root.vis-first,
-        floor(editor-scroll.height / root.line-h) + 3
+        floor(root.eff-height / root.line-h) + 3
     );
 
     // ── Current-line highlight ───────────────────────────────────────────────
@@ -385,68 +459,66 @@ export component Editor inherits Rectangle {
                         && event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
+                    root.up-shift-key-seen = true;
                     if (!root.up-shift-held) {
-                        // Set held flag BEFORE set-selection-offsets so that
-                        // cursor-position-changed does not reset sel-anchor.
                         root.up-shift-held = true;
+                        root.up-shift-repeat-received = false;
                         if (root.sel-anchor < 0) {
                             root.sel-anchor = inner-input.cursor-position-byte-offset;
                         }
-                        let new-pos = root.move-cursor-line(
-                            inner-input.text,
-                            inner-input.cursor-position-byte-offset,
-                            -1
-                        );
+                        let new-pos = root.move-cursor-line(inner-input.text,
+                            inner-input.cursor-position-byte-offset, -1);
                         inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+                    } else {
+                        root.up-shift-repeat-received = true;
                     }
                     EventResult.accept
                 } else if (event.text == Key.DownArrow
                         && event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
+                    root.down-shift-key-seen = true;
                     if (!root.down-shift-held) {
-                        // Set held flag BEFORE set-selection-offsets so that
-                        // cursor-position-changed does not reset sel-anchor.
                         root.down-shift-held = true;
+                        root.down-shift-repeat-received = false;
                         if (root.sel-anchor < 0) {
                             root.sel-anchor = inner-input.cursor-position-byte-offset;
                         }
-                        let new-pos = root.move-cursor-line(
-                            inner-input.text,
-                            inner-input.cursor-position-byte-offset,
-                            1
-                        );
+                        let new-pos = root.move-cursor-line(inner-input.text,
+                            inner-input.cursor-position-byte-offset, 1);
                         inner-input.set-selection-offsets(root.sel-anchor, new-pos);
+                    } else {
+                        root.down-shift-repeat-received = true;
                     }
                     EventResult.accept
                 } else if (event.text == Key.UpArrow
                         && !event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
+                    root.up-key-seen = true;
                     if (!root.up-held) {
-                        // First press: move cursor once right away.
-                        let new-pos = root.move-cursor-line(
-                            inner-input.text,
-                            inner-input.cursor-position-byte-offset,
-                            -1
-                        );
-                        inner-input.set-selection-offsets(new-pos, new-pos);
                         root.up-held = true;
+                        root.up-repeat-received = false;
+                        let new-pos = root.move-cursor-line(inner-input.text,
+                            inner-input.cursor-position-byte-offset, -1);
+                        inner-input.set-selection-offsets(new-pos, new-pos);
+                    } else {
+                        root.up-repeat-received = true;
                     }
-                    // Consume the event so TextInput never sees it.
                     EventResult.accept
                 } else if (event.text == Key.DownArrow
                         && !event.modifiers.shift
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
+                    root.down-key-seen = true;
                     if (!root.down-held) {
-                        let new-pos = root.move-cursor-line(
-                            inner-input.text,
-                            inner-input.cursor-position-byte-offset,
-                            1
-                        );
-                        inner-input.set-selection-offsets(new-pos, new-pos);
                         root.down-held = true;
+                        root.down-repeat-received = false;
+                        let new-pos = root.move-cursor-line(inner-input.text,
+                            inner-input.cursor-position-byte-offset, 1);
+                        inner-input.set-selection-offsets(new-pos, new-pos);
+                    } else {
+                        root.down-repeat-received = true;
                     }
                     EventResult.accept
                 } else if (event.text == Key.Return
@@ -478,16 +550,24 @@ export component Editor inherits Rectangle {
 
             capture-key-released(event) => {
                 if (event.text == Key.UpArrow) {
-                    root.up-held               = false;
-                    root.up-repeat-ready       = false;
-                    root.up-shift-held         = false;
-                    root.up-shift-repeat-ready = false;
+                    root.up-held                    = false;
+                    root.up-repeat-ready            = false;
+                    root.up-repeat-received         = false;
+                    root.up-key-seen                = false;
+                    root.up-shift-held              = false;
+                    root.up-shift-repeat-ready      = false;
+                    root.up-shift-repeat-received   = false;
+                    root.up-shift-key-seen          = false;
                 }
                 if (event.text == Key.DownArrow) {
-                    root.down-held               = false;
-                    root.down-repeat-ready       = false;
-                    root.down-shift-held         = false;
-                    root.down-shift-repeat-ready = false;
+                    root.down-held                  = false;
+                    root.down-repeat-ready          = false;
+                    root.down-repeat-received       = false;
+                    root.down-key-seen              = false;
+                    root.down-shift-held            = false;
+                    root.down-shift-repeat-ready    = false;
+                    root.down-shift-repeat-received = false;
+                    root.down-shift-key-seen        = false;
                 }
                 EventResult.reject
             }
@@ -507,22 +587,54 @@ export component Editor inherits Rectangle {
                 font-family: root.font-family;
                 font-size:   root.font-size-px * 1px;
 
+                // Secondary path to clear hold-flags when a key is released.
+                // capture-key-released (on the FocusScope) is the primary path,
+                // but key-released fires on the normal dispatch chain and is more
+                // reliable when a render is in-flight and the event loop is busy.
+                key-released(event) => {
+                    if (event.text == Key.UpArrow) {
+                        root.up-held                    = false;
+                        root.up-repeat-ready            = false;
+                        root.up-repeat-received         = false;
+                        root.up-key-seen                = false;
+                        root.up-shift-held              = false;
+                        root.up-shift-repeat-ready      = false;
+                        root.up-shift-repeat-received   = false;
+                        root.up-shift-key-seen          = false;
+                    }
+                    if (event.text == Key.DownArrow) {
+                        root.down-held                  = false;
+                        root.down-repeat-ready          = false;
+                        root.down-repeat-received       = false;
+                        root.down-key-seen              = false;
+                        root.down-shift-held            = false;
+                        root.down-shift-repeat-ready    = false;
+                        root.down-shift-repeat-received = false;
+                        root.down-shift-key-seen        = false;
+                    }
+                    EventResult.reject
+                }
+
                 // Notify app.slint on every user keystroke so the completion
                 // debounce timer can be (re)started.
                 edited => {
                     root.text-edited(self.text, self.cursor-position-byte-offset);
                 }
 
-                // Horizontal auto-scroll: keep cursor inside the visible area
-                // whenever the cursor position changes (typing, keyboard nav,
-                // or mouse drag).  pos.x is the cursor's x coordinate in
-                // TextInput content space (independent of scroll offset).
-                // viewport-x is ≤ 0; visible content spans
-                //   [-viewport-x, -viewport-x + editor-scroll.width].
+                // Whenever the cursor moves (key nav, mouse click, set-selection-offsets,
+                // text edit) update current-line synchronously here.  Doing it here
+                // means the window is only dirtied on actual cursor movement — not by
+                // a 16 ms background timer — and the `changed current-line` auto-scroll
+                // runs before we compute popup-y, so popup-y reflects the adjusted
+                // viewport.
                 cursor-position-changed(pos) => {
-                    // Reset shift-selection anchor whenever the cursor moves
-                    // outside of an active Shift+arrow sequence (plain nav,
-                    // mouse click, typing, etc.).
+                    // Update current-line FIRST so `changed current-line` fires and
+                    // adjusts viewport-y before we need it for popup-y below.
+                    root.current-line = root.cursor-line(
+                        inner-input.text,
+                        inner-input.cursor-position-byte-offset
+                    );
+
                     if (!root.down-shift-held && !root.up-shift-held) {
                         root.sel-anchor = -1;
                     }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -166,22 +166,22 @@ export component Editor inherits Rectangle {
     // Fire once ~250 ms after the key is first held.  Setting repeat-ready arms
     // the sustained-movement timer, matching the OS key-repeat initial delay.
     Timer {
-        interval: 250ms;
+        interval: 180ms;
         running: root.up-held && !root.up-repeat-ready;
         triggered => { root.up-repeat-ready = true; }
     }
     Timer {
-        interval: 250ms;
+        interval: 180ms;
         running: root.down-held && !root.down-repeat-ready;
         triggered => { root.down-repeat-ready = true; }
     }
     Timer {
-        interval: 250ms;
+        interval: 180ms;
         running: root.up-shift-held && !root.up-shift-repeat-ready;
         triggered => { root.up-shift-repeat-ready = true; }
     }
     Timer {
-        interval: 250ms;
+        interval: 180ms;
         running: root.down-shift-held && !root.down-shift-repeat-ready;
         triggered => { root.down-shift-repeat-ready = true; }
     }
@@ -195,7 +195,7 @@ export component Editor inherits Rectangle {
     //     If *-key-seen is false, no repeat arrived since last fire → key released → stop.
     //     If *-key-seen is true, a repeat arrived → keep moving.
     Timer {
-        interval: 50ms;
+        interval: 35ms;
         running: root.up-held && root.up-repeat-ready;
         triggered => {
             if (!root.up-repeat-received) {
@@ -216,7 +216,7 @@ export component Editor inherits Rectangle {
         }
     }
     Timer {
-        interval: 50ms;
+        interval: 35ms;
         running: root.down-held && root.down-repeat-ready;
         triggered => {
             if (!root.down-repeat-received) {
@@ -237,7 +237,7 @@ export component Editor inherits Rectangle {
         }
     }
     Timer {
-        interval: 50ms;
+        interval: 35ms;
         running: root.up-shift-held && root.up-shift-repeat-ready;
         triggered => {
             if (!root.up-shift-repeat-received) {
@@ -258,7 +258,7 @@ export component Editor inherits Rectangle {
         }
     }
     Timer {
-        interval: 50ms;
+        interval: 35ms;
         running: root.down-shift-held && root.down-shift-repeat-ready;
         triggered => {
             if (!root.down-shift-repeat-received) {

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -48,7 +48,7 @@ export component MenuBar inherits Rectangle {
             Text {
                 text: @tr("File");
                 color: Colors.text;
-                font-size: Typography.size-sm;
+                font-size:   Typography.size-base;
                 horizontal-alignment: center;
                 vertical-alignment:   center;
             }
@@ -93,7 +93,7 @@ export component MenuBar inherits Rectangle {
             Text {
                 text: @tr("Edit");
                 color: Colors.text;
-                font-size: Typography.size-sm;
+                font-size:   Typography.size-base;
                 horizontal-alignment: center;
                 vertical-alignment:   center;
             }
@@ -135,7 +135,7 @@ export component MenuBar inherits Rectangle {
             Text {
                 text: @tr("Database");
                 color: Colors.text;
-                font-size: Typography.size-sm;
+                font-size:   Typography.size-base;
                 horizontal-alignment: center;
                 vertical-alignment:   center;
             }
@@ -187,7 +187,7 @@ export component MenuBar inherits Rectangle {
             Text {
                 text: @tr("Query");
                 color: Colors.text;
-                font-size: Typography.size-sm;
+                font-size:   Typography.size-base;
                 horizontal-alignment: center;
                 vertical-alignment:   center;
             }
@@ -240,7 +240,7 @@ export component MenuBar inherits Rectangle {
             Text {
                 text: @tr("Settings");
                 color: Colors.text;
-                font-size: Typography.size-sm;
+                font-size:   Typography.size-base;
                 horizontal-alignment: center;
                 vertical-alignment:   center;
             }

--- a/app/src/ui/components/result_table_header.slint
+++ b/app/src/ui/components/result_table_header.slint
@@ -43,7 +43,7 @@ export component ResultTableHeader inherits Flickable {
                     : parent.width - 12px;
                 text: col;
                 color: Colors.text;
-                font-size: Typography.size-base;
+                font-size: Typography.size-lg;
                 overflow: elide;
             }
 


### PR DESCRIPTION
## Summary

UI polish pass covering focus indicators, gutter, result panel layout, panel resize ergonomics, cell preview placement, and smooth UP/DOWN cursor navigation in the SQL editor when the result panel is open.

## Changes

- Thinned focus borders from 2px to 1px for a less heavy feel
- Fixed gutter (line number) background to use `Colors.mantle` instead of `Colors.base`, matching the editor background
- Extended the result table and preview strip to `x=0`, eliminating the left blank gap that appeared when a connection was active
- Added inner vertical edge lines (`Colors.surface0`) as a subtle visual accent
- Restricted Ctrl+J panel toggle to only work when query results or an error message are present
- Moved the resize drag handle to the top edge of the result panel for intuitive resize behaviour
- Fixed focus border edges being obscured by inner edge lines at the window boundary (render order fix)
- Moved cell-value preview strip from above the result panel to the bottom of the result panel (below pagination)
- Increased default result panel height to 2/3 of the content area
- Fixed laggy UP/DOWN navigation when the result panel is open: replaced native OS key-repeat with timer-based navigation (180 ms initial delay + 35 ms repeat) using a two-phase heartbeat stop mechanism to prevent queue overflow from slow full-scene GPU renders
- Capped gutter height to the area above the result panel, eliminating dirty-region overlap that forced result-cell re-renders on every cursor movement
- Removed dead `overlay-height` and `is-navigating` properties left over from earlier iterations
- Increased menu bar label and result table column header font size (10 px → 12 px / 12 px → 13 px) for improved readability

## Related Issues

Closes #194

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes