### PR TITLE
feat(safe-dml): intercept WHERE-less UPDATE/DELETE and show confirmation dialog

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -331,3 +331,19 @@ msgstr "YES"
 msgctxt "TableView"
 msgid "NO"
 msgstr "NO"
+
+msgctxt "SafeDmlDialog"
+msgid "No WHERE clause detected"
+msgstr "No WHERE clause detected"
+
+msgctxt "SafeDmlDialog"
+msgid "This UPDATE/DELETE has no WHERE clause and will affect all rows. Are you sure?"
+msgstr "This UPDATE/DELETE has no WHERE clause and will affect all rows. Are you sure?"
+
+msgctxt "SafeDmlDialog"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "SafeDmlDialog"
+msgid "Execute"
+msgstr "Execute"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -331,3 +331,19 @@ msgstr "YES"
 msgctxt "TableView"
 msgid "NO"
 msgstr "NO"
+
+msgctxt "SafeDmlDialog"
+msgid "No WHERE clause detected"
+msgstr "WHERE 句のない操作が検出されました"
+
+msgctxt "SafeDmlDialog"
+msgid "This UPDATE/DELETE has no WHERE clause and will affect all rows. Are you sure?"
+msgstr "この UPDATE/DELETE には WHERE 句がありません。全行が対象になります。実行しますか？"
+
+msgctxt "SafeDmlDialog"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "SafeDmlDialog"
+msgid "Execute"
+msgstr "実行"

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -74,9 +74,12 @@ impl SessionManager {
             .load()
             .context("failed to load config for session save")?;
 
-        let cc = db_to_config_conn(conn);
+        let mut cc = db_to_config_conn(conn);
         match config.connections.iter_mut().find(|c| c.id == conn.id) {
-            Some(existing) => *existing = cc,
+            Some(existing) => {
+                cc.safe_dml = existing.safe_dml; // preserve per-connection safe_dml setting
+                *existing = cc;
+            }
             None => config.connections.push(cc),
         }
         config.session.last_connection_id = Some(conn.id.clone());
@@ -327,6 +330,7 @@ fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
         user: conn.user.clone(),
         password_encrypted: conn.password_encrypted.clone(),
         database: conn.database.clone(),
+        safe_dml: true, // default; overwritten by save_connection when updating existing entry
     }
 }
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -21,6 +21,7 @@ import { TableView }       from "components/table_view.slint";
 import { TestResultDialog }    from "components/dialogs/test_result_dialog.slint";
 import { AddConnectionDialog } from "components/dialogs/add_connection_dialog.slint";
 import { AllRowsDialog }       from "components/dialogs/all_rows_dialog.slint";
+import { SafeDmlDialog }       from "components/dialogs/safe_dml_dialog.slint";
 import { DbManagerDialog }     from "components/dialogs/db_manager_dialog.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
@@ -140,6 +141,18 @@ export global UiState {
     callback confirm-all-rows();
     /// User dismissed the "fetch all rows" confirm popup.
     callback dismiss-all-rows-confirm();
+    /// Controls the "dangerous DML" confirmation popup.
+    in-out property <bool>   show-safe-dml-confirm:  false;
+    /// SQL to execute if the user confirms.
+    in-out property <string> safe-dml-pending-sql:   "";
+    /// Command kind: "query" | "all" | "cursor"
+    in-out property <string> safe-dml-pending-kind:  "query";
+    /// Active connection safe_dml setting (set by Rust on connect).
+    in-out property <bool>   conn-safe-dml: true;
+    /// User confirmed dangerous DML execution.
+    callback confirm-safe-dml();
+    /// User dismissed the dangerous DML confirm popup.
+    callback dismiss-safe-dml-confirm();
 
     // ── Completion ────────────────────────────────────────────────────────────
     /// Fired by the editor on every user text edit; Rust debounces 300 ms then
@@ -335,7 +348,8 @@ export component AppWindow inherits Window {
                     || UiState.show-db-manager
                     || UiState.show-test-result-popup
                     || UiState.show-add-confirm-popup
-                    || UiState.show-all-rows-confirm) {
+                    || UiState.show-all-rows-confirm
+                    || UiState.show-safe-dml-confirm) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -877,6 +891,14 @@ export component AppWindow inherits Window {
             width: root.width; height: root.height;
             cancel-clicked => { UiState.dismiss-all-rows-confirm(); }
             fetch-clicked  => { UiState.confirm-all-rows(); }
+        }
+
+        // ── Safe-DML confirmation popup ───────────────────────────────────────
+        if UiState.show-safe-dml-confirm: SafeDmlDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            cancel-clicked  => { UiState.dismiss-safe-dml-confirm(); }
+            execute-clicked => { UiState.confirm-safe-dml(); }
         }
 
         // ── DB manager dialog ─────────────────────────────────────────────────

--- a/app/src/ui/components/dialogs/safe_dml_dialog.slint
+++ b/app/src/ui/components/dialogs/safe_dml_dialog.slint
@@ -1,0 +1,44 @@
+import { Colors, Typography, Layout } from "../../theme.slint";
+import { ActionButton, ModalOverlay } from "../common.slint";
+
+export component SafeDmlDialog inherits ModalOverlay {
+    callback cancel-clicked;
+    callback execute-clicked;
+
+    VerticalLayout {
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-2xl;
+        alignment: start;
+
+        Text {
+            text: @tr("No WHERE clause detected");
+            color: Colors.yellow;
+            font-size: Typography.size-xl;
+            font-weight: 700;
+        }
+
+        Text {
+            text: @tr("This UPDATE/DELETE has no WHERE clause and will affect all rows. Are you sure?");
+            color: Colors.text;
+            font-size: Typography.size-lg;
+            wrap: word-wrap;
+        }
+
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: end;
+            ActionButton {
+                width: 80px;
+                text: @tr("Cancel");
+                clicked => { root.cancel-clicked(); }
+            }
+            ActionButton {
+                width: 80px;
+                text: @tr("Execute");
+                bg: Colors.red;
+                fg: Colors.base;
+                clicked => { root.execute-clicked(); }
+            }
+        }
+    }
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use wf_completion::CompletionItem;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
-use wf_query::analyzer::extract_statement_at;
+use wf_query::analyzer::{extract_statement_at, has_dangerous_dml};
 
 const COMPLETION_DEBOUNCE_MS: u64 = 300;
 const ERROR_TRUNCATION_CHARS: usize = 80;
@@ -45,6 +45,25 @@ fn set_status(weak: slint::Weak<crate::AppWindow>, msg: String) {
     let _ = slint::invoke_from_event_loop(move || {
         with_ui(&weak, |ui| ui.set_status_message(msg.into()));
     });
+}
+
+/// Returns true if a safe-DML warning was shown (caller should return early).
+/// Reads conn-safe-dml from UiState; if enabled and SQL is dangerous, shows dialog.
+fn check_safe_dml(weak: &slint::Weak<crate::AppWindow>, sql: &str, kind: &str) -> bool {
+    let Some(w) = weak.upgrade() else {
+        return false;
+    };
+    let ui = w.global::<crate::UiState>();
+    if !ui.get_conn_safe_dml() {
+        return false;
+    }
+    if !has_dangerous_dml(sql) {
+        return false;
+    }
+    ui.set_safe_dml_pending_sql(sql.into());
+    ui.set_safe_dml_pending_kind(kind.into());
+    ui.set_show_safe_dml_confirm(true);
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -507,12 +526,23 @@ impl UI {
             let connections = state.conn.all();
             build_sidebar_tree(&connections, &id, &sb.metadata, &sb.expanded)
         };
+        let safe_dml = wf_config::manager::ConfigManager::new()
+            .load()
+            .ok()
+            .and_then(|cfg| {
+                cfg.connections
+                    .iter()
+                    .find(|c| c.id == id)
+                    .map(|c| c.safe_dml)
+            })
+            .unwrap_or(true);
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, move |ui| {
                 let model = Rc::new(slint::VecModel::from(entries));
                 ui.set_connection_list(model.into());
                 ui.set_active_connection_id(id.into());
+                ui.set_conn_safe_dml(safe_dml);
                 ui.set_show_connection_form(false);
                 // Reopen the DB manager if the form was launched from within it.
                 if ui.get_reopen_db_manager_on_form_close() {
@@ -1228,7 +1258,11 @@ impl UI {
         // run-all: execute the entire editor content
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let window_weak = window.as_weak(); // clone required: check_safe_dml needs window ref
             ui.on_run_all(move |sql| {
+                if check_safe_dml(&window_weak, &sql, "all") {
+                    return;
+                }
                 send_cmd(&tx_cmd, Command::RunAll(sql.to_string()));
             });
         }
@@ -1734,15 +1768,23 @@ impl UI {
 
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let window_weak = window.as_weak(); // clone required: check_safe_dml needs window ref
             ui.on_run_query(move |sql| {
+                if check_safe_dml(&window_weak, &sql, "query") {
+                    return;
+                }
                 send_cmd(&tx_cmd, Command::RunQuery(sql.to_string()));
             });
         }
         {
             let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
+            let window_weak = window.as_weak(); // clone required: check_safe_dml needs window ref
             ui.on_run_query_at_cursor(move |sql, cursor| {
                 let stmt = extract_statement_at(sql.as_str(), cursor as usize);
                 if !stmt.is_empty() {
+                    if check_safe_dml(&window_weak, stmt, "cursor") {
+                        return;
+                    }
                     send_cmd(&tx_cmd, Command::RunQuery(stmt.to_owned()));
                 }
             });
@@ -2221,6 +2263,38 @@ impl UI {
             let window_weak = window_weak.clone();
             ui_state.on_dismiss_all_rows_confirm(move || {
                 with_ui(&window_weak, |ui| ui.set_show_all_rows_confirm(false));
+            });
+        }
+
+        // confirm-safe-dml: user confirmed execution of dangerous DML.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            let tx_cmd = tx_cmd.clone();
+            ui_state.on_confirm_safe_dml(move || {
+                with_ui(&window_weak, |ui| {
+                    let sql = ui.get_safe_dml_pending_sql().to_string();
+                    let kind = ui.get_safe_dml_pending_kind().to_string();
+                    ui.set_show_safe_dml_confirm(false);
+                    ui.set_safe_dml_pending_sql("".into());
+                    let cmd = match kind.as_str() {
+                        "all" => Command::RunAll(sql),
+                        _ => Command::RunQuery(sql),
+                    };
+                    send_cmd(&tx_cmd, cmd);
+                });
+            });
+        }
+
+        // dismiss-safe-dml-confirm: user cancelled the dangerous DML popup.
+        {
+            // clone required: callback closure must be 'static
+            let window_weak = window_weak.clone();
+            ui_state.on_dismiss_safe_dml_confirm(move || {
+                with_ui(&window_weak, |ui| {
+                    ui.set_show_safe_dml_confirm(false);
+                    ui.set_safe_dml_pending_sql("".into());
+                });
             });
         }
 

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -149,6 +149,7 @@ mod tests {
                 user: None,
                 password_encrypted: None,
                 database: Some("local.db".to_string()),
+                safe_dml: true,
             }],
             ..Config::default()
         };

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -152,6 +152,13 @@ pub struct ConnectionConfig {
     pub password_encrypted: Option<String>,
     #[serde(default)]
     pub database: Option<String>,
+    /// When true, UPDATE/DELETE without WHERE shows a confirmation dialog.
+    #[serde(default = "default_safe_dml")]
+    pub safe_dml: bool,
+}
+
+fn default_safe_dml() -> bool {
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +320,7 @@ database = "local.db"
                 user: Some("root".to_string()),
                 password_encrypted: Some("AES256GCM:xyz".to_string()),
                 database: Some("testdb".to_string()),
+                safe_dml: false,
             }],
         };
 

--- a/crates/wf-query/src/analyzer.rs
+++ b/crates/wf-query/src/analyzer.rs
@@ -46,6 +46,17 @@ pub fn extract_all_statements(sql: &str) -> Vec<&str> {
         .collect()
 }
 
+/// Returns `true` if `sql` contains an UPDATE or DELETE statement with no WHERE clause.
+///
+/// Checks all semicolon-separated statements. Intended to guard against accidental
+/// full-table modifications when `safe_dml` is enabled on a connection.
+pub fn has_dangerous_dml(sql: &str) -> bool {
+    extract_all_statements(sql).iter().any(|stmt| {
+        let upper = stmt.to_uppercase();
+        (upper.starts_with("UPDATE ") || upper.starts_with("DELETE ")) && !upper.contains(" WHERE ")
+    })
+}
+
 /// Returns the substring of `sql` for the byte range `start..end`.
 ///
 /// The range is clamped to valid string boundaries.  If `start > end`
@@ -139,6 +150,60 @@ mod tests {
         let sql = "SELECT 1;\nSELECT 2;\n";
         assert_eq!(extract_statement_at(sql, 19), "SELECT 2");
         assert_eq!(extract_statement_at(sql, 20), "SELECT 2");
+    }
+
+    // ── has_dangerous_dml ────────────────────────────────────────────────────
+
+    #[test]
+    fn has_dangerous_dml_should_return_true_for_update_without_where() {
+        assert!(has_dangerous_dml("UPDATE users SET name = 'x'"));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_return_true_for_delete_without_where() {
+        assert!(has_dangerous_dml("DELETE FROM orders"));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_return_false_when_where_is_present() {
+        assert!(!has_dangerous_dml(
+            "UPDATE users SET name = 'x' WHERE id = 1"
+        ));
+        assert!(!has_dangerous_dml("DELETE FROM orders WHERE id = 42"));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_be_case_insensitive() {
+        assert!(has_dangerous_dml("update users set name = 'x'"));
+        assert!(has_dangerous_dml("delete from orders"));
+        assert!(!has_dangerous_dml(
+            "update users set name = 'x' where id = 1"
+        ));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_return_false_for_select() {
+        assert!(!has_dangerous_dml("SELECT * FROM users"));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_return_false_for_truncate() {
+        assert!(!has_dangerous_dml("TRUNCATE users"));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_detect_dangerous_stmt_in_multi_statement_sql() {
+        let sql = "SELECT 1; UPDATE users SET name = 'x'; SELECT 2";
+        assert!(has_dangerous_dml(sql));
+        let safe = "SELECT 1; UPDATE users SET name = 'x' WHERE id = 1; SELECT 2";
+        assert!(!has_dangerous_dml(safe));
+    }
+
+    #[test]
+    fn has_dangerous_dml_should_return_false_for_delete_from_without_where_when_keyword_is_embedded()
+     {
+        // "NOWHERE" or similar embedded strings must not be treated as WHERE
+        assert!(has_dangerous_dml("DELETE FROM nowhere_table"));
     }
 
     // ── extract_selection ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements safe DML mode (T082): when a connection has `safe_dml` enabled (default `true`), any UPDATE or DELETE without a WHERE clause triggers a confirmation dialog before execution. This prevents accidental full-table modifications.

## Changes

- `crates/wf-config/src/models.rs` — added `safe_dml: bool` field (serde default `true`) to `ConnectionConfig`
- `crates/wf-query/src/analyzer.rs` — added `has_dangerous_dml(sql)` function + 8 unit tests covering UPDATE/DELETE with and without WHERE, case-insensitivity, multi-statement SQL, SELECT, and TRUNCATE
- `app/src/ui/components/dialogs/safe_dml_dialog.slint` — new confirmation dialog following the `AllRowsDialog` pattern
- `app/src/ui/app.slint` — added `show-safe-dml-confirm`, `safe-dml-pending-sql`, `safe-dml-pending-kind`, `conn-safe-dml` properties and `confirm-safe-dml` / `dismiss-safe-dml-confirm` callbacks to UiState; added conditional render of `SafeDmlDialog`; added guard to root FocusScope shortcuts
- `app/src/ui/mod.rs` — added `check_safe_dml()` helper; intercepted `on_run_query`, `on_run_query_at_cursor`, and `on_run_all`; registered confirm/dismiss callbacks; set `conn-safe-dml` in `handle_connected` by reading the connection's config value
- `app/src/app/session.rs` — `save_connection` preserves the existing `safe_dml` value when updating a connection
- `app/lang/en/LC_MESSAGES/wellfeather.po` / `app/lang/ja/LC_MESSAGES/wellfeather.po` — added `SafeDmlDialog` translation strings

## Related Issues

Closes #197

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes