### PR TITLE
fix(editor): restore keyboard input in SQL editor

### DIFF
--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -569,15 +569,9 @@ export component Editor inherits Rectangle {
                 font-family: root.font-family;
                 font-size:   root.font-size-px * 1px;
 
-                // TextInput consumes all key events by default, preventing bubbling.
-                // Reject Ctrl+Tab here so it reaches the root FocusScope key-pressed.
-                key-pressed(event) => {
-                    if (event.modifiers.control && event.text == Key.Tab) {
-                        EventResult.reject
-                    } else {
-                        EventResult.accept
-                    }
-                }
+                // Reject all key events so built-in TextInput editing runs and
+                // Ctrl+Tab can bubble up to the root FocusScope for tab switching.
+                key-pressed(event) => { EventResult.reject }
 
                 // Secondary path to clear hold-flags when a key is released.
                 // capture-key-released (on the FocusScope) is the primary path,


### PR DESCRIPTION
## Summary

All keyboard input in the SQL editor (typing, Backspace, Enter, arrow keys) was broken because the `TextInput.key-pressed` callback returned `EventResult.accept` for every non-Ctrl+Tab key, consuming the event before Slint's built-in text editing could run. This single-line fix restores full editing functionality.

## Changes

- `editor.slint` `inner-input` TextInput `key-pressed`: replaced `if/else` block (accept for all non-Ctrl+Tab) with unconditional `EventResult.reject`
- Both Ctrl+Tab (tab switching) and all other keys (character insertion, deletion, cursor movement) now work correctly: regular keys fall through to TextInput built-in handling; Ctrl+Tab bubbles up to the root FocusScope

## Related Issues

Fixes #226

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes