### PR TITLE
feat(ui): multi-tab interface with SQL editor and table view tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6091,9 +6091,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -6767,11 +6767,13 @@ dependencies = [
  "chrono",
  "rfd",
  "rust-i18n",
+ "serde",
  "slint",
  "slint-build",
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -6810,7 +6812,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
- "toml 1.1.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "uuid",
 ]
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -20,6 +20,8 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 arboard             = "3.6.1"
 rfd                 = { version = "0.15", features = ["tokio"] }
 uuid               = { workspace = true }
+serde              = { workspace = true, features = ["derive"] }
+toml               = "1"
 rust-i18n          = "4.0.0"
 
 [dev-dependencies]

--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -291,3 +291,39 @@ msgstr "Disconnect"
 msgctxt "DbManagerDialog"
 msgid "+ Add connection"
 msgstr "+ Add connection"
+
+msgctxt "TableView"
+msgid "Data"
+msgstr "Data"
+
+msgctxt "TableView"
+msgid "Columns"
+msgstr "Columns"
+
+msgctxt "TableView"
+msgid "DDL"
+msgstr "DDL"
+
+msgctxt "TableView"
+msgid "Copy DDL"
+msgstr "Copy DDL"
+
+msgctxt "TableView"
+msgid "Column"
+msgstr "Column"
+
+msgctxt "TableView"
+msgid "Type"
+msgstr "Type"
+
+msgctxt "TableView"
+msgid "Nullable"
+msgstr "Nullable"
+
+msgctxt "TableView"
+msgid "YES"
+msgstr "YES"
+
+msgctxt "TableView"
+msgid "NO"
+msgstr "NO"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -291,3 +291,39 @@ msgstr "切断"
 msgctxt "DbManagerDialog"
 msgid "+ Add connection"
 msgstr "+ 接続を追加"
+
+msgctxt "TableView"
+msgid "Data"
+msgstr "データ"
+
+msgctxt "TableView"
+msgid "Columns"
+msgstr "カラム"
+
+msgctxt "TableView"
+msgid "DDL"
+msgstr "DDL"
+
+msgctxt "TableView"
+msgid "Copy DDL"
+msgstr "DDLをコピー"
+
+msgctxt "TableView"
+msgid "Column"
+msgstr "カラム"
+
+msgctxt "TableView"
+msgid "Type"
+msgstr "型"
+
+msgctxt "TableView"
+msgid "Nullable"
+msgstr "NULL許容"
+
+msgctxt "TableView"
+msgid "YES"
+msgstr "YES"
+
+msgctxt "TableView"
+msgid "NO"
+msgstr "NO"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -40,4 +40,18 @@ pub enum Command {
     FetchCompletion(String, usize), // sql, cursor_pos
     ExportResult(ExportFormat, PathBuf),
     UpdateConfig(ConfigUpdate),
+    /// Fetch the DDL CREATE statement for `name` (table/view/index) on `conn_id`.
+    FetchDdl {
+        tab_id: String,
+        conn_id: String,
+        name: String,
+        kind: String,
+    },
+    /// Fetch a page of rows from `table_name` on `conn_id` for a Table View tab.
+    FetchTableData {
+        tab_id: String,
+        conn_id: String,
+        table_name: String,
+        page_size: usize,
+    },
 }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -21,7 +21,11 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use wf_completion::{cache::MetadataCache, service::CompletionService};
-use wf_db::{error::DbError, models::DbConnection, service::DbService};
+use wf_db::{
+    error::DbError,
+    models::{DbConnection, DbType},
+    service::DbService,
+};
 use wf_history::service::HistoryService;
 
 use crate::{
@@ -130,7 +134,22 @@ impl AppController {
                 Command::FetchCompletion(sql, cursor_pos) => {
                     self.handle_fetch_completion(sql, cursor_pos).await;
                 }
-                _ => {} // remaining commands handled in later tasks
+                Command::FetchDdl {
+                    tab_id,
+                    conn_id,
+                    name,
+                    kind,
+                } => self.handle_fetch_ddl(tab_id, conn_id, name, kind).await,
+                Command::FetchTableData {
+                    tab_id,
+                    conn_id,
+                    table_name,
+                    page_size,
+                } => {
+                    self.handle_fetch_table_data(tab_id, conn_id, table_name, page_size)
+                        .await
+                }
+                Command::ExportResult(_, _) => {} // handled client-side in UI layer
             }
         }
     }
@@ -474,6 +493,74 @@ impl AppController {
             let items = completion.complete(&conn_id, &sql, cursor_pos).await;
             let _ = self.tx_event.send(Event::CompletionReady(items)).await;
         }
+    }
+
+    /// Handle a `FetchDdl` command.
+    ///
+    /// Fetches the DDL CREATE statement for `name` on `conn_id` and sends
+    /// [`Event::DdlLoaded`] or [`Event::DdlFetchFailed`] to the UI.
+    async fn handle_fetch_ddl(&self, tab_id: String, conn_id: String, name: String, kind: String) {
+        let db = self.db.clone(); // clone required: tokio::spawn needs 'static
+        let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
+        tokio::spawn(async move {
+            match db.fetch_ddl(&conn_id, &name, &kind).await {
+                Ok(ddl) => {
+                    let _ = tx.send(Event::DdlLoaded { tab_id, ddl }).await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Event::DdlFetchFailed {
+                            tab_id,
+                            msg: e.localized_message(),
+                        })
+                        .await;
+                }
+            }
+        });
+    }
+
+    /// Handle a `FetchTableData` command.
+    ///
+    /// Executes `SELECT * FROM "{table_name}" LIMIT {page_size}` and sends
+    /// [`Event::TableDataLoaded`] or [`Event::TableDataFailed`] to the UI.
+    async fn handle_fetch_table_data(
+        &self,
+        tab_id: String,
+        conn_id: String,
+        table_name: String,
+        page_size: usize,
+    ) {
+        let quote = self
+            .state
+            .conn
+            .all()
+            .iter()
+            .find(|c| c.id == conn_id)
+            .map(|c| if c.db_type == DbType::MySQL { '`' } else { '"' })
+            .unwrap_or('"');
+        let escaped = table_name.replace(quote, &format!("{quote}{quote}"));
+        let sql = if page_size > 0 {
+            format!("SELECT * FROM {quote}{escaped}{quote} LIMIT {page_size}")
+        } else {
+            format!("SELECT * FROM {quote}{escaped}{quote}")
+        };
+        let db = self.db.clone(); // clone required: tokio::spawn needs 'static
+        let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
+        tokio::spawn(async move {
+            match db.execute(&conn_id, &sql).await {
+                Ok(result) => {
+                    let _ = tx.send(Event::TableDataLoaded { tab_id, result }).await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Event::TableDataFailed {
+                            tab_id,
+                            msg: e.localized_message(),
+                        })
+                        .await;
+                }
+            }
+        });
     }
 
     /// Handle a `CancelQuery` command.

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -35,4 +35,20 @@ pub enum Event {
     InsertText(String),
     ConfigUpdated,
     StateChanged(StateEvent),
+    DdlLoaded {
+        tab_id: String,
+        ddl: String,
+    },
+    DdlFetchFailed {
+        tab_id: String,
+        msg: String,
+    },
+    TableDataLoaded {
+        tab_id: String,
+        result: QueryResult,
+    },
+    TableDataFailed {
+        tab_id: String,
+        msg: String,
+    },
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -11,12 +11,27 @@
 //! lives here because `app/` is the only crate that depends on both.
 
 use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 use wf_config::{
     manager::ConfigManager,
     models::{ConnectionConfig, DbTypeName, PageSize, Theme},
 };
 use wf_db::models::{DbConnection, DbType};
+
+/// Serializable record for a single SQL Editor tab (written to `tabs.toml`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabSessionEntry {
+    pub id: String,
+    pub title: String,
+    pub query_text: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TabsFile {
+    active_index: usize,
+    tabs: Vec<TabSessionEntry>,
+}
 
 /// Persists and restores the last active database connection across app restarts.
 ///
@@ -167,6 +182,50 @@ impl SessionManager {
         }
         info!(len = query.len(), "last_query.sql restored");
         Ok(Some(query))
+    }
+
+    /// Persist the current set of SQL Editor tabs to `tabs.toml`.
+    ///
+    /// `active_index` is the index within the serialized list (sql-editor tabs only).
+    /// Table View tabs are intentionally not persisted — they are easy to reopen.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
+    pub fn save_tabs(&self, active_index: usize, tabs: &[TabSessionEntry]) -> anyhow::Result<()> {
+        let path = self.config_manager.dir().join("tabs.toml");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory {}", parent.display()))?;
+        }
+        let file = TabsFile {
+            active_index,
+            tabs: tabs.to_vec(),
+        };
+        let s = toml::to_string_pretty(&file).context("failed to serialize tabs")?;
+        std::fs::write(&path, s.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        info!(count = tabs.len(), "tabs.toml saved");
+        Ok(())
+    }
+
+    /// Read `tabs.toml` and return `(active_index, tabs)`.
+    ///
+    /// Returns `Ok(None)` when the file does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file exists but cannot be parsed.
+    pub fn restore_tabs(&self) -> anyhow::Result<Option<(usize, Vec<TabSessionEntry>)>> {
+        let path = self.config_manager.dir().join("tabs.toml");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let s = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let file: TabsFile = toml::from_str(&s).context("failed to parse tabs.toml")?;
+        info!(count = file.tabs.len(), "tabs.toml restored");
+        Ok(Some((file.active_index, file.tabs)))
     }
 
     /// Load the last session and return the connection to auto-connect to.
@@ -368,6 +427,43 @@ mod tests {
         let restored = sm.restore_query_file().unwrap();
         assert_eq!(restored, Some("SELECT 1".to_string()));
         assert!(dir.path().join("last_query.sql").exists());
+    }
+
+    #[test]
+    fn save_tabs_should_persist_and_restore() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+
+        let tabs = vec![
+            super::TabSessionEntry {
+                id: "t1".to_string(),
+                title: "Query 1".to_string(),
+                query_text: "SELECT 1".to_string(),
+            },
+            super::TabSessionEntry {
+                id: "t2".to_string(),
+                title: "Query 2".to_string(),
+                query_text: "SELECT 2".to_string(),
+            },
+        ];
+        sm.save_tabs(1, &tabs).unwrap();
+
+        let (active, restored) = sm.restore_tabs().unwrap().expect("should restore");
+        assert_eq!(active, 1);
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[0].id, "t1");
+        assert_eq!(restored[1].query_text, "SELECT 2");
+    }
+
+    #[test]
+    fn restore_tabs_should_return_none_when_absent() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        assert!(sm.restore_tabs().unwrap().is_none());
     }
 
     #[test]

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -10,7 +10,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, CompletionRow } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData } from "globals.slint";
 import { Colors, Typography } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -19,6 +19,8 @@ import { Sidebar }         from "components/sidebar.slint";
 import { Editor }          from "components/editor.slint";
 import { ResultTable }     from "components/result_table.slint";
 import { StatusBar }       from "components/status_bar.slint";
+import { TabBar }          from "components/tab_bar.slint";
+import { TableView }       from "components/table_view.slint";
 import { TestResultDialog }    from "components/dialogs/test_result_dialog.slint";
 import { AddConnectionDialog } from "components/dialogs/add_connection_dialog.slint";
 import { AllRowsDialog }       from "components/dialogs/all_rows_dialog.slint";
@@ -208,6 +210,29 @@ export global UiState {
     callback dismiss-test-popup();
     /// "No" in the add-without-test confirm popup.
     callback dismiss-add-confirm();
+
+    // ── Tab management ────────────────────────────────────────────────────────
+    in-out property <[TabEntry]> tabs:               [];
+    in-out property <int>        active-tab-index:   0;
+    /// true = active tab is a SQL Editor tab; false = Table View tab.
+    in-out property <bool>       active-tab-kind-sql: true;
+    callback new-tab();
+    callback close-tab(int);
+    callback switch-tab(int);
+
+    // ── Table View state (active table-view tab) ──────────────────────────────
+    in-out property <string>       tv-table-name:   "";
+    in-out property <int>          tv-sub-tab:      0;    // 0=Data 1=Structure 2=DDL
+    in-out property <bool>         tv-data-loading: false;
+    in-out property <string>       tv-data-error:   "";
+    in-out property <bool>         tv-ddl-loading:  false;
+    in-out property <string>       tv-ddl:          "";
+    in-out property <[ColumnData]> tv-columns:      [];
+    in-out property <int>          tv-page-size:    1000;
+    callback copy-tv-ddl();
+    callback refresh-tv-data();
+    callback fetch-tv-ddl();
+    callback change-tv-page-size(int);
 }
 
 export component AppWindow inherits Window {
@@ -229,7 +254,8 @@ export component AppWindow inherits Window {
 
     // ── Layout geometry helpers ───────────────────────────────────────────────
     property <length> menu-bar-height:   28px;
-    property <length> content-height:    root.height - 24px - menu-bar-height;  // excludes status bar and menu bar
+    property <length> tab-bar-height:    32px;
+    property <length> content-height:    root.height - 24px - menu-bar-height - tab-bar-height;
     property <length> sidebar-width:     220px;
     property <length> main-width:        root.width - sidebar-width;
     property <length> divider-thickness: 5px;
@@ -276,10 +302,26 @@ export component AppWindow inherits Window {
         if (root._result-active) { root.focused-pane = 2; }
     }
 
+    // When switching to a Table View tab, give it focus so keyboard shortcuts work.
+    property <bool> _tab-kind: UiState.active-tab-kind-sql;
+    changed _tab-kind => {
+        if (!UiState.active-tab-kind-sql) {
+            root.focused-pane = 1;
+            tv-inst.grab-focus();
+        }
+    }
+
+    // Sync focused-pane when the Table View gains focus by click.
+    property <bool> _tv-active: tv-inst.tv-focused;
+    changed _tv-active => {
+        if (root._tv-active) { root.focused-pane = 1; }
+    }
+
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
-    // Wraps all content so that capture-key-pressed fires whenever any descendant
-    // (e.g. the editor's TextInput) has keyboard focus.  focus-on-click: false
-    // prevents the FocusScope from stealing focus from its children on click.
+    // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
+    // of which inner FocusScope — editor, table-view, sidebar, result — has focus.
+    // capture-key-pressed on the root would only fire if the root FocusScope itself
+    // held focus, which never happens with focus-on-click: false and inner scopes.
     FocusScope {
         x: 0;
         y: 0;
@@ -287,7 +329,7 @@ export component AppWindow inherits Window {
         height: root.height;
         focus-on-click: false;
 
-        capture-key-pressed(event) => {
+        key-pressed(event) => {
             // Don't intercept while a modal overlay is open.
             if (UiState.show-connection-form
                     || UiState.show-db-manager
@@ -295,6 +337,64 @@ export component AppWindow inherits Window {
                     || UiState.show-add-confirm-popup
                     || UiState.show-all-rows-confirm) {
                 EventResult.reject
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "t") {
+                UiState.new-tab();
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "w") {
+                UiState.close-tab(UiState.active-tab-index);
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && event.text == Key.Tab) {
+                UiState.switch-tab(Math.mod(UiState.active-tab-index + 1, max(1, UiState.tabs.length)));
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && event.modifiers.shift
+                    && event.text == Key.Tab) {
+                UiState.switch-tab(Math.mod(
+                    UiState.active-tab-index + max(1, UiState.tabs.length) - 1,
+                    max(1, UiState.tabs.length)
+                ));
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt) {
+                if (event.text == "1" && UiState.tabs.length > 0) {
+                    UiState.switch-tab(0);
+                    EventResult.accept
+                } else if (event.text == "2" && UiState.tabs.length > 1) {
+                    UiState.switch-tab(1);
+                    EventResult.accept
+                } else if (event.text == "3" && UiState.tabs.length > 2) {
+                    UiState.switch-tab(2);
+                    EventResult.accept
+                } else if (event.text == "4" && UiState.tabs.length > 3) {
+                    UiState.switch-tab(3);
+                    EventResult.accept
+                } else if (event.text == "5" && UiState.tabs.length > 4) {
+                    UiState.switch-tab(4);
+                    EventResult.accept
+                } else if (event.text == "6" && UiState.tabs.length > 5) {
+                    UiState.switch-tab(5);
+                    EventResult.accept
+                } else if (event.text == "7" && UiState.tabs.length > 6) {
+                    UiState.switch-tab(6);
+                    EventResult.accept
+                } else if (event.text == "8" && UiState.tabs.length > 7) {
+                    UiState.switch-tab(7);
+                    EventResult.accept
+                } else if (event.text == "9") {
+                    UiState.switch-tab(UiState.tabs.length - 1);
+                    EventResult.accept
+                } else {
+                    EventResult.reject
+                }
             } else if (event.modifiers.alt
                     && !event.modifiers.shift
                     && !event.modifiers.control) {
@@ -350,12 +450,24 @@ export component AppWindow inherits Window {
             set-language(lang) => { UiState.set-language(lang); }
         }
 
+        // ── Tab bar (above the editor only) ──────────────────────────────────
+        TabBar {
+            x: sidebar-width;
+            y: menu-bar-height;
+            width:        main-width;
+            tabs:         UiState.tabs;
+            active-index: UiState.active-tab-index;
+            new-tab      => { UiState.new-tab(); }
+            close-tab(i) => { UiState.close-tab(i); }
+            switch-tab(i) => { UiState.switch-tab(i); }
+        }
+
         // ── Sidebar ───────────────────────────────────────────────────────────
         sidebar-inst := Sidebar {
             x: 0;
             y: menu-bar-height;
             width:  sidebar-width;
-            height: content-height;
+            height: content-height + tab-bar-height;
             tree:        UiState.sidebar-tree;
             is-loading:  UiState.sidebar-loading;
             toggle-node(id) => { UiState.toggle-sidebar-node(id); }
@@ -363,31 +475,19 @@ export component AppWindow inherits Window {
             add-connection => { UiState.open-connection-form(); }
         }
 
-        // ── Main content panel ────────────────────────────────────────────────
-        // Single container for all content right of the sidebar.
-        // Layout within the container:
-        //
-        //   x=0 .. gutter-col-width   : shared gutter column (spans full height)
-        //   x=gutter-col-width .. end : editor text area / divider / result table
-        //
-        // The gutter column renders line numbers by reading out-properties from
-        // editor-inst.  All three panels (editor, divider, result) start at the same
-        // x and share the same width, so they are always perfectly aligned.
+        // ── SQL Editor main content panel ─────────────────────────────────────
+        // Always instantiated so that named children (editor-inst, result-table-inst)
+        // remain accessible for focus tracking and grab-focus calls even when the
+        // active tab is a Table View.  Hidden via visible: when a Table View is active.
         Rectangle {
             x: sidebar-width;
-            y: menu-bar-height;
+            y: menu-bar-height + tab-bar-height;
             width:  main-width;
             height: content-height;
             clip: true;
+            visible: UiState.active-tab-kind-sql;
 
             // ── Shared gutter column ──────────────────────────────────────────
-            // Height is capped to the portion above the result panel when the panel
-            // is open.  The panel's opaque background already hides any gutter content
-            // below its top edge, but more importantly: gutter line-number colors
-            // depend on current-line (active-line highlight).  When the gutter's
-            // bounding box overlaps the result panel, every cursor-movement dirty mark
-            // causes Slint to repaint the result cells too.  Clipping the gutter to
-            // the area above the panel eliminates that dirty-region overlap.
             Rectangle {
                 x: 0;
                 y: 0;
@@ -412,13 +512,7 @@ export component AppWindow inherits Window {
                 }
             }
 
-            // ── SQL editor (text area only — gutter is the sibling above) ─────────
-            // Height is capped to the portion of the content area that is NOT covered
-            // by the result panel.  This is the key performance constraint: keeping
-            // the editor's bounds out of the result panel's screen region means Slint's
-            // dirty-region tracker never needs to repaint the result cells when cursor
-            // movement (current-line highlight, TextInput cursor blink, etc.) marks the
-            // editor dirty.  When the panel is closed the editor fills the full height.
+            // ── SQL editor (text area only — gutter is the sibling above) ─────
             editor-inst := Editor {
                 x: root.gutter-col-width;
                 y: 0;
@@ -447,12 +541,16 @@ export component AppWindow inherits Window {
                 completion-selected  <=> UiState.completion-selected;
                 editor-cursor-target <=> UiState.editor-cursor-target;
                 accept-completion(text, pos, offset, tname) => { UiState.accept-completion(text, pos, offset, tname); }
+                focus-sidebar => { root.focused-pane = 0; sidebar-inst.grab-focus(); }
+                focus-result  => {
+                    if (UiState.result-panel-open) {
+                        root.focused-pane = 2;
+                        result-table-inst.grab-focus();
+                    }
+                }
             }
 
             // ── Panel drag handle ─────────────────────────────────────────────
-            // Sits at the top boundary of the result panel.  Dragging grows/shrinks
-            // panel-height upward.  Rendered after the result panel so it is on
-            // top and receives pointer events without being clipped.
             if UiState.result-panel-open: Rectangle {
                 x: 0;
                 y: parent.height - root.panel-height;
@@ -474,9 +572,6 @@ export component AppWindow inherits Window {
             }
 
             // ── Result / error overlay panel ──────────────────────────────────
-            // Overlays the editor from the bottom (VSCode-style).
-            // Always instantiated (so result-table-inst is accessible from AppWindow
-            // scope for focus tracking and grab-focus); hidden via `visible:` when closed.
             Rectangle {
                 x: 0;
                 y: parent.height - root.panel-height;
@@ -572,8 +667,6 @@ export component AppWindow inherits Window {
                 }
 
                 // ── Cell-value preview strip ──────────────────────────────────
-                // Fixed-height strip at the bottom of the result panel; shows the
-                // full value of the last clicked cell with word-wrap and vertical scroll.
                 Rectangle {
                     x: 0;
                     y: root.panel-height - root.preview-strip-h;
@@ -627,12 +720,43 @@ export component AppWindow inherits Window {
             }
         }
 
+        // ── Table View (shown when active tab is a Table View tab) ────────────
+        // Always instantiated so tv-inst.grab-focus() and tv-inst.tv-focused are accessible.
+        tv-inst := TableView {
+            visible: !UiState.active-tab-kind-sql;
+            x: sidebar-width;
+            y: menu-bar-height + tab-bar-height;
+            width:  main-width;
+            height: content-height;
+            table-name:        UiState.tv-table-name;
+            sub-tab           <=> UiState.tv-sub-tab;
+            data-columns:      UiState.result-columns;
+            data-rows:         UiState.result-rows;
+            data-row-count:    UiState.result-row-count;
+            data-loading      <=> UiState.tv-data-loading;
+            data-error:        UiState.tv-data-error;
+            structure-columns: UiState.tv-columns;
+            ddl-text:          UiState.tv-ddl;
+            ddl-loading       <=> UiState.tv-ddl-loading;
+            page-size:         UiState.tv-page-size;
+            ddl-font-size-px:  UiState.font-size;
+            copy-ddl      => { UiState.copy-tv-ddl(); }
+            refresh-data  => { UiState.refresh-tv-data(); }
+            fetch-ddl     => { UiState.fetch-tv-ddl(); }
+            change-page-size(n) => { UiState.change-tv-page-size(n); }
+            copy-cell(v)  => { UiState.copy-result-cell(v); }
+            copy-row(i)   => { UiState.copy-result-row(i); }
+            copy-all-tsv  => { UiState.copy-result-tsv(); }
+            export-csv    => { UiState.export-csv(); }
+            export-json   => { UiState.export-json(); }
+        }
+
         // ── Completion popup overlay ──────────────────────────────────────────
-        // Lives at FocusScope level (not inside the clip:true main Rectangle) so
-        // it is never clipped even when the cursor is near the editor bottom.
-        if UiState.completion-visible && UiState.completion-items.length > 0: CompletionPopup {
+        // Only shown when the SQL editor is active (popup positions reference editor-inst).
+        if UiState.completion-visible && UiState.completion-items.length > 0
+                && UiState.active-tab-kind-sql: CompletionPopup {
             x: root.sidebar-width + root.gutter-col-width + editor-inst.popup-x;
-            y: menu-bar-height + editor-inst.popup-y;
+            y: menu-bar-height + tab-bar-height + editor-inst.popup-y;
             items: UiState.completion-items;
             selected-index <=> UiState.completion-selected;
         }
@@ -640,7 +764,7 @@ export component AppWindow inherits Window {
         // ── Status bar ────────────────────────────────────────────────────────
         StatusBar {
             x: 0;
-            y: menu-bar-height + content-height;
+            y: menu-bar-height + tab-bar-height + content-height;
             width:  root.width;
             height: 24px;
             connection-text: UiState.status-connection;
@@ -648,10 +772,6 @@ export component AppWindow inherits Window {
         }
 
         // ── Inner edge lines ──────────────────────────────────────────────────
-        // Subtle 1px vertical accents on the left and right sides of the client area.
-        // Rendered before focus borders so the focus border draws on top and remains
-        // fully visible when it aligns with a window edge.
-        // Dark mode: surface0 (#313244), light mode: surface0 (#ccd0da).
         Rectangle {
             x: 0; y: 0;
             width: 1px; height: root.height;
@@ -664,14 +784,11 @@ export component AppWindow inherits Window {
         }
 
         // ── Pane focus border indicators ──────────────────────────────────────
-        // Rendered after the inner edge lines so focus borders always appear on top
-        // and are not obscured at the window edges.
-        // Rendered before modal overlays so modals cover the borders.
 
         // Sidebar focus border
         if root.focused-pane == 0: Rectangle {
             x: 0;
-            y: menu-bar-height;
+            y: menu-bar-height + tab-bar-height;
             width:  sidebar-width;
             height: content-height;
             border-width: 1px;
@@ -682,7 +799,7 @@ export component AppWindow inherits Window {
         // Editor / main-content pane focus border
         if root.focused-pane == 1: Rectangle {
             x: sidebar-width;
-            y: menu-bar-height;
+            y: menu-bar-height + tab-bar-height;
             width:  main-width;
             height: content-height;
             border-width: 1px;
@@ -693,7 +810,7 @@ export component AppWindow inherits Window {
         // Result-table pane focus border
         if root.focused-pane == 2 && UiState.result-panel-open: Rectangle {
             x: sidebar-width;
-            y: menu-bar-height + content-height - panel-height;
+            y: menu-bar-height + tab-bar-height + content-height - panel-height;
             width:  main-width;
             height: panel-height;
             border-width: 1px;
@@ -702,7 +819,6 @@ export component AppWindow inherits Window {
         }
 
         // ── Connection form modal overlay ─────────────────────────────────────
-        // Rendered last so it appears above everything else.
         if UiState.show-connection-form: Rectangle {
             x: 0;
             y: 0;
@@ -774,8 +890,6 @@ export component AppWindow inherits Window {
                 UiState.edit-connection(id);
             }
             add-connection => {
-                // Close the DB manager first, then open the connection form.
-                // The flag tells the form to reopen the DB manager when it closes.
                 UiState.show-db-manager = false;
                 UiState.reopen-db-manager-on-form-close = true;
                 UiState.open-connection-form();

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -86,6 +86,10 @@ export component Editor inherits Rectangle {
     /// Fired when the user presses Ctrl+Shift+F to reformat the SQL.
     callback format-sql();
 
+    // Pane navigation initiated from inside the editor.
+    callback focus-sidebar();
+    callback focus-result();
+
     // ── Out properties consumed by the external gutter in app.slint ──────────
     out property <length> gutter-scroll-y:  editor-scroll.viewport-y;
     out property <length> gutter-line-h:    root.line-h;
@@ -408,16 +412,13 @@ export component Editor inherits Rectangle {
                         }
                         root.completion-visible = false;
                         EventResult.accept
-                    } else if (event.text == Key.Tab) {
-                        if (root.completion-selected < root.completion-items.length - 1) {
-                            root.completion-selected += 1;
-                        } else {
-                            root.completion-selected = 0;
-                        }
-                        EventResult.accept
                     } else if (event.text == Key.Escape) {
                         root.completion-visible = false;
                         EventResult.accept
+                    } else if (event.text == Key.Tab && event.modifiers.control) {
+                        // Close popup; let event bubble to root key-pressed for tab switching.
+                        root.completion-visible = false;
+                        EventResult.reject
                     } else {
                         // Close popup immediately on characters that end a SQL token
                         // (statement terminator, space, comma, parentheses).  This
@@ -518,6 +519,12 @@ export component Editor inherits Rectangle {
                         && !event.modifiers.alt) {
                     root.format-sql();
                     EventResult.accept
+                } else if (event.modifiers.alt
+                        && !event.modifiers.control
+                        && !event.modifiers.shift) {
+                    if (event.text == Key.LeftArrow) { root.focus-sidebar(); EventResult.accept }
+                    else if (event.text == Key.DownArrow) { root.focus-result(); EventResult.accept }
+                    else { EventResult.reject }
                 } else {
                     EventResult.reject
                 }
@@ -561,6 +568,16 @@ export component Editor inherits Rectangle {
                 selection-foreground-color: Colors.text;
                 font-family: root.font-family;
                 font-size:   root.font-size-px * 1px;
+
+                // TextInput consumes all key events by default, preventing bubbling.
+                // Reject Ctrl+Tab here so it reaches the root FocusScope key-pressed.
+                key-pressed(event) => {
+                    if (event.modifiers.control && event.text == Key.Tab) {
+                        EventResult.reject
+                    } else {
+                        EventResult.accept
+                    }
+                }
 
                 // Secondary path to clear hold-flags when a key is released.
                 // capture-key-released (on the FocusScope) is the primary path,

--- a/app/src/ui/components/tab_bar.slint
+++ b/app/src/ui/components/tab_bar.slint
@@ -1,0 +1,101 @@
+import { TabEntry } from "../globals.slint";
+import { Colors, Typography } from "../theme.slint";
+
+export component TabBar inherits Rectangle {
+    in property <[TabEntry]> tabs;
+    in property <int>        active-index;
+    callback new-tab();
+    callback close-tab(int);
+    callback switch-tab(int);
+
+    height: 32px;
+    background: Colors.surface0;
+
+    HorizontalLayout {
+        spacing: 0;
+
+        tab-flickable := Flickable {
+            horizontal-stretch: 1;
+            height: parent.height;
+            viewport-width: max(tab-row.preferred-width, self.width);
+
+            tab-row := HorizontalLayout {
+                spacing: 0;
+
+                for tab[i] in root.tabs : Rectangle {
+                    width: min(max(tab-text.preferred-width + 40px, 80px), 180px);
+                    height: 32px;
+                    background: i == root.active-index ? Colors.base : transparent;
+
+                    ta-tab := TouchArea {
+                        clicked => { root.switch-tab(i); }
+                    }
+
+                    HorizontalLayout {
+                        x: 0;
+                        y: (parent.height - 24px) / 2;
+                        width: parent.width;
+                        height: 24px;
+                        padding-left: 10px;
+                        padding-right: 4px;
+                        spacing: 6px;
+
+                        tab-text := Text {
+                            text: tab.title;
+                            width: min(self.preferred-width, 140px);
+                            color: i == root.active-index ? Colors.text : Colors.subtext1;
+                            font-size: Typography.size-lg;
+                            vertical-alignment: center;
+                            overflow: elide;
+                        }
+
+                        Rectangle {
+                            width: 24px;
+                            height: 24px;
+                            border-radius: 4px;
+                            background: close-ta.has-hover ? Colors.surface1 : transparent;
+
+                            Text {
+                                text: "×";
+                                color: close-ta.has-hover ? Colors.text : Colors.subtext1;
+                                font-size: Typography.size-2xl;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                            }
+
+                            close-ta := TouchArea {
+                                clicked => { root.close-tab(i); }
+                            }
+                        }
+                    }
+
+                    if i == root.active-index : Rectangle {
+                        x: 0;
+                        y: parent.height - 2px;
+                        width: parent.width;
+                        height: 2px;
+                        background: Colors.blue;
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            width: 32px;
+            height: 32px;
+            background: new-ta.has-hover ? Colors.surface1 : transparent;
+
+            Text {
+                text: "+";
+                color: Colors.subtext1;
+                font-size: Typography.size-xl;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            new-ta := TouchArea {
+                clicked => { root.new-tab(); }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/table_view.slint
+++ b/app/src/ui/components/table_view.slint
@@ -1,0 +1,256 @@
+import { Colors, Typography } from "../theme.slint";
+import { ColumnData, RowData } from "../globals.slint";
+import { ResultTable } from "result_table.slint";
+
+export component TableView inherits Rectangle {
+    in property <string>       table-name;
+    in-out property <int>      sub-tab: 0;       // 0=Data  1=Structure  2=DDL
+    // Data sub-tab
+    in property <[string]>     data-columns;
+    in property <[RowData]>    data-rows;
+    in property <int>          data-row-count;
+    in-out property <bool>     data-loading;
+    in property <string>       data-error;
+    // Structure sub-tab
+    in property <[ColumnData]> structure-columns;
+    // DDL sub-tab
+    in property <string>       ddl-text;
+    in-out property <bool>     ddl-loading;
+    in property <int>          page-size: 1000;
+    in property <int>          ddl-font-size-px: 14;
+    // Callbacks
+    callback refresh-data();
+    callback fetch-ddl();
+    callback copy-ddl();
+    callback change-page-size(int);
+    // ResultTable pass-through callbacks
+    callback copy-cell(string);
+    callback copy-row(int);
+    callback copy-all-tsv();
+    callback export-csv();
+    callback export-json();
+    out property <bool> tv-focused: tv-focus.has-focus;
+    public function grab-focus() { tv-focus.focus(); }
+
+    background: Colors.base;
+
+    tv-focus := FocusScope {
+        x: 0; y: 0; width: parent.width; height: parent.height;
+        focus-on-click: true;
+
+        capture-key-pressed(event) => {
+            if (event.text == "[" && !event.modifiers.control && !event.modifiers.alt) {
+                if (root.sub-tab > 0) { root.sub-tab -= 1; }
+                EventResult.accept
+            } else if (event.text == "]" && !event.modifiers.control && !event.modifiers.alt) {
+                if (root.sub-tab < 2) {
+                    root.sub-tab += 1;
+                    if (root.sub-tab == 2) { root.fetch-ddl(); }
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+    // ── sub-tab bar ───────────────────────────────────────────────────────────
+    Rectangle {
+        x: 0; y: 0;
+        width: parent.width;
+        height: 32px;
+        background: Colors.surface0;
+
+        HorizontalLayout {
+            spacing: 0;
+
+            for label[i] in [@tr("Data"), @tr("Columns"), @tr("DDL")] : Rectangle {
+                width: 80px;
+                height: 32px;
+                background: i == root.sub-tab ? Colors.base : transparent;
+
+                Text {
+                    text: label;
+                    color: i == root.sub-tab ? Colors.text : Colors.subtext1;
+                    font-size: Typography.size-base;
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+
+                TouchArea {
+                    clicked => {
+                        root.sub-tab = i;
+                        if (i == 2) { root.fetch-ddl(); }
+                    }
+                }
+
+                if i == root.sub-tab : Rectangle {
+                    x: 0;
+                    y: 28px;
+                    width: parent.width;
+                    height: 2px;
+                    background: Colors.blue;
+                }
+            }
+        }
+    }
+
+    // ── content area ──────────────────────────────────────────────────────────
+    Rectangle {
+        x: 0;
+        y: 32px;
+        width: parent.width;
+        height: parent.height - 32px;
+
+        // Data sub-tab
+        if root.sub-tab == 0 : ResultTable {
+            x: 0; y: 0;
+            width: parent.width;
+            height: parent.height;
+            columns: root.data-columns;
+            rows: root.data-rows;
+            row-count: root.data-row-count;
+            total-rows: root.data-row-count;
+            is-loading: root.data-loading;
+            error-message: root.data-error;
+            page-size: root.page-size;
+            change-page-size(n) => { root.change-page-size(n); }
+            copy-cell(v) => { root.copy-cell(v); }
+            copy-row(i)  => { root.copy-row(i); }
+            copy-all-tsv => { root.copy-all-tsv(); }
+            export-csv   => { root.export-csv(); }
+            export-json  => { root.export-json(); }
+        }
+
+        // Structure sub-tab
+        if root.sub-tab == 1 : Flickable {
+            x: 0; y: 0;
+            width: parent.width;
+            height: parent.height;
+            viewport-height: max(col-list.preferred-height, self.height);
+
+            col-list := VerticalLayout {
+                Rectangle {
+                    height: 28px;
+                    background: Colors.surface0;
+
+                    HorizontalLayout {
+                        padding-left: 12px;
+                        spacing: 0;
+
+                        Text {
+                            text: @tr("Column");
+                            width: 200px;
+                            color: Colors.subtext1;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                        }
+
+                        Text {
+                            text: @tr("Type");
+                            width: 160px;
+                            color: Colors.subtext1;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                        }
+
+                        Text {
+                            text: @tr("Nullable");
+                            color: Colors.subtext1;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                for col[i] in root.structure-columns : Rectangle {
+                    height: 28px;
+                    background: Math.mod(i, 2) == 0 ? Colors.base : Colors.mantle;
+
+                    HorizontalLayout {
+                        padding-left: 12px;
+                        spacing: 0;
+
+                        Text {
+                            text: col.name;
+                            width: 200px;
+                            color: Colors.text;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                            overflow: elide;
+                        }
+
+                        Text {
+                            text: col.data-type;
+                            width: 160px;
+                            color: Colors.subtext0;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                            overflow: elide;
+                        }
+
+                        Text {
+                            text: col.nullable ? @tr("YES") : @tr("NO");
+                            color: col.nullable ? Colors.green : Colors.subtext1;
+                            font-size: Typography.size-base;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+
+        // DDL sub-tab
+        if root.sub-tab == 2 : Rectangle {
+            x: 0; y: 0;
+            width: parent.width;
+            height: parent.height;
+            background: Colors.base;
+
+            if root.ddl-loading : Text {
+                text: @tr("Loading\u{2026}");
+                color: Colors.surface2;
+                font-size: Typography.size-base;
+                x: 12px; y: 12px;
+            }
+
+            if !root.ddl-loading && root.ddl-text != "" : Flickable {
+                x: 0; y: 0;
+                width: parent.width;
+                height: parent.height - 40px;
+                viewport-height: max(ddl-text-el.preferred-height + 16px, self.height);
+
+                ddl-text-el := Text {
+                    x: 12px; y: 8px;
+                    width: parent.width - 24px;
+                    text: root.ddl-text;
+                    color: Colors.text;
+                    font-family: "JetBrains Mono";
+                    font-size: root.ddl-font-size-px * 1px;
+                    wrap: word-wrap;
+                }
+            }
+
+            if !root.ddl-loading : Rectangle {
+                x: parent.width - 100px;
+                y: parent.height - 36px;
+                width: 88px;
+                height: 28px;
+                border-radius: 4px;
+                background: copy-ta.has-hover ? Colors.surface1 : Colors.surface0;
+
+                Text {
+                    text: @tr("Copy DDL");
+                    color: Colors.text;
+                    font-size: Typography.size-sm;
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+
+                copy-ta := TouchArea {
+                    clicked => { root.copy-ddl(); }
+                }
+            }
+        }
+    }
+    } // tv-focus FocusScope
+}

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -38,3 +38,15 @@ export struct CompletionRow {
     cursor-offset: int,
     table-name: string,
 }
+
+export struct TabEntry {
+    id: string,
+    title: string,
+    kind: string,   // "sql-editor" | "table-view"
+}
+
+export struct ColumnData {
+    name: string,
+    data-type: string,
+    nullable: bool,
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+mod tabs_state;
+
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -224,6 +227,33 @@ fn push_string_category(
 }
 
 // ---------------------------------------------------------------------------
+// Tab helpers
+// ---------------------------------------------------------------------------
+
+fn tabs_to_slint(tabs: &[tabs_state::TabEntry]) -> Vec<crate::TabEntry> {
+    tabs.iter()
+        .map(|t| crate::TabEntry {
+            id: t.id.clone().into(),
+            title: t.title.clone().into(),
+            kind: match &t.kind {
+                tabs_state::TabKind::SqlEditor { .. } => "sql-editor".into(),
+                tabs_state::TabKind::TableView { .. } => "table-view".into(),
+            },
+        })
+        .collect()
+}
+
+fn columns_to_slint(cols: &[wf_db::models::ColumnInfo]) -> Vec<crate::ColumnData> {
+    cols.iter()
+        .map(|c| crate::ColumnData {
+            name: c.name.clone().into(),
+            data_type: c.data_type.clone().into(),
+            nullable: c.nullable,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
 // UI
 // ---------------------------------------------------------------------------
 
@@ -247,12 +277,33 @@ impl UI {
         // handler on QueryFinished, read by the filter callbacks on the UI thread.
         let original_data: SharedOriginalData = Arc::new(Mutex::new(None));
 
+        // Restore or create tab state. Track whether tabs were loaded from file
+        // so we can fall back to last_query.sql on first launch.
+        let tabs_from_session;
+        let tabs_state: Rc<RefCell<tabs_state::TabsState>> = {
+            let session = SessionManager::new();
+            match session.restore_tabs() {
+                Ok(Some((active_index, entries))) => {
+                    tabs_from_session = true;
+                    Rc::new(RefCell::new(tabs_state::TabsState::from_session(
+                        active_index,
+                        entries,
+                    )))
+                }
+                _ => {
+                    tabs_from_session = false;
+                    Rc::new(RefCell::new(tabs_state::TabsState::new()))
+                }
+            }
+        };
+
         Self::register_sidebar_callbacks(
             &window,
             state.clone(),
             tx_cmd.clone(),
             Arc::clone(&sidebar_state),
             enc_key,
+            Rc::clone(&tabs_state),
         );
         Self::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
         Self::register_editor_callbacks(&window, state.clone(), tx_cmd.clone());
@@ -262,7 +313,13 @@ impl UI {
         Self::register_export_callbacks(&window, Arc::clone(&original_data));
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
         Self::register_menu_callbacks(&window, tx_cmd.clone());
-        Self::register_close_handler(&window);
+        Self::register_close_handler(&window, Rc::clone(&tabs_state));
+        Self::register_tab_callbacks(
+            &window,
+            tx_cmd.clone(),
+            Rc::clone(&tabs_state),
+            Arc::clone(&sidebar_state),
+        );
         // Set initial page size and theme on the Slint window from shared state.
         let ui_global = window.global::<crate::UiState>();
         ui_global.set_page_size(state.ui.page_size() as i32);
@@ -278,9 +335,28 @@ impl UI {
         let _ = slint::select_bundled_translation(lang);
         rust_i18n::set_locale(lang);
         ui_global.set_language(lang.clone().into());
-        // Restore last editor query from previous session (last_query.sql).
-        if let Ok(Some(query)) = SessionManager::new().restore_query_file() {
-            ui_global.set_editor_text(query.into());
+        // Initialise tab bar from the restored (or freshly created) tab state.
+        {
+            let ts = tabs_state.borrow();
+            let slint_tabs = tabs_to_slint(&ts.tabs);
+            ui_global.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
+            ui_global.set_active_tab_index(ts.active_index as i32);
+            match ts.active_tab().map(|t| t.kind.clone()) {
+                Some(tabs_state::TabKind::SqlEditor { query_text }) => {
+                    ui_global.set_editor_text(query_text.into());
+                    ui_global.set_active_tab_kind_sql(true);
+                }
+                Some(tabs_state::TabKind::TableView { table_name, .. }) => {
+                    ui_global.set_tv_table_name(table_name.into());
+                    ui_global.set_active_tab_kind_sql(false);
+                }
+                None => {}
+            }
+        }
+        // Fall back to last_query.sql on first launch (no tabs.toml yet).
+        if !tabs_from_session && let Ok(Some(query)) = SessionManager::new().restore_query_file() {
+            ui_global.set_editor_text(query.clone().into());
+            tabs_state.borrow_mut().save_current_text(&query);
         }
 
         Self::register_result_callbacks(
@@ -358,6 +434,18 @@ impl UI {
                     }
                     Event::StateChanged(StateEvent::ThemeChanged(t)) => {
                         Self::handle_theme_changed(t, window_weak.clone())
+                    }
+                    Event::DdlLoaded { tab_id, ddl } => {
+                        Self::handle_ddl_loaded(tab_id, ddl, window_weak.clone())
+                    }
+                    Event::DdlFetchFailed { tab_id, msg } => {
+                        Self::handle_ddl_fetch_failed(tab_id, msg, window_weak.clone())
+                    }
+                    Event::TableDataLoaded { tab_id, result } => {
+                        Self::handle_table_data_loaded(tab_id, result, window_weak.clone())
+                    }
+                    Event::TableDataFailed { tab_id, msg } => {
+                        Self::handle_table_data_failed(tab_id, msg, window_weak.clone())
                     }
                     _ => {}
                 }
@@ -657,6 +745,64 @@ impl UI {
         });
     }
 
+    fn handle_ddl_loaded(_tab_id: String, ddl: String, ww: slint::Weak<crate::AppWindow>) {
+        // clone required: invoke_from_event_loop closure must be 'static
+        let _ = slint::invoke_from_event_loop(move || {
+            with_ui(&ww, move |ui| {
+                ui.set_tv_ddl(ddl.into());
+                ui.set_tv_ddl_loading(false);
+            });
+        });
+    }
+
+    fn handle_ddl_fetch_failed(_tab_id: String, msg: String, ww: slint::Weak<crate::AppWindow>) {
+        // clone required: invoke_from_event_loop closure must be 'static
+        let _ = slint::invoke_from_event_loop(move || {
+            with_ui(&ww, move |ui| {
+                ui.set_tv_ddl(format!("Error: {}", msg).into());
+                ui.set_tv_ddl_loading(false);
+            });
+        });
+    }
+
+    fn handle_table_data_loaded(
+        _tab_id: String,
+        result: QueryResult,
+        ww: slint::Weak<crate::AppWindow>,
+    ) {
+        let col_count = result.columns.len();
+        let columns: Vec<slint::SharedString> =
+            result.columns.iter().map(|c| c.clone().into()).collect();
+        let raw_rows: Vec<Vec<Option<String>>> = result.rows.iter().map(|r| r.to_vec()).collect();
+        let row_count = result.row_count as i32;
+        // clone required: invoke_from_event_loop closure must be 'static
+        let _ = slint::invoke_from_event_loop(move || {
+            with_ui(&ww, move |ui| {
+                ui.set_tv_data_loading(false);
+                ui.set_tv_data_error("".into());
+                let col_model = Rc::new(slint::VecModel::from(columns));
+                ui.set_result_columns(col_model.into());
+                let rows: Vec<crate::RowData> = raw_rows.into_iter().map(rows_to_ui).collect();
+                ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                ui.set_result_row_count(row_count);
+                let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
+                let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;
+                ui.set_result_col_widths(Rc::new(slint::VecModel::from(widths)).into());
+                ui.set_result_total_col_width(total_w);
+            });
+        });
+    }
+
+    fn handle_table_data_failed(_tab_id: String, msg: String, ww: slint::Weak<crate::AppWindow>) {
+        // clone required: invoke_from_event_loop closure must be 'static
+        let _ = slint::invoke_from_event_loop(move || {
+            with_ui(&ww, move |ui| {
+                ui.set_tv_data_loading(false);
+                ui.set_tv_data_error(msg.into());
+            });
+        });
+    }
+
     // ── Theme callback ────────────────────────────────────────────────────────
 
     fn register_theme_callback(
@@ -683,19 +829,339 @@ impl UI {
 
     // ── Window lifecycle ──────────────────────────────────────────────────────
 
-    fn register_close_handler(window: &crate::AppWindow) {
+    fn register_close_handler(
+        window: &crate::AppWindow,
+        tabs_state: Rc<RefCell<tabs_state::TabsState>>,
+    ) {
         let window_weak = window.as_weak(); // clone required: on_close_requested closure
         window.window().on_close_requested(move || {
             let text = window_weak
                 .upgrade()
                 .map(|w| w.global::<crate::UiState>().get_editor_text().to_string())
                 .unwrap_or_default();
+            // Flush the active editor text into the tab before persisting.
+            tabs_state.borrow_mut().save_current_text(&text);
             let sm = SessionManager::new();
+            {
+                let ts = tabs_state.borrow();
+                let (active_sql_idx, entries) = ts.session_entries();
+                if let Err(e) = sm.save_tabs(active_sql_idx, &entries) {
+                    tracing::warn!(error = %e, "failed to save tabs.toml on close");
+                }
+            }
+            // Keep last_query.sql in sync for backwards compatibility.
             if let Err(e) = sm.save_query_file(&text) {
                 tracing::warn!(error = %e, "failed to save last_query.sql on close");
             }
             slint::CloseRequestResponse::HideWindow
         });
+    }
+
+    // ── Tab callbacks ─────────────────────────────────────────────────────────
+
+    fn register_tab_callbacks(
+        window: &crate::AppWindow,
+        tx_cmd: mpsc::Sender<Command>,
+        tabs_state: Rc<RefCell<tabs_state::TabsState>>,
+        sidebar_state: Arc<Mutex<SidebarUiState>>,
+    ) {
+        let ui = window.global::<crate::UiState>();
+
+        // on_new_tab: save current editor text, add a SQL Editor tab, switch to it.
+        {
+            let window_weak = window.as_weak();
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            ui.on_new_tab(move || {
+                let current_text = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_editor_text().to_string())
+                    .unwrap_or_default();
+                let current_sub_tab = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_tv_sub_tab() as usize)
+                    .unwrap_or(0);
+                let (slint_tabs, active_idx) = {
+                    let mut ts = tabs_state.borrow_mut();
+                    ts.save_current_text(&current_text);
+                    ts.save_tv_sub_tab(current_sub_tab);
+                    ts.add_sql_editor();
+                    (tabs_to_slint(&ts.tabs), ts.active_index as i32)
+                };
+                with_ui(&window_weak, |ui| {
+                    ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
+                    ui.set_active_tab_index(active_idx);
+                    ui.set_active_tab_kind_sql(true);
+                    ui.set_editor_text("".into());
+                });
+            });
+        }
+
+        // on_switch_tab: save current text, switch active tab, restore tab content.
+        {
+            let window_weak = window.as_weak();
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: callback closure needs owned sidebar_state
+            ui.on_switch_tab(move |i| {
+                let i = i as usize;
+                let current_text = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_editor_text().to_string())
+                    .unwrap_or_default();
+                let current_sub_tab = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_tv_sub_tab() as usize)
+                    .unwrap_or(0);
+                let (slint_tabs, active_idx, kind_sql, editor_text, tv_name, tv_cols, tv_sub_tab) = {
+                    let mut ts = tabs_state.borrow_mut();
+                    ts.save_current_text(&current_text);
+                    ts.save_tv_sub_tab(current_sub_tab);
+                    ts.set_active(i);
+                    let slint_tabs = tabs_to_slint(&ts.tabs);
+                    let active_idx = ts.active_index as i32;
+                    match ts.active_tab().map(|t| t.kind.clone()) {
+                        Some(tabs_state::TabKind::SqlEditor { query_text }) => (
+                            slint_tabs,
+                            active_idx,
+                            true,
+                            query_text,
+                            String::new(),
+                            vec![],
+                            0usize,
+                        ),
+                        Some(tabs_state::TabKind::TableView {
+                            conn_id,
+                            table_name,
+                            sub_tab,
+                        }) => {
+                            let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            let cols = sb
+                                .metadata
+                                .get(&conn_id)
+                                .and_then(|meta| {
+                                    meta.tables
+                                        .iter()
+                                        .chain(meta.views.iter())
+                                        .find(|t| t.name == table_name)
+                                        .map(|ti| columns_to_slint(&ti.columns))
+                                })
+                                .unwrap_or_default();
+                            (
+                                slint_tabs,
+                                active_idx,
+                                false,
+                                String::new(),
+                                table_name,
+                                cols,
+                                sub_tab,
+                            )
+                        }
+                        None => (
+                            slint_tabs,
+                            active_idx,
+                            true,
+                            String::new(),
+                            String::new(),
+                            vec![],
+                            0usize,
+                        ),
+                    }
+                };
+                with_ui(&window_weak, |ui| {
+                    ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
+                    ui.set_active_tab_index(active_idx);
+                    ui.set_active_tab_kind_sql(kind_sql);
+                    if kind_sql {
+                        ui.set_editor_text(editor_text.into());
+                    } else {
+                        ui.set_tv_table_name(tv_name.into());
+                        ui.set_tv_columns(Rc::new(slint::VecModel::from(tv_cols)).into());
+                        ui.set_tv_sub_tab(tv_sub_tab as i32);
+                    }
+                });
+            });
+        }
+
+        // on_close_tab: close the given tab; prevents closing the last SQL Editor tab.
+        {
+            let window_weak = window.as_weak();
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            ui.on_close_tab(move |i| {
+                let i = i as usize;
+                let current_text = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_editor_text().to_string())
+                    .unwrap_or_default();
+                let mut ts = tabs_state.borrow_mut();
+                if ts.active_index != i {
+                    ts.save_current_text(&current_text);
+                }
+                if !ts.close(i) {
+                    return; // can't close the last SQL Editor tab
+                }
+                let slint_tabs = tabs_to_slint(&ts.tabs);
+                let active_idx = ts.active_index as i32;
+                let (kind_sql, editor_text) = match ts.active_tab().map(|t| t.kind.clone()) {
+                    Some(tabs_state::TabKind::SqlEditor { query_text }) => (true, query_text),
+                    _ => (false, String::new()),
+                };
+                drop(ts);
+                with_ui(&window_weak, |ui| {
+                    ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
+                    ui.set_active_tab_index(active_idx);
+                    ui.set_active_tab_kind_sql(kind_sql);
+                    if kind_sql {
+                        ui.set_editor_text(editor_text.into());
+                    }
+                });
+            });
+        }
+
+        // on_copy_tv_ddl: write the DDL text to the system clipboard.
+        {
+            let window_weak = window.as_weak();
+            ui.on_copy_tv_ddl(move || {
+                let ddl = window_weak
+                    .upgrade()
+                    .map(|w| w.global::<crate::UiState>().get_tv_ddl().to_string())
+                    .unwrap_or_default();
+                if let Ok(mut clip) = arboard::Clipboard::new() {
+                    let _ = clip.set_text(ddl);
+                }
+            });
+        }
+
+        // on_refresh_tv_data: re-fetch the table data for the active Table View tab.
+        {
+            let window_weak = window.as_weak();
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            ui.on_refresh_tv_data(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let tv_table_name = ui.get_tv_table_name().to_string();
+                let conn_id = ui.get_active_connection_id().to_string();
+                let page_size = ui.get_tv_page_size() as usize;
+                if conn_id.is_empty() || tv_table_name.is_empty() {
+                    return;
+                }
+                let tab_id = {
+                    let ts = tabs_state.borrow();
+                    ts.find_table_view(&conn_id, &tv_table_name)
+                        .and_then(|idx| ts.tabs.get(idx))
+                        .map(|t| t.id.clone())
+                        .unwrap_or_default()
+                };
+                if tab_id.is_empty() {
+                    return;
+                }
+                with_ui(&window_weak, |ui| ui.set_tv_data_loading(true));
+                send_cmd(
+                    &tx_cmd,
+                    Command::FetchTableData {
+                        tab_id,
+                        conn_id,
+                        table_name: tv_table_name,
+                        page_size,
+                    },
+                );
+            });
+        }
+
+        // on_fetch_tv_ddl: fetch the DDL statement for the active Table View tab.
+        {
+            let window_weak = window.as_weak();
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: callback closure needs owned sidebar_state
+            ui.on_fetch_tv_ddl(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let tv_table_name = ui.get_tv_table_name().to_string();
+                let conn_id = ui.get_active_connection_id().to_string();
+                if conn_id.is_empty() || tv_table_name.is_empty() {
+                    return;
+                }
+                let tab_id = {
+                    let ts = tabs_state.borrow();
+                    ts.find_table_view(&conn_id, &tv_table_name)
+                        .and_then(|idx| ts.tabs.get(idx))
+                        .map(|t| t.id.clone())
+                        .unwrap_or_default()
+                };
+                if tab_id.is_empty() {
+                    return;
+                }
+                let kind = {
+                    let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    if let Some(meta) = sb.metadata.get(&conn_id) {
+                        if meta.views.iter().any(|v| v.name == tv_table_name) {
+                            "view".to_string()
+                        } else {
+                            "table".to_string()
+                        }
+                    } else {
+                        "table".to_string()
+                    }
+                };
+                with_ui(&window_weak, |ui| {
+                    ui.set_tv_ddl("".into());
+                    ui.set_tv_ddl_loading(true);
+                });
+                send_cmd(
+                    &tx_cmd,
+                    Command::FetchDdl {
+                        tab_id,
+                        conn_id,
+                        name: tv_table_name,
+                        kind,
+                    },
+                );
+            });
+        }
+
+        // on_change_tv_page_size: re-fetch table data with a new row limit.
+        {
+            let window_weak = window.as_weak();
+            let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            ui.on_change_tv_page_size(move |n| {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let page_size = n as usize;
+                ui.set_tv_page_size(n);
+                let tv_table_name = ui.get_tv_table_name().to_string();
+                let conn_id = ui.get_active_connection_id().to_string();
+                if conn_id.is_empty() || tv_table_name.is_empty() {
+                    return;
+                }
+                let tab_id = {
+                    let ts = tabs_state.borrow();
+                    ts.find_table_view(&conn_id, &tv_table_name)
+                        .and_then(|idx| ts.tabs.get(idx))
+                        .map(|t| t.id.clone())
+                        .unwrap_or_default()
+                };
+                if tab_id.is_empty() {
+                    return;
+                }
+                with_ui(&window_weak, |ui| ui.set_tv_data_loading(true));
+                send_cmd(
+                    &tx_cmd,
+                    Command::FetchTableData {
+                        tab_id,
+                        conn_id,
+                        table_name: tv_table_name,
+                        page_size,
+                    },
+                );
+            });
+        }
     }
 
     // ── Menu bar callbacks ────────────────────────────────────────────────────
@@ -725,6 +1191,7 @@ impl UI {
         tx_cmd: mpsc::Sender<Command>,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
         enc_key: [u8; 32],
+        tabs_state: Rc<RefCell<tabs_state::TabsState>>,
     ) {
         let ui_state = window.global::<crate::UiState>();
 
@@ -973,19 +1440,79 @@ impl UI {
             });
         }
 
-        // table-double-clicked: insert SELECT * FROM <name> into the editor
-        // and immediately execute it so the result appears without a manual
-        // Ctrl+Enter.  tx_cmd is cloned here because the closure is 'static.
+        // table-double-clicked: open a Table View tab for the clicked table/view.
+        // Saves the active editor text, opens or focuses the TV tab, then triggers
+        // a FetchTableData command if the tab is new.
         {
             let window_weak = window.as_weak();
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: callback closure needs owned sidebar_state
             ui_state.on_table_double_clicked(move |name| {
-                let sql = format!("SELECT * FROM {}", name);
+                let name = name.to_string();
+                let (conn_id, current_text, current_sub_tab) = {
+                    let Some(w) = window_weak.upgrade() else {
+                        return;
+                    };
+                    let ui = w.global::<crate::UiState>();
+                    (
+                        ui.get_active_connection_id().to_string(),
+                        ui.get_editor_text().to_string(),
+                        ui.get_tv_sub_tab() as usize,
+                    )
+                };
+                if conn_id.is_empty() {
+                    return;
+                }
+                let (tab_id, is_new, slint_tabs, active_idx, tv_sub_tab) = {
+                    let mut ts = tabs_state.borrow_mut();
+                    ts.save_current_text(&current_text);
+                    ts.save_tv_sub_tab(current_sub_tab);
+                    let (tab_id, _idx, is_new) = ts.open_table_view(&conn_id, &name);
+                    let tv_sub_tab = ts.active_tv_sub_tab();
+                    let slint_tabs = tabs_to_slint(&ts.tabs);
+                    let active_idx = ts.active_index as i32;
+                    (tab_id, is_new, slint_tabs, active_idx, tv_sub_tab)
+                };
+                let tv_cols = {
+                    let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    sb.metadata
+                        .get(&conn_id)
+                        .and_then(|meta| {
+                            meta.tables
+                                .iter()
+                                .chain(meta.views.iter())
+                                .find(|t| t.name == name)
+                                .map(|ti| columns_to_slint(&ti.columns))
+                        })
+                        .unwrap_or_default()
+                };
                 with_ui(&window_weak, |ui| {
-                    let current = ui.get_editor_text().to_string();
-                    ui.set_editor_text(append_editor_text(&current, &sql).into());
+                    ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
+                    ui.set_active_tab_index(active_idx);
+                    ui.set_active_tab_kind_sql(false);
+                    ui.set_tv_table_name(name.clone().into());
+                    ui.set_tv_sub_tab(tv_sub_tab as i32);
+                    if is_new {
+                        ui.set_tv_page_size(1000);
+                    }
+                    ui.set_tv_data_loading(is_new);
+                    ui.set_tv_data_error("".into());
+                    ui.set_tv_ddl("".into());
+                    ui.set_tv_ddl_loading(false);
+                    ui.set_tv_columns(Rc::new(slint::VecModel::from(tv_cols)).into());
                 });
-                send_cmd(&tx_cmd, Command::RunQuery(sql));
+                if is_new {
+                    send_cmd(
+                        &tx_cmd,
+                        Command::FetchTableData {
+                            tab_id,
+                            conn_id,
+                            table_name: name,
+                            page_size: 1000,
+                        },
+                    );
+                }
             });
         }
     }

--- a/app/src/ui/tabs_state.rs
+++ b/app/src/ui/tabs_state.rs
@@ -1,0 +1,217 @@
+use uuid::Uuid;
+
+use crate::app::session::TabSessionEntry;
+
+pub struct TabsState {
+    pub tabs: Vec<TabEntry>,
+    pub active_index: usize,
+    counter: usize,
+}
+
+#[derive(Clone)]
+pub struct TabEntry {
+    pub id: String,
+    pub title: String,
+    pub kind: TabKind,
+}
+
+#[derive(Clone)]
+pub enum TabKind {
+    SqlEditor {
+        query_text: String,
+    },
+    TableView {
+        conn_id: String,
+        table_name: String,
+        sub_tab: usize,
+    },
+}
+
+impl TabsState {
+    pub fn new() -> Self {
+        Self {
+            tabs: vec![TabEntry {
+                id: Uuid::new_v4().to_string(),
+                title: "Query 1".to_string(),
+                kind: TabKind::SqlEditor {
+                    query_text: String::new(),
+                },
+            }],
+            active_index: 0,
+            counter: 1,
+        }
+    }
+
+    /// Restore from persisted session entries (SqlEditor tabs only).
+    pub fn from_session(active_index: usize, entries: Vec<TabSessionEntry>) -> Self {
+        let counter = entries.len();
+        let tabs: Vec<TabEntry> = entries
+            .into_iter()
+            .map(|e| TabEntry {
+                id: e.id,
+                title: e.title,
+                kind: TabKind::SqlEditor {
+                    query_text: e.query_text,
+                },
+            })
+            .collect();
+        let tabs = if tabs.is_empty() {
+            vec![TabEntry {
+                id: Uuid::new_v4().to_string(),
+                title: "Query 1".to_string(),
+                kind: TabKind::SqlEditor {
+                    query_text: String::new(),
+                },
+            }]
+        } else {
+            tabs
+        };
+        let active_index = active_index.min(tabs.len() - 1);
+        Self {
+            tabs,
+            active_index,
+            counter,
+        }
+    }
+
+    /// Save the current editor text into the active SqlEditor tab.
+    pub fn save_current_text(&mut self, text: &str) {
+        if let Some(tab) = self.tabs.get_mut(self.active_index)
+            && let TabKind::SqlEditor { query_text } = &mut tab.kind
+        {
+            *query_text = text.to_string();
+        }
+    }
+
+    /// Add a new SQL Editor tab. Returns `(id, new_index)`.
+    pub fn add_sql_editor(&mut self) -> (String, usize) {
+        self.counter += 1;
+        let id = Uuid::new_v4().to_string();
+        let title = format!("Query {}", self.counter);
+        self.tabs.push(TabEntry {
+            id: id.clone(),
+            title,
+            kind: TabKind::SqlEditor {
+                query_text: String::new(),
+            },
+        });
+        let idx = self.tabs.len() - 1;
+        self.active_index = idx;
+        (id, idx)
+    }
+
+    /// Open or focus a Table View tab. Returns `(id, index, is_new)`.
+    pub fn open_table_view(&mut self, conn_id: &str, table_name: &str) -> (String, usize, bool) {
+        if let Some(idx) = self.find_table_view(conn_id, table_name) {
+            let id = self.tabs[idx].id.clone();
+            self.active_index = idx;
+            return (id, idx, false);
+        }
+        let id = Uuid::new_v4().to_string();
+        self.tabs.push(TabEntry {
+            id: id.clone(),
+            title: table_name.to_string(),
+            kind: TabKind::TableView {
+                conn_id: conn_id.to_string(),
+                table_name: table_name.to_string(),
+                sub_tab: 0,
+            },
+        });
+        let idx = self.tabs.len() - 1;
+        self.active_index = idx;
+        (id, idx, true)
+    }
+
+    pub fn find_table_view(&self, conn_id: &str, table_name: &str) -> Option<usize> {
+        self.tabs.iter().position(|t| {
+            matches!(&t.kind, TabKind::TableView { conn_id: c, table_name: n, .. } if c == conn_id && n == table_name)
+        })
+    }
+
+    /// Close tab at `index`. Returns `false` if the last SqlEditor tab would be closed.
+    pub fn close(&mut self, index: usize) -> bool {
+        if index >= self.tabs.len() {
+            return false;
+        }
+        let sql_count = self
+            .tabs
+            .iter()
+            .filter(|t| matches!(t.kind, TabKind::SqlEditor { .. }))
+            .count();
+        if matches!(self.tabs[index].kind, TabKind::SqlEditor { .. }) && sql_count <= 1 {
+            return false;
+        }
+        self.tabs.remove(index);
+        if self.active_index >= self.tabs.len() {
+            self.active_index = self.tabs.len().saturating_sub(1);
+        }
+        true
+    }
+
+    pub fn set_active(&mut self, index: usize) {
+        if index < self.tabs.len() {
+            self.active_index = index;
+        }
+    }
+
+    pub fn active_tab(&self) -> Option<&TabEntry> {
+        self.tabs.get(self.active_index)
+    }
+
+    /// Save the sub-tab index for the active TableView tab.
+    pub fn save_tv_sub_tab(&mut self, sub_tab: usize) {
+        if let Some(tab) = self.tabs.get_mut(self.active_index)
+            && let TabKind::TableView {
+                sub_tab: ref mut st,
+                ..
+            } = tab.kind
+        {
+            *st = sub_tab;
+        }
+    }
+
+    /// Return the sub-tab index stored for the active TableView tab.
+    pub fn active_tv_sub_tab(&self) -> usize {
+        if let Some(tab) = self.tabs.get(self.active_index)
+            && let TabKind::TableView { sub_tab, .. } = tab.kind
+        {
+            sub_tab
+        } else {
+            0
+        }
+    }
+
+    /// Extract session-persistable data (SqlEditor tabs only).
+    /// Returns `(active_sql_index, entries)`.
+    pub fn session_entries(&self) -> (usize, Vec<TabSessionEntry>) {
+        let sql_tabs: Vec<(usize, &TabEntry)> = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| matches!(t.kind, TabKind::SqlEditor { .. }))
+            .collect();
+
+        let active_sql_idx = sql_tabs
+            .iter()
+            .position(|(i, _)| *i == self.active_index)
+            .unwrap_or(0);
+
+        let entries = sql_tabs
+            .into_iter()
+            .map(|(_, t)| {
+                let qt = if let TabKind::SqlEditor { query_text } = &t.kind {
+                    query_text.clone()
+                } else {
+                    String::new()
+                };
+                TabSessionEntry {
+                    id: t.id.clone(),
+                    title: t.title.clone(),
+                    query_text: qt,
+                }
+            })
+            .collect();
+
+        (active_sql_idx, entries)
+    }
+}

--- a/crates/wf-db/src/drivers/my.rs
+++ b/crates/wf-db/src/drivers/my.rs
@@ -159,6 +159,30 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     })
 }
 
+/// Fetch the DDL `CREATE` statement for `name` from MySQL.
+///
+/// Uses `SHOW CREATE TABLE` or `SHOW CREATE VIEW` depending on `kind`.
+/// Returns `DbError::QueryError` if the object does not exist.
+pub async fn fetch_ddl(pool: &MySqlPool, name: &str, kind: &str) -> Result<String, DbError> {
+    if kind == "view" {
+        let sql = format!("SHOW CREATE VIEW `{}`", name.replace('`', "``"));
+        let row = sqlx::query(&sql)
+            .fetch_optional(pool)
+            .await
+            .map_err(DbError::from)?
+            .ok_or_else(|| DbError::QueryError(format!("view '{name}' not found")))?;
+        Ok(get_meta_str(&row, 1))
+    } else {
+        let sql = format!("SHOW CREATE TABLE `{}`", name.replace('`', "``"));
+        let row = sqlx::query(&sql)
+            .fetch_optional(pool)
+            .await
+            .map_err(DbError::from)?
+            .ok_or_else(|| DbError::QueryError(format!("table '{name}' not found")))?;
+        Ok(get_meta_str(&row, 1))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Metadata string decoding
 // ---------------------------------------------------------------------------

--- a/crates/wf-db/src/drivers/pg.rs
+++ b/crates/wf-db/src/drivers/pg.rs
@@ -161,6 +161,119 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     })
 }
 
+/// Fetch the DDL `CREATE` statement for `name` from PostgreSQL.
+///
+/// For tables: reconstructs DDL from `pg_catalog` (columns + constraints + indexes).
+/// For views: builds `CREATE OR REPLACE VIEW … AS …` from `pg_views`.
+/// Returns `DbError::QueryError` if the object is not found in the `public` schema.
+pub async fn fetch_ddl(pool: &PgPool, name: &str, kind: &str) -> Result<String, DbError> {
+    use sqlx::Row as _;
+
+    if kind == "view" {
+        let row = sqlx::query(
+            "SELECT 'CREATE OR REPLACE VIEW ' || viewname || ' AS ' || chr(10) || definition \
+             FROM pg_catalog.pg_views WHERE viewname = $1 AND schemaname = 'public'",
+        )
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+        .map_err(DbError::from)?;
+
+        return row.map(|r| r.get::<String, _>(0)).ok_or_else(|| {
+            DbError::QueryError(format!("view '{name}' not found in public schema"))
+        });
+    }
+
+    // ── columns with defaults ─────────────────────────────────────────────────
+    let col_rows = sqlx::query(
+        "SELECT a.attname, \
+                pg_catalog.format_type(a.atttypid, a.atttypmod), \
+                a.attnotnull, \
+                CASE WHEN a.atthasdef THEN pg_catalog.pg_get_expr(d.adbin, d.adrelid) ELSE NULL END \
+         FROM pg_catalog.pg_class c \
+         JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped \
+         LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum \
+         WHERE c.relname = $1 \
+           AND c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public') \
+         ORDER BY a.attnum",
+    )
+    .bind(name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    if col_rows.is_empty() {
+        return Err(DbError::QueryError(format!(
+            "table '{name}' not found in public schema"
+        )));
+    }
+
+    // ── constraints ───────────────────────────────────────────────────────────
+    let con_rows = sqlx::query(
+        "SELECT conname, pg_catalog.pg_get_constraintdef(oid, true) \
+         FROM pg_catalog.pg_constraint \
+         WHERE conrelid = ( \
+             SELECT c.oid FROM pg_catalog.pg_class c \
+             WHERE c.relname = $1 AND c.relnamespace = \
+                 (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'public') \
+         ) \
+         ORDER BY contype, conname",
+    )
+    .bind(name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    // ── non-constraint indexes ────────────────────────────────────────────────
+    let idx_rows = sqlx::query(
+        "SELECT indexdef FROM pg_catalog.pg_indexes \
+         WHERE tablename = $1 AND schemaname = 'public' \
+           AND indexname NOT IN ( \
+               SELECT c.conname FROM pg_catalog.pg_constraint c \
+               JOIN pg_catalog.pg_class t ON t.oid = c.conrelid WHERE t.relname = $1 \
+           ) \
+         ORDER BY indexname",
+    )
+    .bind(name)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)?;
+
+    // ── reconstruct DDL ───────────────────────────────────────────────────────
+    let mut lines: Vec<String> = col_rows
+        .iter()
+        .map(|r| {
+            let col_name: String = r.get(0);
+            let col_type: String = r.get(1);
+            let not_null: bool = r.get(2);
+            let default: Option<String> = r.get(3);
+            let mut line = format!("  {col_name} {col_type}");
+            if not_null {
+                line.push_str(" NOT NULL");
+            }
+            if let Some(def) = default {
+                line.push_str(&format!(" DEFAULT {def}"));
+            }
+            line
+        })
+        .collect();
+
+    for r in &con_rows {
+        let con_name: String = r.get(0);
+        let con_def: String = r.get(1);
+        lines.push(format!("  CONSTRAINT {con_name} {con_def}"));
+    }
+
+    let mut ddl = format!("CREATE TABLE {name} (\n{}\n);", lines.join(",\n"));
+
+    for r in &idx_rows {
+        let idx_def: String = r.get(0);
+        ddl.push_str(&format!("\n\n{idx_def};"));
+    }
+
+    Ok(ddl)
+}
+
 // ---------------------------------------------------------------------------
 // Cell decoding
 // ---------------------------------------------------------------------------

--- a/crates/wf-db/src/drivers/sqlite.rs
+++ b/crates/wf-db/src/drivers/sqlite.rs
@@ -123,6 +123,27 @@ pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
     })
 }
 
+/// Fetch the DDL `CREATE` statement for `name` from `sqlite_master`.
+///
+/// `kind` should be `"table"`, `"view"`, or `"index"`.
+/// Returns `DbError::QueryError` if no matching object is found.
+pub async fn fetch_ddl(pool: &SqlitePool, name: &str, kind: &str) -> Result<String, DbError> {
+    use sqlx::Row as _;
+    let type_filter = match kind {
+        "view" => "view",
+        "index" => "index",
+        _ => "table",
+    };
+    let row = sqlx::query("SELECT sql FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1")
+        .bind(type_filter)
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+        .map_err(DbError::from)?;
+    row.map(|r| r.get::<String, _>(0))
+        .ok_or_else(|| DbError::QueryError(format!("'{name}' not found in sqlite_master")))
+}
+
 /// Run `PRAGMA table_info` for `table_name` and return column descriptors.
 async fn pragma_columns(pool: &SqlitePool, table_name: &str) -> Result<Vec<ColumnInfo>, DbError> {
     use sqlx::Row as _;
@@ -458,6 +479,48 @@ mod tests {
         assert!(meta.views.is_empty());
         assert!(meta.indexes.is_empty());
         assert!(meta.stored_procs.is_empty());
+    }
+
+    // ── fetch_ddl ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fetch_ddl_should_return_create_statement_for_table() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE orders (id INTEGER NOT NULL, total REAL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ddl = fetch_ddl(&pool, "orders", "table").await.unwrap();
+
+        assert!(ddl.to_uppercase().contains("CREATE TABLE"));
+        assert!(ddl.contains("orders"));
+    }
+
+    #[tokio::test]
+    async fn fetch_ddl_should_return_error_for_unknown_table() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+
+        let err = fetch_ddl(&pool, "nonexistent", "table").await.unwrap_err();
+
+        assert!(matches!(err, DbError::QueryError(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_ddl_should_return_create_statement_for_view() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE items (id INTEGER NOT NULL, price REAL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("CREATE VIEW cheap AS SELECT id FROM items WHERE price < 10")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ddl = fetch_ddl(&pool, "cheap", "view").await.unwrap();
+
+        assert!(ddl.to_uppercase().contains("CREATE VIEW"));
     }
 
     // ── execute — timing ─────────────────────────────────────────────────────

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -69,6 +69,17 @@ impl DbPool {
         }
     }
 
+    /// Fetch the DDL `CREATE` statement for the object named `name`.
+    ///
+    /// `kind` should be `"table"`, `"view"`, or `"index"`.
+    pub async fn fetch_ddl(&self, name: &str, kind: &str) -> Result<String, DbError> {
+        match self {
+            DbPool::Pg(p) => drivers::pg::fetch_ddl(p, name, kind).await,
+            DbPool::My(p) => drivers::my::fetch_ddl(p, name, kind).await,
+            DbPool::Sqlite(p) => drivers::sqlite::fetch_ddl(p, name, kind).await,
+        }
+    }
+
     /// Returns the [`DbKind`] variant that identifies which DB engine this pool targets.
     pub fn kind(&self) -> DbKind {
         match self {

--- a/crates/wf-db/src/service.rs
+++ b/crates/wf-db/src/service.rs
@@ -103,6 +103,20 @@ impl DbService {
         pool.fetch_metadata().await
     }
 
+    /// Fetch the DDL `CREATE` statement for `name` on `conn_id`.
+    ///
+    /// `kind` should be `"table"`, `"view"`, or `"index"`.
+    /// Returns `Err(DbError::ConnectionFailed)` if `conn_id` is not connected.
+    pub async fn fetch_ddl(
+        &self,
+        conn_id: &str,
+        name: &str,
+        kind: &str,
+    ) -> Result<String, DbError> {
+        let pool = self.pool_for(conn_id)?;
+        pool.fetch_ddl(name, kind).await
+    }
+
     /// Returns `true` if a pool for `conn_id` exists in the map.
     pub fn is_connected(&self, conn_id: &str) -> bool {
         self.pools


### PR DESCRIPTION
## Summary

Implements T101: a TablePlus-style tab bar where SQL editor tabs and table view tabs coexist in a shared tab strip. Double-clicking a table in the sidebar opens a dedicated table view tab showing Data, Columns, and DDL sub-tabs. SQL editor tab state (text and active index) is persisted across restarts via `tabs.toml`. Global keyboard shortcuts are centralized in the root FocusScope bubble phase so they work from any focused element.

## Changes

- **`wf-db`**: added `fetch_ddl` to SQLite (queries `sqlite_master`), PostgreSQL (reconstructs DDL from `pg_catalog`), and MySQL (`SHOW CREATE TABLE/VIEW`) drivers; wired through `pool.rs` and `service.rs`
- **`app/src/app/`**: added `FetchDdl` and `FetchTableData` commands; added `DdlLoaded`, `DdlFetchFailed`, `TableDataLoaded`, `TableDataFailed` events; controller handles both; session adds `save_tabs` / `restore_tabs` with round-trip tests
- **`app/src/ui/tabs_state.rs`**: new `TabsState` managing `SqlEditor` and `TableView` tab entries with per-tab sub-tab persistence
- **`tab_bar.slint`**: horizontal scrollable tab strip with × close and + new buttons, active indicator
- **`table_view.slint`**: three sub-tabs — Data (reuses `ResultTable`), Columns (column list), DDL (monospace scrollable text + Copy DDL button); font sizes matched to editor
- **`app.slint`**: tab bar inserted below menu bar; content area switches between editor and table view; global shortcuts (Ctrl+T/W/Tab/Shift+Tab/1-9) moved to root `key-pressed` bubble phase
- **`editor.slint`**: removed global shortcut callbacks; added `key-pressed` on `TextInput` to reject Ctrl+Tab so it bubbles to root; removed Tab cycling from completion popup
- **i18n**: added Data / Columns / DDL / Copy DDL / Column / Type / Nullable strings in EN and JA

## Related Issues

Closes #207

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes