### PR TITLE
fix(ui): reduce DB type button label font size from 15px to 13px

### DIFF
--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -123,7 +123,7 @@ component DbTypeButton inherits Rectangle {
         Text {
             text: label-text;
             color: active ? Colors.base : Colors.text;
-            font-size: Typography.size-xl;
+            font-size: Typography.size-lg;
             font-family: root.ui-font;
             vertical-alignment: center;
             wrap: no-wrap;


### PR DESCRIPTION
## Summary

The PostgreSQL / MySQL / SQLite toggle labels in the Add/Edit Connection modal were using `Typography.size-xl` (15px), which felt slightly oversized relative to the surrounding form controls. This reduces them to `Typography.size-lg` (13px) for better visual balance.

## Changes

- `connection_form.slint`: `DbTypeButton` label `font-size` changed from `Typography.size-xl` (15px) to `Typography.size-lg` (13px)

## Related Issues

N/A

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes