### PR TITLE
refactor(ui): introduce Layout, Typography, and Icons design tokens

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -11,7 +11,7 @@ import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
 import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData } from "globals.slint";
-import { Colors, Typography } from "theme.slint";
+import { Colors, Typography, Layout, Icons } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
 import { MenuBar }         from "components/menu_bar.slint";
@@ -255,9 +255,9 @@ export component AppWindow inherits Window {
     changed _theme-sync => { Colors.is-dark = UiState.is-dark; }
 
     // ── Layout geometry helpers ───────────────────────────────────────────────
-    property <length> menu-bar-height:   28px;
-    property <length> tab-bar-height:    32px;
-    property <length> content-height:    root.height - 24px - menu-bar-height - tab-bar-height;
+    property <length> menu-bar-height:   Layout.height-bar;
+    property <length> tab-bar-height:    Layout.height-tab-bar;
+    property <length> content-height:    root.height - Layout.height-compact - menu-bar-height - tab-bar-height;
     property <length> sidebar-width:     220px;
     property <length> main-width:        root.width - sidebar-width;
     property <length> divider-thickness: 5px;
@@ -620,7 +620,7 @@ export component AppWindow inherits Window {
                             y: (parent.height - self.height) / 2;
                             width: 14px;
                             height: 14px;
-                            source: @image-url("../../assets/icons/close.svg");
+                            source: Icons.close;
                             colorize: Colors.surface2;
                             image-fit: contain;
                         }

--- a/app/src/ui/components/common.slint
+++ b/app/src/ui/components/common.slint
@@ -1,7 +1,7 @@
 // Shared UI primitives used across multiple components.
 // All components here depend only on theme.slint — no circular imports.
 
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 
 // ── ToolbarButton ─────────────────────────────────────────────────────────────
 // Small toggle button used in the result-table toolbar (page-size selector,
@@ -16,8 +16,8 @@ export component ToolbarButton inherits Rectangle {
     in property <image>  icon;
     callback clicked;
 
-    height: 20px;
-    border-radius: 3px;
+    height: Layout.height-btn-sm;
+    border-radius: Layout.radius-sm;
     background: ta.has-hover ? Colors.surface1
         : root.active ? Colors.blue : Colors.surface0;
 
@@ -26,9 +26,9 @@ export component ToolbarButton inherits Rectangle {
     }
     HorizontalLayout {
         alignment: center;
-        spacing: 3px;
+        spacing: Layout.spacing-btn;
         if root.leading-icon.width > 0 : Image {
-            width: 12px;
+            width: Layout.icon-sm;
             source: root.leading-icon;
             colorize: root.active ? Colors.base : Colors.overlay2;
             image-fit: contain;
@@ -40,7 +40,7 @@ export component ToolbarButton inherits Rectangle {
             vertical-alignment: center;
         }
         if root.icon.width > 0 : Image {
-            width: 10px;
+            width: Layout.icon-xs;
             source: root.icon;
             colorize: root.active ? Colors.base : Colors.overlay2;
             image-fit: contain;
@@ -64,15 +64,15 @@ export component ActionButton inherits Rectangle {
     in property <image>  leading-icon;
     callback clicked;
 
-    height: 32px;
-    border-radius: 4px;
+    height: Layout.height-btn-lg;
+    border-radius: Layout.radius-md;
     background: root.bg;
 
     HorizontalLayout {
         alignment: center;
-        spacing: 5px;
+        spacing: Layout.spacing-icon;
         if root.leading-icon.width > 0 : Image {
-            width: 14px;
+            width: Layout.icon-md;
             source: root.leading-icon;
             colorize: root.fg;
             image-fit: contain;
@@ -107,7 +107,7 @@ export component ModalOverlay inherits Rectangle {
             Rectangle {
                 width: 360px;
                 background: Colors.surface0;
-                border-radius: 8px;
+                border-radius: Layout.radius-lg;
                 border-width: 1px;
                 border-color: Colors.surface2;
                 drop-shadow-blur: 20px;
@@ -127,7 +127,7 @@ export component MenuItem inherits Rectangle {
     in property <bool>   selected: false;
     callback clicked;
 
-    height: 30px;
+    height: Layout.height-menu-item;
     background: ta.has-hover ? Colors.surface1 : transparent;
 
     ta := TouchArea {
@@ -136,12 +136,12 @@ export component MenuItem inherits Rectangle {
     HorizontalLayout {
         x: 0; y: 0;
         width: parent.width; height: parent.height;
-        padding-left: 12px;
-        spacing: 6px;
+        padding-left: Layout.padding-md;
+        spacing: Layout.spacing-md;
         alignment: start;
         Image {
-            width: 10px;
-            source: @image-url("../../../assets/icons/chevron-right.svg");
+            width: Layout.icon-xs;
+            source: Icons.chevron-right;
             colorize: Colors.text;
             image-fit: contain;
             opacity: root.selected ? 1.0 : 0.0;

--- a/app/src/ui/components/completion_popup.slint
+++ b/app/src/ui/components/completion_popup.slint
@@ -1,14 +1,14 @@
 import { CompletionRow } from "../globals.slint";
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout } from "../theme.slint";
 
 export component CompletionPopup inherits Rectangle {
     in property    <[CompletionRow]> items: [];
     in-out property <int>            selected-index: 0;
 
-    property <length> item-h: 22px;
+    property <length> item-h: Layout.height-completion-item;
 
     background: Colors.surface0;
-    border-radius: 4px;
+    border-radius: Layout.radius-md;
     border-width: 1px;
     border-color: Colors.surface2;
     drop-shadow-blur: 10px;
@@ -30,12 +30,12 @@ export component CompletionPopup inherits Rectangle {
             background: i == root.selected-index ? Colors.surface1 : transparent;
 
             Text {
-                x: 8px;
+                x: Layout.padding-sm;
                 y: (parent.height - self.preferred-height) / 2;
                 text: item.label;
                 color: Colors.text;
                 font-size: Typography.size-lg;
-                font-family: "JetBrains Mono";
+                font-family: Typography.font-mono;
             }
 
             Text {

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -3,7 +3,7 @@
 // Does not import UiState directly to avoid circular imports
 // (app.slint imports this file; UiState is defined in app.slint).
 
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 import { ActionButton } from "common.slint";
 
 // ── Helper: labelled text field row ──────────────────────────────────────────
@@ -18,7 +18,7 @@ component FieldRow inherits HorizontalLayout {
     callback move-focus(int);
     public function grab-focus() { field-input.focus(); }
 
-    spacing: 8px;
+    spacing: Layout.spacing-lg;
     Text {
         text: label-text;
         color: Colors.subtext0;
@@ -28,15 +28,15 @@ component FieldRow inherits HorizontalLayout {
     Rectangle {
         horizontal-stretch: 1;
         background: Colors.base;
-        border-radius: 4px;
-        height: 28px;
+        border-radius: Layout.radius-md;
+        height: Layout.height-row;
         // Placeholder overlaid at the same position as TextInput.
         // Rendered first (behind) so TextInput stays on top and receives focus.
         // Not shown for password fields.
         if !is-password && root.placeholder != "" && root.value == "": Text {
-            x: 6px;
+            x: Layout.padding-input;
             y: 0;
-            width: parent.width - 12px;
+            width: parent.width - Layout.padding-input * 2;
             height: parent.height;
             text: root.placeholder;
             color: Colors.surface2;
@@ -44,9 +44,9 @@ component FieldRow inherits HorizontalLayout {
         }
         // TextInput rendered last → on top → receives all pointer/focus events.
         field-input := TextInput {
-            x: 6px;
+            x: Layout.padding-input;
             y: 0;
-            width: parent.width - 12px;
+            width: parent.width - Layout.padding-input * 2;
             height: parent.height;
             vertical-alignment: center;
             text <=> value;
@@ -83,7 +83,7 @@ component TabButton inherits VerticalLayout {
         color: active ? Colors.blue : Colors.subtext0;
         horizontal-alignment: center;
         vertical-alignment: center;
-        height: 28px;
+        height: Layout.height-row;
     }
     Rectangle {
         height: 2px;
@@ -101,16 +101,16 @@ component DbTypeButton inherits Rectangle {
     callback clicked;
 
     background: active ? Colors.blue : Colors.surface1;
-    border-radius: 4px;
-    height: 32px;
+    border-radius: Layout.radius-md;
+    height: Layout.height-btn-lg;
     horizontal-stretch: 1;
     // Wrapping Image in a Rectangle with explicit width prevents Slint from using
     // the SVG's intrinsic size (800px) in the alignment: center group calculation.
     HorizontalLayout {
         alignment: center;
-        spacing: 6px;
+        spacing: Layout.spacing-md;
         Rectangle {
-            width: root.icon.width > 0 ? 18px : 0px;
+            width: root.icon.width > 0 ? Layout.icon-xl : 0;
             horizontal-stretch: 0;
             Image {
                 width: parent.width;
@@ -123,7 +123,7 @@ component DbTypeButton inherits Rectangle {
             text: label-text;
             color: active ? Colors.base : Colors.text;
             font-size: Typography.size-xl;
-            font-family: "Segoe UI";
+            font-family: Typography.font-ui;
             vertical-alignment: center;
             wrap: no-wrap;
         }
@@ -164,7 +164,7 @@ export component ConnectionForm inherits Rectangle {
 
     // ── Layout ────────────────────────────────────────────────────────────────
     background: Colors.surface0;
-    border-radius: 8px;
+    border-radius: Layout.radius-lg;
     border-width: 1px;
     border-color: Colors.surface2;
     drop-shadow-blur: 24px;
@@ -174,8 +174,8 @@ export component ConnectionForm inherits Rectangle {
     clip: true;
 
     VerticalLayout {
-        padding: 20px;
-        spacing: 10px;
+        padding: Layout.padding-xl;
+        spacing: Layout.spacing-xl;
 
         // Title
         Text {
@@ -201,22 +201,22 @@ export component ConnectionForm inherits Rectangle {
 
         // DB type selector
         HorizontalLayout {
-            spacing: 6px;
+            spacing: Layout.spacing-md;
             DbTypeButton {
                 label-text: "PostgreSQL";
-                icon: @image-url("../../../assets/icons/brand-postgresql.svg");
+                icon: Icons.brand-postgresql;
                 active: root.db-type == 0;
                 clicked => { root.db-type = 0; }
             }
             DbTypeButton {
                 label-text: "MySQL";
-                icon: @image-url("../../../assets/icons/brand-mysql.svg");
+                icon: Icons.brand-mysql;
                 active: root.db-type == 1;
                 clicked => { root.db-type = 1; }
             }
             DbTypeButton {
                 label-text: "SQLite";
-                icon: @image-url("../../../assets/icons/brand-sqlite.svg");
+                icon: Icons.brand-sqlite;
                 active: root.db-type == 2;
                 clicked => { root.db-type = 2; }
             }
@@ -253,25 +253,25 @@ export component ConnectionForm inherits Rectangle {
             Rectangle {
                 visible: root.tab-index == 0;
                 background: Colors.base;
-                border-radius: 4px;
+                border-radius: Layout.radius-md;
                 width: parent.width;
-                height: 28px;
-                y: parent.height - 28px;
+                height: Layout.height-row;
+                y: parent.height - Layout.height-row;
 
                 if root.conn-string == "": Text {
-                    x: 6px;
+                    x: Layout.padding-input;
                     y: 0;
-                    width: parent.width - 12px;
-                    height: 28px;
+                    width: parent.width - Layout.padding-input * 2;
+                    height: Layout.height-row;
                     text: "postgres://user:pass@host:5432/db";
                     color: Colors.surface2;
                     vertical-alignment: center;
                 }
                 conn-string-input := TextInput {
-                    x: 6px;
+                    x: Layout.padding-input;
                     y: 0;
-                    width: parent.width - 12px;
-                    height: 28px;
+                    width: parent.width - Layout.padding-input * 2;
+                    height: Layout.height-row;
                     vertical-alignment: center;
                     text <=> root.conn-string;
                     color: Colors.text;
@@ -293,7 +293,7 @@ export component ConnectionForm inherits Rectangle {
             // Individual Fields tab
             fields-layout := VerticalLayout {
                 visible: root.tab-index == 1;
-                spacing: 6px;
+                spacing: Layout.spacing-md;
 
                 host-field := FieldRow {
                     label-text: @tr("Host");
@@ -344,11 +344,11 @@ export component ConnectionForm inherits Rectangle {
 
         // Status message (shown only when not empty)
         HorizontalLayout {
-            height: 20px;
-            spacing: 5px;
+            height: Layout.height-btn-sm;
+            spacing: Layout.spacing-icon;
             if root.status != "" : Image {
-                width: 14px;
-                source: @image-url("../../../assets/icons/alert-error.svg");
+                width: Layout.icon-md;
+                source: Icons.alert-error;
                 colorize: Colors.red;
                 image-fit: contain;
             }
@@ -364,7 +364,7 @@ export component ConnectionForm inherits Rectangle {
 
         // Buttons
         HorizontalLayout {
-            spacing: 8px;
+            spacing: Layout.spacing-lg;
             alignment: end;
 
             if root.is-edit : ActionButton {
@@ -372,7 +372,7 @@ export component ConnectionForm inherits Rectangle {
                 text: @tr("Delete");
                 bg: Colors.red;
                 fg: Colors.base;
-                leading-icon: @image-url("../../../assets/icons/delete.svg");
+                leading-icon: Icons.delete;
                 enabled: !root.testing;
                 clicked => { root.delete-connection(); }
             }
@@ -388,7 +388,7 @@ export component ConnectionForm inherits Rectangle {
                 text: root.testing ? @tr("Testing\u{2026}") : @tr("Test Connection");
                 bg: root.testing ? Colors.surface2 : Colors.blue;
                 fg: root.testing ? Colors.subtext0 : Colors.base;
-                leading-icon: @image-url("../../../assets/icons/test-connection.svg");
+                leading-icon: Icons.test-connection;
                 enabled: !root.testing;
                 clicked => { root.test-connection(); }
             }
@@ -401,7 +401,7 @@ export component ConnectionForm inherits Rectangle {
                   : root.test-ok  ? Colors.green
                   :                 Colors.overlay0;
                 fg: root.testing ? Colors.subtext0 : Colors.base;
-                leading-icon: @image-url("../../../assets/icons/confirm.svg");
+                leading-icon: Icons.confirm;
                 enabled: !root.testing;
                 clicked => { root.add-connection(); }
             }

--- a/app/src/ui/components/dialogs/add_connection_dialog.slint
+++ b/app/src/ui/components/dialogs/add_connection_dialog.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../../theme.slint";
+import { Colors, Typography, Layout } from "../../theme.slint";
 import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component AddConnectionDialog inherits ModalOverlay {
@@ -6,8 +6,8 @@ export component AddConnectionDialog inherits ModalOverlay {
     callback yes-clicked;
 
     VerticalLayout {
-        padding: 24px;
-        spacing: 16px;
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-2xl;
         alignment: start;
 
         Text {
@@ -25,7 +25,7 @@ export component AddConnectionDialog inherits ModalOverlay {
         }
 
         HorizontalLayout {
-            spacing: 8px;
+            spacing: Layout.spacing-lg;
             alignment: end;
             ActionButton {
                 width: 80px;

--- a/app/src/ui/components/dialogs/all_rows_dialog.slint
+++ b/app/src/ui/components/dialogs/all_rows_dialog.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../../theme.slint";
+import { Colors, Typography, Layout } from "../../theme.slint";
 import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component AllRowsDialog inherits ModalOverlay {
@@ -6,8 +6,8 @@ export component AllRowsDialog inherits ModalOverlay {
     callback fetch-clicked;
 
     VerticalLayout {
-        padding: 24px;
-        spacing: 16px;
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-2xl;
         alignment: start;
 
         Text {
@@ -25,7 +25,7 @@ export component AllRowsDialog inherits ModalOverlay {
         }
 
         HorizontalLayout {
-            spacing: 8px;
+            spacing: Layout.spacing-lg;
             alignment: end;
             ActionButton {
                 width: 80px;

--- a/app/src/ui/components/dialogs/db_manager_dialog.slint
+++ b/app/src/ui/components/dialogs/db_manager_dialog.slint
@@ -1,5 +1,5 @@
 import { ConnectionEntry } from "../../globals.slint";
-import { Colors, Typography } from "../../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../../theme.slint";
 
 export component DbManagerDialog inherits Rectangle {
     in property <[ConnectionEntry]> connections: [];
@@ -24,8 +24,8 @@ export component DbManagerDialog inherits Rectangle {
     // viewport-y is 0 at top and negative as content scrolls down.
     changed kb-focus => {
         if (root.kb-focus >= 0) {
-            let row-top = root.kb-focus * 48px;
-            let row-bot = row-top + 48px;
+            let row-top = root.kb-focus * Layout.height-dialog-row;
+            let row-bot = row-top + Layout.height-dialog-row;
             if (row-top < -dialog-scroll.viewport-y) {
                 dialog-scroll.viewport-y = -row-top;
             } else if (row-bot > -dialog-scroll.viewport-y + dialog-scroll.height) {
@@ -73,7 +73,7 @@ export component DbManagerDialog inherits Rectangle {
             width: 560px;
             height: 520px;
             background: Colors.surface0;
-            border-radius: 8px;
+            border-radius: Layout.radius-lg;
             border-width: 1px;
             border-color: Colors.surface2;
             drop-shadow-blur: 24px;
@@ -83,12 +83,12 @@ export component DbManagerDialog inherits Rectangle {
             VerticalLayout {
                 // ── Header ────────────────────────────────────────────────────
                 Rectangle {
-                    height: 48px;
+                    height: Layout.height-dialog-row;
                     background: Colors.mantle;
 
                     HorizontalLayout {
-                        padding-left: 16px;
-                        padding-right: 8px;
+                        padding-left: Layout.padding-2xl;
+                        padding-right: Layout.padding-sm;
                         spacing: 0;
 
                         Text {
@@ -103,15 +103,15 @@ export component DbManagerDialog inherits Rectangle {
                         // Close button
                         close-rect := Rectangle {
                             width: 36px;
-                            border-radius: 4px;
+                            border-radius: Layout.radius-md;
                             background: close-ta.has-hover ? Colors.surface1 : transparent;
 
                             Image {
                                 x: (parent.width - self.width) / 2;
                                 y: (parent.height - self.height) / 2;
-                                width: 16px;
-                                height: 16px;
-                                source: @image-url("../../../../assets/icons/close.svg");
+                                width: Layout.icon-lg;
+                                height: Layout.icon-lg;
+                                source: Icons.close;
                                 colorize: Colors.subtext0;
                                 image-fit: contain;
                             }
@@ -138,7 +138,7 @@ export component DbManagerDialog inherits Rectangle {
 
                     dialog-content := VerticalLayout {
                         for conn[i] in root.connections: Rectangle {
-                            height: 48px;
+                            height: Layout.height-dialog-row;
                             clip: true;
 
                             background: i == root.kb-focus
@@ -165,9 +165,9 @@ export component DbManagerDialog inherits Rectangle {
                                 x: 0; y: 0;
                                 width: parent.width;
                                 height: parent.height;
-                                padding-left: 16px;
-                                padding-right: 12px;
-                                spacing: 8px;
+                                padding-left: Layout.padding-2xl;
+                                padding-right: Layout.padding-md;
+                                spacing: Layout.spacing-lg;
 
                                 // Active / inactive indicator dot
                                 Text {
@@ -175,7 +175,7 @@ export component DbManagerDialog inherits Rectangle {
                                     color: conn.is-active ? Colors.blue : Colors.surface2;
                                     font-size: Typography.size-lg;
                                     vertical-alignment: center;
-                                    width: 16px;
+                                    width: Layout.icon-lg;
                                 }
 
                                 // Connection name
@@ -204,17 +204,17 @@ export component DbManagerDialog inherits Rectangle {
                                     width: 60px;
 
                                     edit-rect := Rectangle {
-                                        height: 26px;
-                                        border-radius: 4px;
+                                        height: Layout.height-btn-md;
+                                        border-radius: Layout.radius-md;
                                         background: edit-ta.has-hover
                                             ? Colors.surface2 : Colors.surface1;
 
                                         HorizontalLayout {
                                             alignment: center;
-                                            spacing: 4px;
+                                            spacing: Layout.spacing-sm;
                                             Image {
-                                                width: 12px;
-                                                source: @image-url("../../../../assets/icons/edit.svg");
+                                                width: Layout.icon-sm;
+                                                source: Icons.edit;
                                                 colorize: Colors.text;
                                                 image-fit: contain;
                                             }
@@ -237,20 +237,20 @@ export component DbManagerDialog inherits Rectangle {
                                     width: 100px;
 
                                     btn-rect := Rectangle {
-                                        height: 26px;
-                                        border-radius: 4px;
+                                        height: Layout.height-btn-md;
+                                        border-radius: Layout.radius-md;
                                         background: conn.is-active
                                             ? Colors.surface2
                                             : Colors.blue;
 
                                         HorizontalLayout {
                                             alignment: center;
-                                            spacing: 4px;
+                                            spacing: Layout.spacing-sm;
                                             Image {
-                                                width: 12px;
+                                                width: Layout.icon-sm;
                                                 source: conn.is-active
-                                                    ? @image-url("../../../../assets/icons/unlink.svg")
-                                                    : @image-url("../../../../assets/icons/link.svg");
+                                                    ? Icons.unlink
+                                                    : Icons.link;
                                                 colorize: Colors.base;
                                                 image-fit: contain;
                                             }
@@ -285,7 +285,7 @@ export component DbManagerDialog inherits Rectangle {
 
                 // ── Add connection footer ──────────────────────────────────────
                 Rectangle {
-                    height: 44px;
+                    height: Layout.height-footer;
 
                     footer-ta := TouchArea {
                         width: parent.width;
@@ -300,11 +300,11 @@ export component DbManagerDialog inherits Rectangle {
                     }
 
                     HorizontalLayout {
-                        padding-left: 16px;
-                        spacing: 6px;
+                        padding-left: Layout.padding-2xl;
+                        spacing: Layout.spacing-md;
                         Image {
-                            width: 14px;
-                            source: @image-url("../../../../assets/icons/plus.svg");
+                            width: Layout.icon-md;
+                            source: Icons.plus;
                             colorize: Colors.blue;
                             image-fit: contain;
                         }

--- a/app/src/ui/components/dialogs/test_result_dialog.slint
+++ b/app/src/ui/components/dialogs/test_result_dialog.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../../theme.slint";
+import { Colors, Typography, Layout } from "../../theme.slint";
 import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component TestResultDialog inherits ModalOverlay {
@@ -7,8 +7,8 @@ export component TestResultDialog inherits ModalOverlay {
     callback ok-clicked;
 
     VerticalLayout {
-        padding: 24px;
-        spacing: 16px;
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-2xl;
         alignment: start;
 
         Text {

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -2,11 +2,11 @@
 // Each top-level label shows a PopupWindow dropdown on click.
 // Items reuse MenuItem from common.slint.
 
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout } from "../theme.slint";
 import { MenuItem } from "common.slint";
 
 export component MenuBar inherits Rectangle {
-    height: 28px;
+    height: Layout.height-bar;
     background: Colors.mantle;
 
     callback export-csv();
@@ -33,7 +33,7 @@ export component MenuBar inherits Rectangle {
     }
 
     HorizontalLayout {
-        padding-left:   4px;
+        padding-left:   Layout.padding-xs;
         padding-top:    2px;
         padding-bottom: 2px;
         alignment:      start;
@@ -43,7 +43,7 @@ export component MenuBar inherits Rectangle {
         Rectangle {
             width: 60px;
             background: file-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: 3px;
+            border-radius: Layout.radius-sm;
 
             Text {
                 text: @tr("File");
@@ -59,14 +59,14 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  180px;
-                height: 91px;
+                height: 3 * Layout.height-menu-item + 1px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  180px;
-                    height: 91px;
+                    height: 3 * Layout.height-menu-item + 1px;
                     background:    Colors.surface0;
-                    border-radius: 4px;
+                    border-radius: Layout.radius-md;
                     border-width:  1px;
                     border-color:  Colors.surface2;
                     drop-shadow-blur:  8px;
@@ -88,7 +88,7 @@ export component MenuBar inherits Rectangle {
         Rectangle {
             width: 60px;
             background: edit-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: 3px;
+            border-radius: Layout.radius-sm;
 
             Text {
                 text: @tr("Edit");
@@ -104,14 +104,14 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  180px;
-                height: 30px;
+                height: Layout.height-menu-item;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  180px;
-                    height: 30px;
+                    height: Layout.height-menu-item;
                     background:    Colors.surface0;
-                    border-radius: 4px;
+                    border-radius: Layout.radius-md;
                     border-width:  1px;
                     border-color:  Colors.surface2;
                     drop-shadow-blur:  8px;
@@ -130,7 +130,7 @@ export component MenuBar inherits Rectangle {
         Rectangle {
             width: 80px;
             background: db-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: 3px;
+            border-radius: Layout.radius-sm;
 
             Text {
                 text: @tr("Database");
@@ -146,14 +146,18 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  220px;
-                height: root.has-active-connection ? 61px : 30px;
+                height: root.has-active-connection
+                    ? 2 * Layout.height-menu-item + 1px
+                    : Layout.height-menu-item;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  220px;
-                    height: root.has-active-connection ? 61px : 30px;
+                    height: root.has-active-connection
+                        ? 2 * Layout.height-menu-item + 1px
+                        : Layout.height-menu-item;
                     background:    Colors.surface0;
-                    border-radius: 4px;
+                    border-radius: Layout.radius-md;
                     border-width:  1px;
                     border-color:  Colors.surface2;
                     drop-shadow-blur:  8px;
@@ -182,7 +186,7 @@ export component MenuBar inherits Rectangle {
         Rectangle {
             width: 70px;
             background: query-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: 3px;
+            border-radius: Layout.radius-sm;
 
             Text {
                 text: @tr("Query");
@@ -198,14 +202,14 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  220px;
-                height: 90px;
+                height: 3 * Layout.height-menu-item;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  220px;
-                    height: 90px;
+                    height: 3 * Layout.height-menu-item;
                     background:    Colors.surface0;
-                    border-radius: 4px;
+                    border-radius: Layout.radius-md;
                     border-width:  1px;
                     border-color:  Colors.surface2;
                     drop-shadow-blur:  8px;
@@ -235,7 +239,7 @@ export component MenuBar inherits Rectangle {
         Rectangle {
             width: 80px;
             background: settings-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: 3px;
+            border-radius: Layout.radius-sm;
 
             Text {
                 text: @tr("Settings");
@@ -251,14 +255,14 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  220px;
-                height: 91px;
+                height: 3 * Layout.height-menu-item + 1px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  220px;
-                    height: 91px;
+                    height: 3 * Layout.height-menu-item + 1px;
                     background:    Colors.surface0;
-                    border-radius: 4px;
+                    border-radius: Layout.radius-md;
                     border-width:  1px;
                     border-color:  Colors.surface2;
                     drop-shadow-blur:  8px;

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -1,5 +1,5 @@
 import { RowData } from "../globals.slint";
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 import { ResultTableToolbar } from "result_table_toolbar.slint";
 import { ResultTableHeader } from "result_table_header.slint";
 import { ResultTableBody }   from "result_table_body.slint";
@@ -41,14 +41,14 @@ export component ResultTable inherits Rectangle {
     out property <string> selected-cell-value:   body-inst.selected-cell-value;
     out property <bool>   selected-cell-is-null: body-inst.selected-cell-is-null;
     public function grab-focus() { body-inst.grab-focus(); }
-    property <length> row-height:    28px;
+    property <length> row-height:    Layout.height-row;
     property <length> default-col-w: 150px;
     property <length> min-col-w:     48px;
     property <length> vp-w: root.total-col-width > 0
         ? max(root.total-col-width * 1px, root.width)
         : max(root.columns.length * root.default-col-w, root.width);
-    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
-    property <length> search-bar-h:    body-inst.nav-mode == 2 ? 32px : 0px;
+    property <length> filter-banner-h: root.active-filter != "" ? Layout.height-compact : 0px;
+    property <length> search-bar-h:    body-inst.nav-mode == 2 ? Layout.height-tab-bar : 0px;
     property <length> bottom-total:    root.filter-banner-h + root.search-bar-h;
     property <string> search-query: "";
 
@@ -141,7 +141,7 @@ export component ResultTable inherits Rectangle {
                 spacing: 6px;
                 Image {
                     width: 18px;
-                    source: @image-url("../../../assets/icons/alert-error.svg");
+                    source: Icons.alert-error;
                     colorize: Colors.red;
                     image-fit: contain;
                 }

--- a/app/src/ui/components/result_table_body.slint
+++ b/app/src/ui/components/result_table_body.slint
@@ -1,6 +1,6 @@
 import { ListView } from "std-widgets.slint";
 import { RowData } from "../globals.slint";
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout } from "../theme.slint";
 import { MenuItem } from "common.slint";
 
 // Data body: keyboard handler (FocusScope), virtualised row list, and right-click context menu.
@@ -228,14 +228,14 @@ export component ResultTableBody inherits Rectangle {
             x: root.ctx-menu-x;
             y: root.ctx-menu-y;
             width: 204px;
-            height: 90px;
+            height: 3 * Layout.height-menu-item;
             close-policy: PopupClosePolicy.close-on-click;
 
             Rectangle {
                 width: 204px;
-                height: 90px;
+                height: 3 * Layout.height-menu-item;
                 background: Colors.surface0;
-                border-radius: 4px;
+                border-radius: Layout.radius-md;
                 border-width: 1px;
                 border-color: Colors.surface2;
                 drop-shadow-blur: 8px;
@@ -302,10 +302,10 @@ export component ResultTableBody inherits Rectangle {
                         }
 
                         if cell.is-null: Rectangle {
-                            x: 8px;
+                            x: Layout.padding-sm;
                             y: (parent.height - self.height) / 2;
                             width: 36px; height: 16px;
-                            border-radius: 3px;
+                            border-radius: Layout.radius-sm;
                             background: Colors.surface1;
                             Text {
                                 width: parent.width; height: parent.height;
@@ -318,9 +318,9 @@ export component ResultTableBody inherits Rectangle {
                         }
 
                         if !cell.is-null: Text {
-                            x: 8px;
+                            x: Layout.padding-sm;
                             y: (parent.height - self.height) / 2;
-                            width: parent.width - 16px;
+                            width: parent.width - Layout.padding-sm * 2;
                             text: cell.value;
                             color: i == root.selected-row ? Colors.selected-text : Colors.subtext0;
                             font-family: root.font-family;

--- a/app/src/ui/components/result_table_header.slint
+++ b/app/src/ui/components/result_table_header.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 
 // Column header row with sort indicators and drag-to-resize handles.
 export component ResultTableHeader inherits Flickable {
@@ -36,11 +36,11 @@ export component ResultTableHeader inherits Flickable {
             }
 
             Text {
-                x: 8px;
+                x: Layout.padding-sm;
                 y: (parent.height - self.height) / 2;
                 width: root.sort-col == i
-                    ? parent.width - 28px
-                    : parent.width - 12px;
+                    ? parent.width - Layout.padding-md - Layout.icon-sm
+                    : parent.width - Layout.padding-md;
                 text: col;
                 color: Colors.text;
                 font-size: Typography.size-lg;
@@ -48,13 +48,13 @@ export component ResultTableHeader inherits Flickable {
             }
 
             if root.sort-col == i: Image {
-                x: parent.width - 20px;
+                x: parent.width - Layout.padding-md - Layout.icon-sm;
                 y: (parent.height - self.height) / 2;
-                width: 12px;
-                height: 12px;
+                width: Layout.icon-sm;
+                height: Layout.icon-sm;
                 source: root.sort-asc
-                    ? @image-url("../../../assets/icons/sort-asc.svg")
-                    : @image-url("../../../assets/icons/sort-desc.svg");
+                    ? Icons.sort-asc
+                    : Icons.sort-desc;
                 colorize: Colors.blue;
                 image-fit: contain;
             }

--- a/app/src/ui/components/result_table_search.slint
+++ b/app/src/ui/components/result_table_search.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout } from "../theme.slint";
 
 // Search bar (shown when in search mode) + active-filter indicator banner.
 export component ResultTableSearch inherits Rectangle {
@@ -13,8 +13,8 @@ export component ResultTableSearch inherits Rectangle {
 
     public function grab-focus() { search-input.focus(); }
 
-    property <length> search-bar-h:    root.in-search-mode ? 32px : 0px;
-    property <length> filter-banner-h: root.active-filter != "" ? 24px : 0px;
+    property <length> search-bar-h:    root.in-search-mode ? Layout.height-tab-bar : 0px;
+    property <length> filter-banner-h: root.active-filter != "" ? Layout.height-compact : 0px;
 
     // Search bar
     Rectangle {
@@ -31,7 +31,7 @@ export component ResultTableSearch inherits Rectangle {
         }
 
         Text {
-            x: 10px;
+            x: Layout.padding-tab;
             y: (parent.height - self.height) / 2;
             text: "/";
             color: Colors.blue;
@@ -68,9 +68,9 @@ export component ResultTableSearch inherits Rectangle {
         }
 
         HorizontalLayout {
-            padding-left: 10px;
-            padding-right: 10px;
-            spacing: 6px;
+            padding-left: Layout.padding-tab;
+            padding-right: Layout.padding-tab;
+            spacing: Layout.spacing-md;
 
             Text {
                 text: @tr("Filter:");

--- a/app/src/ui/components/result_table_toolbar.slint
+++ b/app/src/ui/components/result_table_toolbar.slint
@@ -1,9 +1,9 @@
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 import { ToolbarButton, MenuItem } from "common.slint";
 
 // Toolbar strip for the result table: row-count display, Export button, page-size selector.
 export component ResultTableToolbar inherits Rectangle {
-    height: 28px;
+    height: Layout.height-bar;
     background: Colors.mantle;
     clip: true;
 
@@ -37,7 +37,7 @@ export component ResultTableToolbar inherits Rectangle {
         y: (parent.height - self.height) / 2;
         width: 80px;
         text: @tr("Export");
-        leading-icon: @image-url("../../../assets/icons/export.svg");
+        leading-icon: Icons.export;
         clicked => { export-popup.show(); }
     }
 
@@ -45,8 +45,8 @@ export component ResultTableToolbar inherits Rectangle {
         x: parent.width - 178px;
         y: (parent.height - self.height) / 2;
         width: 170px;
-        height: 20px;
-        spacing: 2px;
+        height: Layout.height-btn-sm;
+        spacing: Layout.spacing-xs;
 
         ToolbarButton {
             width: 38px; text: "100";
@@ -81,7 +81,7 @@ export component ResultTableToolbar inherits Rectangle {
             width: 120px;
             height: 60px;
             background: Colors.surface0;
-            border-radius: 4px;
+            border-radius: Layout.radius-md;
             border-width: 1px;
             border-color: Colors.surface2;
             drop-shadow-blur: 8px;

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -1,5 +1,5 @@
 import { SidebarNode } from "../globals.slint";
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 
 export component Sidebar inherits Rectangle {
     background: Colors.base;
@@ -110,7 +110,7 @@ export component Sidebar inherits Rectangle {
             sidebar-content := VerticalLayout {
                 // ── Schema tree ───────────────────────────────────────────────────────
                 for node[i] in root.tree : Rectangle {
-                    height: 32px;
+                    height: Layout.height-sidebar-row;
                     clip: true;
 
                     background: i == root.kb-focus
@@ -152,28 +152,28 @@ export component Sidebar inherits Rectangle {
                         x: 0; y: 0;
                         width: parent.width;
                         height: parent.height;
-                        padding-left: (8 + node.level * 14) * 1px;
-                        padding-right: 8px;
-                        spacing: 8px;
+                        padding-left: Layout.padding-sm + node.level * Layout.sidebar-indent;
+                        padding-right: Layout.padding-sm;
+                        spacing: Layout.spacing-lg;
 
                         // Expand/collapse toggle icon for connection and category nodes
                         if node.level < 2 : Image {
-                            width: 14px;
+                            width: Layout.icon-md;
                             source: node.is-expanded
-                                ? @image-url("../../../assets/icons/chevron-down.svg")
-                                : @image-url("../../../assets/icons/chevron-right.svg");
+                                ? Icons.chevron-down
+                                : Icons.chevron-right;
                             colorize: Colors.surface2;
                             image-fit: contain;
                         }
                         // Spacer for item nodes
-                        if node.level >= 2 : Rectangle { width: 14px; }
+                        if node.level >= 2 : Rectangle { width: Layout.icon-md; }
 
                         // Connection status dot (filled = active / empty = inactive)
                         if node.level == 0 : Image {
-                            width: 16px;
+                            width: Layout.icon-lg;
                             source: node.is-active
-                                ? @image-url("../../../assets/icons/dot-filled.svg")
-                                : @image-url("../../../assets/icons/dot-empty.svg");
+                                ? Icons.dot-filled
+                                : Icons.dot-empty;
                             colorize: node.is-active ? Colors.blue : Colors.surface2;
                             image-fit: contain;
                         }
@@ -202,7 +202,7 @@ export component Sidebar inherits Rectangle {
 
                 // ── Metadata loading indicator ────────────────────────────────────────
                 if root.is-loading : Rectangle {
-                    height: 28px;
+                    height: Layout.height-row;
                     HorizontalLayout {
                         padding-left: 24px;
                         Text {
@@ -223,15 +223,15 @@ export component Sidebar inherits Rectangle {
 
                 // ── Add connection button ─────────────────────────────────────────────
                 Rectangle {
-                    height: 36px;
+                    height: Layout.height-sidebar-row + 4px;
                     background: transparent;
 
                     HorizontalLayout {
-                        padding-left: 12px;
-                        spacing: 6px;
+                        padding-left: Layout.padding-md;
+                        spacing: Layout.spacing-md;
                         Image {
-                            width: 14px;
-                            source: @image-url("../../../assets/icons/plus.svg");
+                            width: Layout.icon-md;
+                            source: Icons.plus;
                             colorize: Colors.blue;
                             image-fit: contain;
                         }

--- a/app/src/ui/components/status_bar.slint
+++ b/app/src/ui/components/status_bar.slint
@@ -2,7 +2,7 @@
 // Left: active connection name (and DB) or "Not connected".
 // Right: query lifecycle status — "Running…", "N ms · M rows", "Cancelled", "Error: …".
 
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout } from "../theme.slint";
 
 export component StatusBar inherits Rectangle {
     background: Colors.crust;
@@ -15,9 +15,9 @@ export component StatusBar inherits Rectangle {
     in property <string> query-status;
 
     HorizontalLayout {
-        padding-left:  12px;
-        padding-right: 12px;
-        spacing: 8px;
+        padding-left:  Layout.padding-md;
+        padding-right: Layout.padding-md;
+        spacing: Layout.spacing-lg;
 
         Text {
             text: root.connection-text;

--- a/app/src/ui/components/tab_bar.slint
+++ b/app/src/ui/components/tab_bar.slint
@@ -1,5 +1,5 @@
 import { TabEntry } from "../globals.slint";
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 
 export component TabBar inherits Rectangle {
     in property <[TabEntry]> tabs;
@@ -8,7 +8,7 @@ export component TabBar inherits Rectangle {
     callback close-tab(int);
     callback switch-tab(int);
 
-    height: 32px;
+    height: Layout.height-tab-bar;
     background: Colors.surface0;
 
     HorizontalLayout {
@@ -24,7 +24,7 @@ export component TabBar inherits Rectangle {
 
                 for tab[i] in root.tabs : Rectangle {
                     width: min(max(tab-text.preferred-width + 64px, 80px), 240px);
-                    height: 32px;
+                    height: Layout.height-tab-bar;
                     background: i == root.active-index ? Colors.base : transparent;
 
                     ta-tab := TouchArea {
@@ -33,21 +33,21 @@ export component TabBar inherits Rectangle {
 
                     HorizontalLayout {
                         x: 0;
-                        y: (parent.height - 24px) / 2;
+                        y: (parent.height - Layout.height-compact) / 2;
                         width: parent.width;
-                        height: 24px;
-                        padding-left: 10px;
-                        padding-right: 4px;
-                        spacing: 6px;
+                        height: Layout.height-compact;
+                        padding-left: Layout.padding-tab;
+                        padding-right: Layout.padding-xs;
+                        spacing: Layout.spacing-md;
 
                         if tab.kind == "sql-editor" : Image {
-                            width: 14px;
-                            source: @image-url("../../../assets/icons/sql-database.svg");
+                            width: Layout.icon-md;
+                            source: Icons.sql-database;
                             image-fit: contain;
                         }
                         if tab.kind == "table-view" : Image {
-                            width: 14px;
-                            source: @image-url("../../../assets/icons/table-list.svg");
+                            width: Layout.icon-md;
+                            source: Icons.table-list;
                             colorize: i == root.active-index ? Colors.text : Colors.subtext1;
                             image-fit: contain;
                         }
@@ -62,17 +62,17 @@ export component TabBar inherits Rectangle {
                         }
 
                         Rectangle {
-                            width: 24px;
-                            height: 24px;
-                            border-radius: 4px;
+                            width: Layout.height-compact;
+                            height: Layout.height-compact;
+                            border-radius: Layout.radius-md;
                             background: close-ta.has-hover ? Colors.surface1 : transparent;
 
                             Image {
                                 x: (parent.width - self.width) / 2;
                                 y: (parent.height - self.height) / 2;
-                                width: 14px;
-                                height: 14px;
-                                source: @image-url("../../../assets/icons/close.svg");
+                                width: Layout.icon-md;
+                                height: Layout.icon-md;
+                                source: Icons.close;
                                 colorize: close-ta.has-hover ? Colors.text : Colors.subtext1;
                                 image-fit: contain;
                             }
@@ -95,16 +95,16 @@ export component TabBar inherits Rectangle {
         }
 
         Rectangle {
-            width: 32px;
-            height: 32px;
+            width: Layout.height-tab-bar;
+            height: Layout.height-tab-bar;
             background: new-ta.has-hover ? Colors.surface1 : transparent;
 
             Image {
                 x: (parent.width - self.width) / 2;
                 y: (parent.height - self.height) / 2;
-                width: 16px;
-                height: 16px;
-                source: @image-url("../../../assets/icons/plus.svg");
+                width: Layout.icon-lg;
+                height: Layout.icon-lg;
+                source: Icons.plus;
                 colorize: new-ta.has-hover ? Colors.text : Colors.subtext1;
                 image-fit: contain;
             }

--- a/app/src/ui/components/table_view.slint
+++ b/app/src/ui/components/table_view.slint
@@ -1,4 +1,4 @@
-import { Colors, Typography } from "../theme.slint";
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
 import { ColumnData, RowData } from "../globals.slint";
 import { ResultTable } from "result_table.slint";
 
@@ -57,7 +57,7 @@ export component TableView inherits Rectangle {
     Rectangle {
         x: 0; y: 0;
         width: parent.width;
-        height: 32px;
+        height: Layout.height-tab-bar;
         background: Colors.surface0;
 
         HorizontalLayout {
@@ -65,27 +65,27 @@ export component TableView inherits Rectangle {
 
             for label[i] in [@tr("Data"), @tr("Columns"), @tr("DDL")] : Rectangle {
                 width: 80px;
-                height: 32px;
+                height: Layout.height-tab-bar;
                 background: i == root.sub-tab ? Colors.base : transparent;
 
                 HorizontalLayout {
                     alignment: center;
-                    spacing: 4px;
+                    spacing: Layout.spacing-sm;
                     if i == 0 : Image {
-                        width: 14px;
-                        source: @image-url("../../../assets/icons/table-list.svg");
+                        width: Layout.icon-md;
+                        source: Icons.table-list;
                         colorize: i == root.sub-tab ? Colors.text : Colors.subtext1;
                         image-fit: contain;
                     }
                     if i == 1 : Image {
-                        width: 14px;
-                        source: @image-url("../../../assets/icons/columns.svg");
+                        width: Layout.icon-md;
+                        source: Icons.columns;
                         colorize: i == root.sub-tab ? Colors.text : Colors.subtext1;
                         image-fit: contain;
                     }
                     if i == 2 : Image {
-                        width: 14px;
-                        source: @image-url("../../../assets/icons/code.svg");
+                        width: Layout.icon-md;
+                        source: Icons.code;
                         colorize: i == root.sub-tab ? Colors.text : Colors.subtext1;
                         image-fit: contain;
                     }
@@ -106,7 +106,7 @@ export component TableView inherits Rectangle {
 
                 if i == root.sub-tab : Rectangle {
                     x: 0;
-                    y: 28px;
+                    y: Layout.height-tab-bar - 2px;
                     width: parent.width;
                     height: 2px;
                     background: Colors.blue;
@@ -118,9 +118,9 @@ export component TableView inherits Rectangle {
     // ── content area ──────────────────────────────────────────────────────────
     Rectangle {
         x: 0;
-        y: 32px;
+        y: Layout.height-tab-bar;
         width: parent.width;
-        height: parent.height - 32px;
+        height: parent.height - Layout.height-tab-bar;
 
         // Data sub-tab
         if root.sub-tab == 0 : ResultTable {
@@ -151,11 +151,11 @@ export component TableView inherits Rectangle {
 
             col-list := VerticalLayout {
                 Rectangle {
-                    height: 28px;
+                    height: Layout.height-row;
                     background: Colors.surface0;
 
                     HorizontalLayout {
-                        padding-left: 12px;
+                        padding-left: Layout.padding-md;
                         spacing: 0;
 
                         Text {
@@ -184,11 +184,11 @@ export component TableView inherits Rectangle {
                 }
 
                 for col[i] in root.structure-columns : Rectangle {
-                    height: 28px;
+                    height: Layout.height-row;
                     background: Math.mod(i, 2) == 0 ? Colors.base : Colors.mantle;
 
                     HorizontalLayout {
-                        padding-left: 12px;
+                        padding-left: Layout.padding-md;
                         spacing: 0;
 
                         Text {
@@ -241,11 +241,11 @@ export component TableView inherits Rectangle {
                 viewport-height: max(ddl-text-el.preferred-height + 16px, self.height);
 
                 ddl-text-el := Text {
-                    x: 12px; y: 8px;
-                    width: parent.width - 24px;
+                    x: Layout.padding-md; y: Layout.padding-sm;
+                    width: parent.width - Layout.padding-md * 2;
                     text: root.ddl-text;
                     color: Colors.text;
-                    font-family: "JetBrains Mono";
+                    font-family: Typography.font-mono;
                     font-size: root.ddl-font-size-px * 1px;
                     wrap: word-wrap;
                 }
@@ -255,16 +255,16 @@ export component TableView inherits Rectangle {
                 x: parent.width - 100px;
                 y: parent.height - 36px;
                 width: 88px;
-                height: 28px;
-                border-radius: 4px;
+                height: Layout.height-row;
+                border-radius: Layout.radius-md;
                 background: copy-ta.has-hover ? Colors.surface1 : Colors.surface0;
 
                 HorizontalLayout {
                     alignment: center;
-                    spacing: 5px;
+                    spacing: Layout.spacing-icon;
                     Image {
-                        width: 12px;
-                        source: @image-url("../../../assets/icons/copy.svg");
+                        width: Layout.icon-sm;
+                        source: Icons.copy;
                         colorize: Colors.text;
                         image-fit: contain;
                     }

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -50,4 +50,89 @@ export global Typography {
     out property <length> size-lg:  13px;
     out property <length> size-xl:  15px;
     out property <length> size-2xl: 16px;
+    // Font family tokens — update values here when #228 adds per-platform switching.
+    out property <string> font-ui:   "Segoe UI";       // system UI font
+    out property <string> font-mono: "JetBrains Mono"; // monospace / code font
+}
+
+export global Layout {
+    // ── Heights: chrome bars ──────────────────────────────────────────────────
+    out property <length> height-bar:        28px;  // MenuBar, result toolbar strip
+    out property <length> height-tab-bar:    32px;  // TabBar
+    out property <length> height-compact:    24px;  // compact rows (filter banner, tab text area)
+
+    // ── Heights: content rows and inputs ─────────────────────────────────────
+    out property <length> height-row:         28px;  // data rows, form inputs, structure rows
+    out property <length> height-sidebar-row: 32px;  // sidebar tree row
+    out property <length> height-dialog-row:  48px;  // db_manager list rows
+    out property <length> height-footer:      44px;  // db_manager add-connection footer
+    out property <length> height-completion-item: 22px; // completion popup row
+
+    // ── Heights: buttons and menu items ───────────────────────────────────────
+    out property <length> height-menu-item: 30px;  // MenuItem dropdown row
+    out property <length> height-btn-sm:    20px;  // ToolbarButton (compact)
+    out property <length> height-btn-md:    26px;  // inline modal buttons (Edit, Connect)
+    out property <length> height-btn-lg:    32px;  // ActionButton, DbTypeButton
+
+    // ── Icon widths ───────────────────────────────────────────────────────────
+    out property <length> icon-xs:  10px;
+    out property <length> icon-sm:  12px;
+    out property <length> icon-md:  14px;
+    out property <length> icon-lg:  16px;
+    out property <length> icon-xl:  18px;
+
+    // ── Spacing (gap between siblings in a layout) ────────────────────────────
+    out property <length> spacing-xs:   2px;
+    out property <length> spacing-sm:   4px;
+    out property <length> spacing-md:   6px;
+    out property <length> spacing-lg:   8px;
+    out property <length> spacing-xl:  10px;   // form content gap
+    out property <length> spacing-2xl: 16px;   // dialog section gap
+    out property <length> spacing-btn:  3px;   // icon-to-label gap inside ToolbarButton
+    out property <length> spacing-icon: 5px;   // icon-to-label gap inside ActionButton
+
+    // ── Padding (inset from container edge) ───────────────────────────────────
+    out property <length> padding-xs:    4px;
+    out property <length> padding-sm:    8px;
+    out property <length> padding-md:   12px;
+    out property <length> padding-lg:   16px;
+    out property <length> padding-xl:   20px;
+    out property <length> padding-2xl:  24px;
+    out property <length> padding-tab:  10px;  // tab strip left edge
+    out property <length> padding-input: 6px;  // TextInput horizontal inset
+
+    // ── Border radius ─────────────────────────────────────────────────────────
+    out property <length> radius-sm: 3px;
+    out property <length> radius-md: 4px;
+    out property <length> radius-lg: 8px;
+
+    // ── Sidebar-specific ──────────────────────────────────────────────────────
+    out property <length> sidebar-indent: 14px;  // per-level indentation in tree
+}
+
+export global Icons {
+    out property <image> alert-error:      @image-url("../../assets/icons/alert-error.svg");
+    out property <image> brand-mysql:      @image-url("../../assets/icons/brand-mysql.svg");
+    out property <image> brand-postgresql: @image-url("../../assets/icons/brand-postgresql.svg");
+    out property <image> brand-sqlite:     @image-url("../../assets/icons/brand-sqlite.svg");
+    out property <image> chevron-down:     @image-url("../../assets/icons/chevron-down.svg");
+    out property <image> chevron-right:    @image-url("../../assets/icons/chevron-right.svg");
+    out property <image> close:            @image-url("../../assets/icons/close.svg");
+    out property <image> code:             @image-url("../../assets/icons/code.svg");
+    out property <image> columns:          @image-url("../../assets/icons/columns.svg");
+    out property <image> confirm:          @image-url("../../assets/icons/confirm.svg");
+    out property <image> copy:             @image-url("../../assets/icons/copy.svg");
+    out property <image> delete:           @image-url("../../assets/icons/delete.svg");
+    out property <image> dot-empty:        @image-url("../../assets/icons/dot-empty.svg");
+    out property <image> dot-filled:       @image-url("../../assets/icons/dot-filled.svg");
+    out property <image> edit:             @image-url("../../assets/icons/edit.svg");
+    out property <image> export:           @image-url("../../assets/icons/export.svg");
+    out property <image> link:             @image-url("../../assets/icons/link.svg");
+    out property <image> plus:             @image-url("../../assets/icons/plus.svg");
+    out property <image> sort-asc:         @image-url("../../assets/icons/sort-asc.svg");
+    out property <image> sort-desc:        @image-url("../../assets/icons/sort-desc.svg");
+    out property <image> sql-database:     @image-url("../../assets/icons/sql-database.svg");
+    out property <image> table-list:       @image-url("../../assets/icons/table-list.svg");
+    out property <image> test-connection:  @image-url("../../assets/icons/test-connection.svg");
+    out property <image> unlink:           @image-url("../../assets/icons/unlink.svg");
 }


### PR DESCRIPTION
## Summary

Establishes a global design token system in `theme.slint` to eliminate all hardcoded spacing, sizing, font strings, and SVG icon paths from Slint components. Any future visual change — row height, padding, icon swap — now requires editing a single file instead of hunting across 19 components.

## Changes

- **`theme.slint`**: Added `Layout` global (heights for bars/rows/buttons/dialogs, icon sizes, spacing, padding, border radii, sidebar indent), `Typography.font-ui` / `Typography.font-mono` string tokens, and `Icons` global with `out property <image>` for all 24 SVG assets
- **19 component files updated**: All hardcoded `px` values replaced with `Layout.*` tokens, `"Segoe UI"` / `"JetBrains Mono"` strings replaced with `Typography.font-ui` / `Typography.font-mono`, and all `@image-url("...assets/icons/xxx.svg")` calls replaced with `Icons.xxx`
- Depth-varying relative paths (`../../../` vs `../../../../`) across component subdirectories are fully eliminated — every component now uses the same `Icons.close`, `Icons.plus`, etc.

## Related Issues

Resolves #229

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes