### PR TITLE
refactor(wf-config): migrate connection storage from config.toml to SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6810,9 +6810,12 @@ dependencies = [
  "directories",
  "rand 0.10.0",
  "serde",
+ "sqlx",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "uuid",
 ]
 

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use wf_config::models::{ConnectionConfig, PageSize, Theme};
+use wf_config::models::{PageSize, Theme};
 use wf_db::models::DbConnection;
 
 /// Format for result export.
@@ -18,7 +18,6 @@ pub enum ConfigUpdate {
     FontFamily(String),
     FontSize(u32),
     Language(String),
-    Connection(ConnectionConfig),
     /// Update only safe_dml / read_only flags for an existing connection entry.
     ConnectionFlags {
         id: String,

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -13,7 +13,7 @@
 //! Both channels are bounded (`capacity = CMD_CHANNEL_CAPACITY`). The controller task exits cleanly
 //! when all `Sender<Command>` clones are dropped (i.e. when the UI window closes).
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use chrono::Utc;
 use rust_i18n::t;
@@ -21,7 +21,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use wf_completion::{cache::MetadataCache, service::CompletionService};
-use wf_config::manager::ConfigManager;
+use wf_config::ConnectionRepository;
 use wf_db::{
     error::DbError,
     models::{DbConnection, DbType},
@@ -34,7 +34,7 @@ use crate::{
         LocalizedMessage,
         command::{Command, ConfigUpdate},
         event::{Event, StateEvent},
-        session::SessionManager,
+        session::{SessionManager, db_to_config_conn},
     },
     state::SharedState,
 };
@@ -50,6 +50,7 @@ pub struct AppController {
     state: SharedState,
     db: DbService,
     session: SessionManager,
+    repo: Arc<ConnectionRepository>,
     /// Path to `history.db`; opened asynchronously at the start of `run()`.
     history_path: PathBuf,
     /// `None` until `run()` opens the database; failures are non-fatal (logged).
@@ -75,6 +76,7 @@ impl AppController {
         state: SharedState,
         db: DbService,
         session: SessionManager,
+        repo: Arc<ConnectionRepository>,
         history_path: PathBuf,
         metadata_cache_path: PathBuf,
     ) -> (Self, mpsc::Sender<Command>, mpsc::Receiver<Event>) {
@@ -85,6 +87,7 @@ impl AppController {
                 state,
                 db,
                 session,
+                repo,
                 history_path,
                 history: None,
                 metadata_cache_path,
@@ -170,11 +173,15 @@ impl AppController {
         info!(conn_id = %id, "handling Connect command");
         match self.db.connect(&conn, password.as_deref()).await {
             Ok(()) => {
-                // persist session so we can auto-reconnect on next launch
-                if let Err(e) = self.session.save_connection(&conn) {
-                    warn!(conn_id = %id, error = %e, "failed to save session");
+                // Persist to repository so we can auto-reconnect on next launch.
+                let conn_cfg = db_to_config_conn(&conn);
+                if let Err(e) = self.repo.upsert(&conn_cfg).await {
+                    warn!(conn_id = %id, error = %e, "failed to upsert connection");
                 }
-                // Add or update the connection in the saved list.
+                if let Err(e) = self.repo.touch_last_used(&id).await {
+                    warn!(conn_id = %id, error = %e, "failed to touch last_used");
+                }
+                // Add or update the connection in the runtime list.
                 let already_saved = self.state.conn.all().iter().any(|c| c.id == id);
                 if already_saved {
                     self.state.conn.update(conn);
@@ -183,7 +190,22 @@ impl AppController {
                 }
                 self.state.conn.set_active(&id);
                 info!(conn_id = %id, "connected successfully");
-                let _ = self.tx_event.send(Event::Connected(id.clone())).await;
+                // Load the full list from the repo so the UI can show all saved connections.
+                let connections = self.repo.all().await.unwrap_or_default();
+                let (safe_dml, read_only) = connections
+                    .iter()
+                    .find(|c| c.id == id)
+                    .map(|c| (c.safe_dml, c.read_only))
+                    .unwrap_or((true, false));
+                let _ = self
+                    .tx_event
+                    .send(Event::Connected {
+                        id: id.clone(),
+                        connections,
+                        safe_dml,
+                        read_only,
+                    })
+                    .await;
 
                 let db = self.db.clone(); // clone required: tokio::spawn needs 'static
                 let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
@@ -258,8 +280,8 @@ impl AppController {
         info!(conn_id = %id, "handling RemoveConnection command");
         self.db.disconnect(&id);
         self.state.conn.remove(&id);
-        if let Err(e) = self.session.remove_connection(&id) {
-            warn!(conn_id = %id, error = %e, "failed to remove connection from config");
+        if let Err(e) = self.repo.delete(&id).await {
+            warn!(conn_id = %id, error = %e, "failed to delete connection from repo");
         }
         let _ = self.tx_event.send(Event::ConnectionRemoved(id)).await;
     }
@@ -503,20 +525,8 @@ impl AppController {
                 safe_dml,
                 read_only,
             } => {
-                let cm = ConfigManager::new();
-                match cm.load() {
-                    Ok(mut config) => {
-                        if let Some(entry) = config.connections.iter_mut().find(|c| c.id == id) {
-                            entry.safe_dml = safe_dml;
-                            entry.read_only = read_only;
-                            if let Err(e) = cm.save(&config) {
-                                warn!(error = %e, "failed to persist connection flags to config");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "failed to load config for connection flags update")
-                    }
+                if let Err(e) = self.repo.update_flags(&id, safe_dml, read_only).await {
+                    warn!(error = %e, "failed to update connection flags in repo");
                 }
                 let _ = self
                     .tx_event
@@ -630,15 +640,13 @@ impl AppController {
     /// When `true`, sends `Event::QueryError` with a localized "blocked" message so the
     /// caller can return early without executing the query.
     async fn is_read_only_blocked(&self, conn_id: &str, sql: &str) -> bool {
-        let read_only = ConfigManager::new()
-            .load()
+        let read_only = self
+            .repo
+            .find(conn_id)
+            .await
             .ok()
-            .and_then(|cfg| {
-                cfg.connections
-                    .iter()
-                    .find(|c| c.id == conn_id)
-                    .map(|c| c.read_only)
-            })
+            .flatten()
+            .map(|c| c.read_only)
             .unwrap_or(false);
         if read_only && wf_query::analyzer::is_write_statement(sql) {
             warn!(conn_id = %conn_id, "RunQuery blocked: connection is read-only");
@@ -683,7 +691,7 @@ mod tests {
     use std::{path::PathBuf, sync::Arc};
 
     use tempfile::tempdir;
-    use wf_config::manager::ConfigManager;
+    use wf_config::{ConnectionRepository, manager::ConfigManager};
     use wf_db::{
         models::{DbConnection, DbType},
         service::DbService,
@@ -702,6 +710,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.keep().join("config.toml");
         SessionManager::with_config_manager(ConfigManager::with_path(path))
+    }
+
+    async fn test_repo() -> Arc<ConnectionRepository> {
+        Arc::new(ConnectionRepository::open_memory().await.unwrap())
     }
 
     /// Return a path to a temporary `history.db` (file created lazily by the controller).
@@ -795,6 +807,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -809,7 +822,6 @@ mod tests {
 
         let event = rx_event.recv().await.expect("expected event");
         assert!(matches!(event, Event::TestConnectionOk));
-        // Must NOT be added to state
         assert!(state.conn.all().is_empty(), "test conn should not be saved");
     }
 
@@ -821,6 +833,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -860,6 +873,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -868,12 +882,12 @@ mod tests {
             .send(Command::Connect(sqlite_conn("c1"), None))
             .await
             .unwrap();
-        drop(tx_cmd); // close channel → run() exits after processing
+        drop(tx_cmd);
 
         controller.run().await;
 
         let event = rx_event.recv().await.expect("expected event");
-        assert!(matches!(event, Event::Connected(ref id) if id == "c1"));
+        assert!(matches!(event, Event::Connected { ref id, .. } if id == "c1"));
         assert!(state.conn.active().is_some());
     }
 
@@ -885,6 +899,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -917,6 +932,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -934,7 +950,7 @@ mod tests {
         tokio::spawn(controller.run());
 
         let e1 = rx_event.recv().await.unwrap();
-        assert!(matches!(e1, Event::Connected(_)));
+        assert!(matches!(e1, Event::Connected { .. }));
         // Drain any MetadataLoaded/MetadataFetchFailed from the background fetch.
         let e2 = loop {
             match rx_event.recv().await.unwrap() {
@@ -955,11 +971,11 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
 
-        // Connect first so there is an active connection.
         tx_cmd
             .send(Command::Connect(sqlite_conn("q1"), None))
             .await
@@ -973,8 +989,7 @@ mod tests {
         tokio::spawn(controller.run());
 
         let e1 = rx_event.recv().await.unwrap();
-        assert!(matches!(e1, Event::Connected(_)));
-        // Drain any MetadataLoaded/MetadataFetchFailed before QueryStarted.
+        assert!(matches!(e1, Event::Connected { .. }));
         let e2 = loop {
             match rx_event.recv().await.unwrap() {
                 Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => continue,
@@ -982,7 +997,6 @@ mod tests {
             }
         };
         assert!(matches!(e2, Event::QueryStarted));
-        // Drain any late MetadataLoaded/MetadataFetchFailed before QueryFinished.
         let e3 = loop {
             match rx_event.recv().await.unwrap() {
                 Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => continue,
@@ -1000,6 +1014,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -1024,6 +1039,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -1045,6 +1061,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -1058,7 +1075,7 @@ mod tests {
         tokio::spawn(controller.run());
 
         let e1 = rx_event.recv().await.unwrap();
-        assert!(matches!(e1, Event::Connected(_)));
+        assert!(matches!(e1, Event::Connected { .. }));
         let e2 = rx_event.recv().await.unwrap();
         assert!(
             matches!(
@@ -1077,6 +1094,7 @@ mod tests {
             state.clone(),
             db,
             test_session(),
+            test_repo().await,
             test_history_path(),
             test_metadata_path(),
         );
@@ -1093,11 +1111,10 @@ mod tests {
 
         tokio::spawn(controller.run());
 
-        // Drain the 2 Connected events plus any MetadataLoaded/MetadataFetchFailed events.
         let mut connected_count = 0;
         while connected_count < 2 {
             match rx_event.recv().await.unwrap() {
-                Event::Connected(_) => connected_count += 1,
+                Event::Connected { .. } => connected_count += 1,
                 Event::MetadataLoaded(_, _) | Event::MetadataFetchFailed(_) => {}
                 _ => {}
             }

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -1,5 +1,5 @@
 use wf_completion::CompletionItem;
-use wf_config::models::Theme;
+use wf_config::models::{ConnectionConfig, Theme};
 use wf_db::models::{DbMetadata, QueryResult};
 
 /// Fine-grained state transitions forwarded to the UI via `StateChanged`.
@@ -15,7 +15,13 @@ pub enum StateEvent {
 /// Controller → UI channel messages.
 #[derive(Debug)]
 pub enum Event {
-    Connected(String), // connection_id
+    Connected {
+        id: String,
+        /// Full list of all saved connections at connect time.
+        connections: Vec<ConnectionConfig>,
+        safe_dml: bool,
+        read_only: bool,
+    },
     Disconnected(String),
     ConnectionRemoved(String), // connection_id — deleted from config
     /// Fired when `Command::Connect` fails. Distinct from `QueryError` so the UI

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -1,18 +1,17 @@
-//! Session persistence for the last active database connection.
+//! Session persistence helpers.
 //!
-//! [`SessionManager`] wraps [`ConfigManager`] and provides two operations:
+//! [`SessionManager`] wraps [`ConfigManager`] and persists editor/tab state,
+//! page size, language, and theme settings to `config.toml`.
 //!
-//! - [`SessionManager::save_connection`] — called after every successful connect to
-//!   upsert the connection entry and record it as `last_connection_id` in `config.toml`.
-//! - [`SessionManager::restore`] — called at startup to retrieve the connection that was
-//!   active when the app last closed, enabling automatic reconnect.
+//! Connection persistence (CRUD + last-used tracking) has moved to
+//! [`wf_config::ConnectionRepository`] (SQLite-backed).
 //!
 //! Conversion between `wf_db::models::DbConnection` and `wf_config::models::ConnectionConfig`
 //! lives here because `app/` is the only crate that depends on both.
 
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tracing::info;
 use wf_config::{
     manager::ConfigManager,
     models::{ConnectionConfig, DbTypeName, PageSize, Theme},
@@ -57,59 +56,6 @@ impl SessionManager {
     /// Primarily used in tests to point at a temporary directory.
     pub fn with_config_manager(cm: ConfigManager) -> Self {
         Self { config_manager: cm }
-    }
-
-    /// Persist `conn` as the last active connection.
-    ///
-    /// Upserts the connection entry in `config.connections` (matched by `id`)
-    /// and sets `config.session.last_connection_id`. The config file is then
-    /// saved atomically.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the config file cannot be loaded or written.
-    pub fn save_connection(&self, conn: &DbConnection) -> anyhow::Result<()> {
-        let mut config = self
-            .config_manager
-            .load()
-            .context("failed to load config for session save")?;
-
-        let mut cc = db_to_config_conn(conn);
-        match config.connections.iter_mut().find(|c| c.id == conn.id) {
-            Some(existing) => {
-                cc.safe_dml = existing.safe_dml; // preserve per-connection safe_dml setting
-                cc.read_only = existing.read_only; // preserve per-connection read_only setting
-                *existing = cc;
-            }
-            None => config.connections.push(cc),
-        }
-        config.session.last_connection_id = Some(conn.id.clone());
-
-        self.config_manager
-            .save(&config)
-            .context("failed to save session")?;
-        info!(conn_id = %conn.id, "session saved");
-        Ok(())
-    }
-
-    /// Remove the connection with `id` from `config.connections`.
-    ///
-    /// If `last_connection_id` matches the removed connection it is cleared.
-    /// No-op if no connection with that id is found.
-    pub fn remove_connection(&self, id: &str) -> anyhow::Result<()> {
-        let mut config = self
-            .config_manager
-            .load()
-            .context("failed to load config for connection removal")?;
-        config.connections.retain(|c| c.id != id);
-        if config.session.last_connection_id.as_deref() == Some(id) {
-            config.session.last_connection_id = None;
-        }
-        self.config_manager
-            .save(&config)
-            .context("failed to save config after connection removal")?;
-        info!(conn_id = %id, "connection removed from config");
-        Ok(())
     }
 
     /// Persist `size` (100 / 500 / 1000) as `[editor].page_size` in `config.toml`.
@@ -251,41 +197,6 @@ impl SessionManager {
         info!(count = file.tabs.len(), "tabs.toml restored");
         Ok(Some((file.active_index, file.tabs)))
     }
-
-    /// Load the last session and return the connection to auto-connect to.
-    ///
-    /// Returns `Ok(None)` when:
-    /// - no config file exists yet, or
-    /// - `last_connection_id` is not set, or
-    /// - the recorded id has no matching entry in `config.connections`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the config file exists but cannot be parsed.
-    pub fn restore(&self) -> anyhow::Result<Option<DbConnection>> {
-        let config = self
-            .config_manager
-            .load()
-            .context("failed to load config for session restore")?;
-
-        let Some(last_id) = &config.session.last_connection_id else {
-            return Ok(None);
-        };
-
-        let conn = config
-            .connections
-            .iter()
-            .find(|c| &c.id == last_id)
-            .map(config_to_db_conn);
-
-        if conn.is_some() {
-            info!(conn_id = %last_id, "session restore: found connection");
-        } else {
-            warn!(conn_id = %last_id, "session restore: id not found in connections list");
-        }
-
-        Ok(conn)
-    }
 }
 
 impl Default for SessionManager {
@@ -297,7 +208,7 @@ impl Default for SessionManager {
 // ── Conversion helpers (only in app/ — sees both wf-config and wf-db) ────────
 
 /// Convert a stored [`ConnectionConfig`] to the runtime [`DbConnection`] model.
-fn config_to_db_conn(cc: &ConnectionConfig) -> DbConnection {
+pub(crate) fn config_to_db_conn(cc: &ConnectionConfig) -> DbConnection {
     DbConnection {
         id: cc.id.clone(),
         name: cc.name.clone(),
@@ -316,7 +227,7 @@ fn config_to_db_conn(cc: &ConnectionConfig) -> DbConnection {
 }
 
 /// Convert a runtime [`DbConnection`] to the storable [`ConnectionConfig`] model.
-fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
+pub(crate) fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
     ConnectionConfig {
         id: conn.id.clone(),
         name: conn.name.clone(),
@@ -342,74 +253,8 @@ fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
 mod tests {
     use tempfile::tempdir;
     use wf_config::manager::ConfigManager;
-    use wf_db::models::{DbConnection, DbType};
 
     use super::SessionManager;
-
-    fn sqlite_conn(id: &str) -> DbConnection {
-        DbConnection {
-            id: id.to_string(),
-            name: id.to_string(),
-            db_type: DbType::SQLite,
-            connection_string: Some("sqlite::memory:".to_string()),
-            host: None,
-            port: None,
-            user: None,
-            password_encrypted: None,
-            database: None,
-        }
-    }
-
-    #[test]
-    fn restore_should_return_none_when_config_absent() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        assert!(sm.restore().unwrap().is_none());
-    }
-
-    #[test]
-    fn save_connection_should_persist_last_connection_id() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        sm.save_connection(&sqlite_conn("c1")).unwrap();
-
-        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
-            .load()
-            .unwrap();
-        assert_eq!(cfg.session.last_connection_id, Some("c1".to_string()));
-        assert_eq!(cfg.connections.len(), 1);
-        assert_eq!(cfg.connections[0].id, "c1");
-    }
-
-    #[test]
-    fn restore_should_return_connection_when_id_exists() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        sm.save_connection(&sqlite_conn("c2")).unwrap();
-
-        let restored = sm.restore().unwrap().expect("should restore connection");
-        assert_eq!(restored.id, "c2");
-        assert_eq!(restored.db_type, DbType::SQLite);
-    }
-
-    #[test]
-    fn restore_should_return_none_when_id_not_in_connections() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        // Write a config with a last_connection_id but no matching connection entry
-        let mut cfg = wf_config::models::Config::default();
-        cfg.session.last_connection_id = Some("ghost".to_string());
-        ConfigManager::with_path(path.clone()).save(&cfg).unwrap();
-
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(path));
-        assert!(sm.restore().unwrap().is_none());
-    }
 
     #[test]
     fn save_page_size_should_persist_to_config() {
@@ -424,22 +269,6 @@ mod tests {
             .unwrap();
         use wf_config::models::PageSize;
         assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
-    }
-
-    #[test]
-    fn save_connection_should_upsert_not_duplicate() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        // Save same id twice
-        sm.save_connection(&sqlite_conn("c3")).unwrap();
-        sm.save_connection(&sqlite_conn("c3")).unwrap();
-
-        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
-            .load()
-            .unwrap();
-        assert_eq!(cfg.connections.len(), 1, "should not duplicate");
     }
 
     #[test]
@@ -490,22 +319,5 @@ mod tests {
             dir.path().join("config.toml"),
         ));
         assert!(sm.restore_tabs().unwrap().is_none());
-    }
-
-    #[test]
-    fn save_query_file_should_not_affect_config_toml() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        sm.save_connection(&sqlite_conn("c1")).unwrap();
-        sm.save_query_file("SELECT 2").unwrap();
-
-        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
-            .load()
-            .unwrap();
-        assert_eq!(cfg.session.last_connection_id, Some("c1".to_string()));
-        assert_eq!(cfg.session.last_query, None);
-        assert_eq!(cfg.connections.len(), 1);
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -24,10 +24,13 @@ mod ui;
 
 use std::sync::Arc;
 
-use app::{controller::AppController, session::SessionManager};
+use app::{
+    controller::AppController,
+    session::{SessionManager, config_to_db_conn},
+};
 use state::AppState;
 use ui::UI;
-use wf_config::{crypto, manager::ConfigManager};
+use wf_config::{ConnectionRepository, crypto, manager::ConfigManager};
 use wf_db::service::DbService;
 
 /// Entry point. Runs on the main OS thread; the Slint event loop must stay here.
@@ -60,23 +63,31 @@ fn main() -> anyhow::Result<()> {
         state.ui.set_theme(config.appearance.theme);
     }
 
+    // Open the connection repository, migrating from config.toml if it is the first launch.
+    let repo: Arc<ConnectionRepository> =
+        Arc::new(runtime.block_on(ConnectionRepository::open_with_migration(
+            &ConfigManager::app_dir().join("connections.db"),
+            &ConfigManager::new(),
+        ))?);
+
+    // Load all saved connections for the initial sidebar/DB-manager list.
+    let initial_connections = runtime.block_on(repo.all()).unwrap_or_default();
+
+    // Find the most-recently-used connection for auto-connect.
+    let restore_conn = runtime
+        .block_on(repo.last_used())
+        .ok()
+        .flatten()
+        .map(|cc| config_to_db_conn(&cc));
+
     let db = DbService::new();
-
     let session = SessionManager::new();
-
-    // Attempt to restore the last session before the event loop starts.
-    let restore_conn = match session.restore() {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!("session restore failed: {e}");
-            None
-        }
-    };
 
     let (controller, tx_cmd, rx_event) = AppController::new(
         state.clone(),
         db,
         session,
+        repo,
         ConfigManager::app_dir().join("history.db"),
         ConfigManager::app_dir().join("metadata.db"),
     );
@@ -98,6 +109,6 @@ fn main() -> anyhow::Result<()> {
         });
     }
 
-    let ui = UI::new(state, tx_cmd, rx_event, enc_key)?;
+    let ui = UI::new(state, tx_cmd, rx_event, enc_key, initial_connections)?;
     ui.run()
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -81,13 +81,13 @@ struct OriginalQueryData {
 
 type SharedOriginalData = Arc<Mutex<Option<OriginalQueryData>>>;
 
-use wf_config::models::Theme;
+use wf_config::models::{ConnectionConfig, DbTypeName, Theme};
 
 use crate::{
     app::{
         command::{Command, ConfigUpdate},
         event::{Event, StateEvent},
-        session::SessionManager,
+        session::{SessionManager, config_to_db_conn},
     },
     state::SharedState,
 };
@@ -101,24 +101,27 @@ struct SidebarUiState {
     metadata: HashMap<String, DbMetadata>,
     expanded: HashSet<String>,
     read_only: HashMap<String, bool>,
+    /// All saved connections (from ConnectionRepository). Used to build the
+    /// sidebar and DB manager list even when no DB is running.
+    config_connections: Vec<ConnectionConfig>,
 }
 
 fn build_sidebar_tree(
-    connections: &[DbConnection],
+    config_conns: &[ConnectionConfig],
     active_id: &str,
     metadata: &HashMap<String, DbMetadata>,
     expanded: &HashSet<String>,
     read_only: &HashMap<String, bool>,
 ) -> Vec<crate::SidebarNode> {
     let mut nodes = vec![];
-    for conn in connections {
+    for conn in config_conns {
         let conn_node_id = format!("conn:{}", conn.id);
         let is_conn_expanded = expanded.contains(&conn_node_id);
         let conn_idx = nodes.len() as i32;
         nodes.push(crate::SidebarNode {
             id: conn_node_id.clone().into(),
             label: conn.name.clone().into(),
-            sub_label: db_type_label(&conn.db_type).into(),
+            sub_label: db_type_label_config(&conn.db_type).into(),
             level: 0,
             is_expanded: is_conn_expanded,
             is_active: conn.id == active_id,
@@ -293,11 +296,18 @@ impl UI {
         tx_cmd: mpsc::Sender<Command>,
         rx_event: mpsc::Receiver<Event>,
         enc_key: [u8; 32],
+        initial_connections: Vec<ConnectionConfig>,
     ) -> Result<Self> {
         let window = crate::AppWindow::new()?;
 
-        let sidebar_state: Arc<Mutex<SidebarUiState>> =
-            Arc::new(Mutex::new(SidebarUiState::default()));
+        let sidebar_state: Arc<Mutex<SidebarUiState>> = Arc::new(Mutex::new(SidebarUiState {
+            read_only: initial_connections
+                .iter()
+                .map(|c| (c.id.clone(), c.read_only))
+                .collect(),
+            config_connections: initial_connections,
+            ..Default::default()
+        }));
 
         // Shared storage for the unfiltered query result; written by the event
         // handler on QueryFinished, read by the filter callbacks on the UI thread.
@@ -393,6 +403,30 @@ impl UI {
             ui_global.set_editor_text(query.clone().into());
             tabs_state.borrow_mut().save_current_text(&query);
         }
+        // Populate the connection list and sidebar from all saved connections at startup
+        // so they are visible even when no DB is running.
+        {
+            let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+            let entries: Vec<crate::ConnectionEntry> = sb
+                .config_connections
+                .iter()
+                .map(|c| crate::ConnectionEntry {
+                    is_active: false,
+                    db_type: db_type_label_config(&c.db_type).into(),
+                    name: c.name.clone().into(),
+                    id: c.id.clone().into(),
+                })
+                .collect();
+            ui_global.set_connection_list(Rc::new(slint::VecModel::from(entries)).into());
+            let nodes = build_sidebar_tree(
+                &sb.config_connections,
+                "",
+                &sb.metadata,
+                &sb.expanded,
+                &sb.read_only,
+            );
+            ui_global.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+        }
 
         Self::register_result_callbacks(
             &window,
@@ -431,8 +465,16 @@ impl UI {
         tokio::spawn(async move {
             while let Some(event) = rx_event.recv().await {
                 match event {
-                    Event::Connected(id) => Self::handle_connected(
+                    Event::Connected {
                         id,
+                        connections,
+                        safe_dml,
+                        read_only,
+                    } => Self::handle_connected(
+                        id,
+                        connections,
+                        safe_dml,
+                        read_only,
                         window_weak.clone(),
                         state.clone(),
                         Arc::clone(&sidebar_state),
@@ -510,45 +552,25 @@ impl UI {
 
     fn handle_connected(
         id: String,
+        connections: Vec<ConnectionConfig>,
+        safe_dml: bool,
+        read_only: bool,
         ww: slint::Weak<crate::AppWindow>,
         state: SharedState,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
     ) {
         // Build Send data outside invoke_from_event_loop (Rc<VecModel> is not Send).
-        let entries: Vec<crate::ConnectionEntry> = state
-            .conn
-            .all()
-            .into_iter()
+        let entries: Vec<crate::ConnectionEntry> = connections
+            .iter()
             .map(|c| crate::ConnectionEntry {
                 is_active: c.id == id,
-                db_type: db_type_label(&c.db_type).into(),
+                db_type: db_type_label_config(&c.db_type).into(),
                 name: c.name.clone().into(),
                 id: c.id.clone().into(),
             })
             .collect();
-        let config = wf_config::manager::ConfigManager::new().load().ok();
-        let safe_dml = config
-            .as_ref()
-            .and_then(|cfg| {
-                cfg.connections
-                    .iter()
-                    .find(|c| c.id == id)
-                    .map(|c| c.safe_dml)
-            })
-            .unwrap_or(true);
-        let read_only = config
-            .as_ref()
-            .and_then(|cfg| {
-                cfg.connections
-                    .iter()
-                    .find(|c| c.id == id)
-                    .map(|c| c.read_only)
-            })
-            .unwrap_or(false);
-        let base_status = state
-            .conn
-            .all()
-            .into_iter()
+        let base_status = connections
+            .iter()
             .find(|c| c.id == id)
             .map(|c| match c.database.as_deref() {
                 Some(db) if !db.is_empty() => format!("{} / {}", c.name, db),
@@ -563,19 +585,24 @@ impl UI {
         {
             let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
             sb.expanded.insert(format!("conn:{}", id));
-            if let Some(cfg) = &config {
-                sb.read_only = cfg
-                    .connections
-                    .iter()
-                    .map(|c| (c.id.clone(), c.read_only))
-                    .collect();
-            }
+            sb.config_connections = connections.clone();
+            sb.read_only = connections
+                .iter()
+                .map(|c| (c.id.clone(), c.read_only))
+                .collect();
         }
         let sidebar_nodes = {
             let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-            let connections = state.conn.all();
-            build_sidebar_tree(&connections, &id, &sb.metadata, &sb.expanded, &sb.read_only)
+            build_sidebar_tree(
+                &sb.config_connections,
+                &id,
+                &sb.metadata,
+                &sb.expanded,
+                &sb.read_only,
+            )
         };
+        // Update AppState active connection if not already tracked (needed for read-only check).
+        let _ = state.conn.active(); // no-op; active is set by controller before event fires
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
             with_ui(&ww, move |ui| {
@@ -610,22 +637,24 @@ impl UI {
         state: SharedState,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
     ) {
-        // Update the cached read_only map and rebuild the sidebar tree outside the
-        // UI thread so we don't hold the mutex inside invoke_from_event_loop.
+        // Update the cached flags and rebuild the sidebar tree outside the UI thread.
         {
             let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
             sb.read_only.insert(id.clone(), read_only);
+            if let Some(cc) = sb.config_connections.iter_mut().find(|c| c.id == id) {
+                cc.safe_dml = safe_dml;
+                cc.read_only = read_only;
+            }
         }
         let sidebar_nodes = {
             let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-            let connections = state.conn.all();
             let active_id = state
                 .conn
                 .active()
                 .map(|c| c.id.clone())
                 .unwrap_or_default();
             build_sidebar_tree(
-                &connections,
+                &sb.config_connections,
                 &active_id,
                 &sb.metadata,
                 &sb.expanded,
@@ -640,16 +669,17 @@ impl UI {
             .unwrap_or_default();
         let is_active = active_id == id;
         let new_status = if is_active {
-            let base = state
-                .conn
-                .all()
-                .into_iter()
-                .find(|c| c.id == id)
-                .map(|c| match c.database.as_deref() {
-                    Some(db) if !db.is_empty() => format!("{} / {}", c.name, db),
-                    _ => c.name.clone(),
-                })
-                .unwrap_or_else(|| id.clone());
+            let base = {
+                let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                sb.config_connections
+                    .iter()
+                    .find(|c| c.id == id)
+                    .map(|c| match c.database.as_deref() {
+                        Some(db) if !db.is_empty() => format!("{} / {}", c.name, db),
+                        _ => c.name.clone(),
+                    })
+                    .unwrap_or_else(|| id.clone())
+            };
             if read_only {
                 Some(format!("{} · {}", base, t!("status.read_only")))
             } else {
@@ -815,24 +845,36 @@ impl UI {
     fn handle_connection_removed(
         id: String,
         ww: slint::Weak<crate::AppWindow>,
-        state: SharedState,
+        _state: SharedState,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
     ) {
-        let entries: Vec<crate::ConnectionEntry> = state
-            .conn
-            .all()
-            .into_iter()
-            .map(|c| crate::ConnectionEntry {
-                is_active: false,
-                db_type: db_type_label(&c.db_type).into(),
-                name: c.name.clone().into(),
-                id: c.id.clone().into(),
-            })
-            .collect();
-        let sidebar_nodes = {
+        {
+            let mut sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+            sb.config_connections.retain(|c| c.id != id);
+            sb.read_only.remove(&id);
+            sb.metadata.remove(&id);
+            sb.expanded.remove(&format!("conn:{}", id));
+        }
+        let (entries, sidebar_nodes) = {
             let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-            let connections = state.conn.all();
-            build_sidebar_tree(&connections, "", &sb.metadata, &sb.expanded, &sb.read_only)
+            let e = sb
+                .config_connections
+                .iter()
+                .map(|c| crate::ConnectionEntry {
+                    is_active: false,
+                    db_type: db_type_label_config(&c.db_type).into(),
+                    name: c.name.clone().into(),
+                    id: c.id.clone().into(),
+                })
+                .collect::<Vec<_>>();
+            let nodes = build_sidebar_tree(
+                &sb.config_connections,
+                "",
+                &sb.metadata,
+                &sb.expanded,
+                &sb.read_only,
+            );
+            (e, nodes)
         };
         // clone required: invoke_from_event_loop closure must be 'static
         let _ = slint::invoke_from_event_loop(move || {
@@ -862,14 +904,13 @@ impl UI {
         }
         let nodes = {
             let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-            let connections = state.conn.all();
             let active_id = state
                 .conn
                 .active()
                 .map(|c| c.id.clone())
                 .unwrap_or_default();
             build_sidebar_tree(
-                &connections,
+                &sb.config_connections,
                 &active_id,
                 &sb.metadata,
                 &sb.expanded,
@@ -1431,12 +1472,21 @@ impl UI {
         // derived via derive_conn_string / parse_conn_string.
         {
             let window_weak = window.as_weak();
-            let state = state.clone();
+            let sidebar_state = Arc::clone(&sidebar_state);
             ui_state.on_edit_connection(move |id| {
                 let id = id.to_string();
-                let Some(conn) = state.conn.all().into_iter().find(|c| c.id == id) else {
+                // Look up from config_connections — works even when the DB is not running.
+                let conn_cfg = {
+                    let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    sb.config_connections.iter().find(|c| c.id == id).cloned()
+                };
+                let Some(conn_cfg) = conn_cfg else {
                     return;
                 };
+                let conn = config_to_db_conn(&conn_cfg);
+                let safe_dml = conn_cfg.safe_dml;
+                let read_only = conn_cfg.read_only;
+
                 // Decrypt stored password (only present for individual-field connections).
                 let stored_password = conn
                     .password_encrypted
@@ -1477,27 +1527,6 @@ impl UI {
                         conn.database.clone().unwrap_or_default(),
                     )
                 };
-
-                // Load behaviour flags from config (not present in runtime DbConnection).
-                let config = wf_config::manager::ConfigManager::new().load().ok();
-                let safe_dml = config
-                    .as_ref()
-                    .and_then(|c| {
-                        c.connections
-                            .iter()
-                            .find(|cc| cc.id == id)
-                            .map(|cc| cc.safe_dml)
-                    })
-                    .unwrap_or(true);
-                let read_only = config
-                    .as_ref()
-                    .and_then(|c| {
-                        c.connections
-                            .iter()
-                            .find(|cc| cc.id == id)
-                            .map(|cc| cc.read_only)
-                    })
-                    .unwrap_or(false);
 
                 with_ui(&window_weak, move |ui| {
                     ui.set_form_edit_id(conn.id.clone().into());
@@ -1540,8 +1569,15 @@ impl UI {
                         .map(|c| c.id.clone())
                         .unwrap_or_default();
                     if conn_id != active_id {
-                        let conn = state.conn.all().into_iter().find(|c| c.id == conn_id);
-                        if let Some(conn) = conn {
+                        let conn_cfg = {
+                            let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                            sb.config_connections
+                                .iter()
+                                .find(|c| c.id == conn_id)
+                                .cloned()
+                        };
+                        if let Some(cc) = conn_cfg {
+                            let conn = config_to_db_conn(&cc);
                             let password = conn
                                 .password_encrypted
                                 .as_ref()
@@ -1564,14 +1600,13 @@ impl UI {
                 // Rebuild and push the updated tree (already on UI thread)
                 let nodes = {
                     let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-                    let connections = state.conn.all();
                     let active_id = state
                         .conn
                         .active()
                         .map(|c| c.id.clone())
                         .unwrap_or_default();
                     build_sidebar_tree(
-                        &connections,
+                        &sb.config_connections,
                         &active_id,
                         &sb.metadata,
                         &sb.expanded,
@@ -1590,6 +1625,7 @@ impl UI {
             // clone required: callback closure needs owned captures
             let tx_cmd = tx_cmd.clone();
             let state = state.clone();
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: lookup from config_connections
             ui_state.on_connect_db(move |id| {
                 let id = id.to_string();
                 let active_id = state
@@ -1600,8 +1636,12 @@ impl UI {
                 if id == active_id {
                     return;
                 }
-                let conn = state.conn.all().into_iter().find(|c| c.id == id);
-                if let Some(conn) = conn {
+                let conn_cfg = {
+                    let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                    sb.config_connections.iter().find(|c| c.id == id).cloned()
+                };
+                if let Some(cc) = conn_cfg {
+                    let conn = config_to_db_conn(&cc);
                     let password = conn
                         .password_encrypted
                         .as_ref()
@@ -1644,24 +1684,27 @@ impl UI {
                 }
 
                 // Rebuild tree (no active connection, no expanded node for id).
-                let nodes = {
+                let (nodes, entries) = {
                     let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
-                    let connections = state.conn.all();
-                    build_sidebar_tree(&connections, "", &sb.metadata, &sb.expanded, &sb.read_only)
+                    let nodes = build_sidebar_tree(
+                        &sb.config_connections,
+                        "",
+                        &sb.metadata,
+                        &sb.expanded,
+                        &sb.read_only,
+                    );
+                    let entries = sb
+                        .config_connections
+                        .iter()
+                        .map(|c| crate::ConnectionEntry {
+                            is_active: false,
+                            db_type: db_type_label_config(&c.db_type).into(),
+                            name: c.name.clone().into(),
+                            id: c.id.clone().into(),
+                        })
+                        .collect::<Vec<_>>();
+                    (nodes, entries)
                 };
-
-                // Connection list with all entries inactive.
-                let entries: Vec<crate::ConnectionEntry> = state
-                    .conn
-                    .all()
-                    .into_iter()
-                    .map(|c| crate::ConnectionEntry {
-                        is_active: false,
-                        db_type: db_type_label(&c.db_type).into(),
-                        name: c.name.clone().into(),
-                        id: c.id.clone().into(),
-                    })
-                    .collect();
 
                 // Already on the UI thread — update directly.
                 with_ui(&window_weak, move |ui| {
@@ -2555,6 +2598,14 @@ fn db_type_label(dt: &DbType) -> &'static str {
         DbType::PostgreSQL => "PostgreSQL",
         DbType::MySQL => "MySQL",
         DbType::SQLite => "SQLite",
+    }
+}
+
+fn db_type_label_config(dt: &DbTypeName) -> &'static str {
+    match dt {
+        DbTypeName::PostgreSQL => "PostgreSQL",
+        DbTypeName::MySQL => "MySQL",
+        DbTypeName::SQLite => "SQLite",
     }
 }
 

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use wf_db::models::{DbConnection, DbMetadata, DbType, TableInfo};
+use wf_config::models::{ConnectionConfig, DbTypeName};
+use wf_db::models::{DbMetadata, TableInfo};
 
 // ── find_prefix_start ────────────────────────────────────────────────────────
 
@@ -94,17 +95,19 @@ fn is_terminal_expression_should_not_match_word_ending_with_null_suffix() {
     assert!(!is_terminal_expression("SELECT is_not_null_col"));
 }
 
-fn make_conn(id: &str, name: &str) -> DbConnection {
-    DbConnection {
+fn make_conn(id: &str, name: &str) -> ConnectionConfig {
+    ConnectionConfig {
         id: id.to_string(),
         name: name.to_string(),
-        db_type: DbType::SQLite,
+        db_type: DbTypeName::SQLite,
         connection_string: None,
         host: None,
         port: None,
         user: None,
         password_encrypted: None,
         database: None,
+        safe_dml: true,
+        read_only: false,
     }
 }
 

--- a/crates/wf-config/Cargo.toml
+++ b/crates/wf-config/Cargo.toml
@@ -16,6 +16,9 @@ serde       = { workspace = true }
 anyhow      = { workspace = true }
 thiserror   = { workspace = true }
 uuid        = { workspace = true }
+tokio       = { workspace = true }
+sqlx        = { workspace = true }
+tracing     = { workspace = true }
 toml        = "1"
 aes-gcm     = "0.10.3"
 directories = "6.0.0"

--- a/crates/wf-config/src/lib.rs
+++ b/crates/wf-config/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod crypto;
 pub mod manager;
 pub mod models;
+pub mod repository;
+
+pub use repository::ConnectionRepository;

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -117,7 +117,7 @@ impl Default for ConfigManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{AppearanceConfig, ConnectionConfig, DbTypeName, Theme};
+    use crate::models::{AppearanceConfig, Theme};
 
     #[test]
     fn config_manager_should_return_default_when_file_absent() {
@@ -133,25 +133,13 @@ mod tests {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let mgr = ConfigManager::with_path(dir.path().join("config.toml"));
 
+        // connections is skip_serializing (migration-only), so it is excluded here.
         let original = Config {
             appearance: AppearanceConfig {
                 theme: Theme::Light,
                 font_family: "Cascadia Code".to_string(),
                 font_size: 16,
             },
-            connections: vec![ConnectionConfig {
-                id: "test-id".to_string(),
-                name: "local".to_string(),
-                db_type: DbTypeName::SQLite,
-                connection_string: None,
-                host: None,
-                port: None,
-                user: None,
-                password_encrypted: None,
-                database: Some("local.db".to_string()),
-                safe_dml: true,
-                read_only: false,
-            }],
             ..Config::default()
         };
 

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -106,6 +106,8 @@ pub struct EditorConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct SessionConfig {
+    /// Preserved for migration only — read from old config.toml but never written back.
+    #[serde(default, skip_serializing)]
     pub last_connection_id: Option<String>,
     pub last_query: Option<String>,
 }
@@ -175,6 +177,8 @@ pub struct Config {
     pub editor: EditorConfig,
     pub session: SessionConfig,
     pub ui: UiConfig,
+    /// Preserved for migration only — read from old config.toml but never written back.
+    #[serde(default, skip_serializing)]
     pub connections: Vec<ConnectionConfig>,
 }
 
@@ -297,6 +301,8 @@ database = "local.db"
 
     #[test]
     fn config_should_roundtrip_serialize_deserialize() {
+        // connections and session.last_connection_id are skip_serializing (migration-only
+        // fields), so they are intentionally excluded from the roundtrip assertion.
         let original = Config {
             appearance: AppearanceConfig {
                 theme: Theme::Light,
@@ -307,25 +313,13 @@ database = "local.db"
                 page_size: PageSize::Rows100,
             },
             session: SessionConfig {
-                last_connection_id: Some("conn-1".to_string()),
+                last_connection_id: None,
                 last_query: Some("SELECT 1".to_string()),
             },
             ui: UiConfig {
                 language: "ja".to_string(),
             },
-            connections: vec![ConnectionConfig {
-                id: "conn-1".to_string(),
-                name: "test".to_string(),
-                db_type: DbTypeName::MySQL,
-                connection_string: None,
-                host: Some("127.0.0.1".to_string()),
-                port: Some(3306),
-                user: Some("root".to_string()),
-                password_encrypted: Some("AES256GCM:xyz".to_string()),
-                database: Some("testdb".to_string()),
-                safe_dml: false,
-                read_only: true,
-            }],
+            connections: vec![],
         };
 
         let serialized = toml::to_string(&original).expect("failed to serialize");

--- a/crates/wf-config/src/repository.rs
+++ b/crates/wf-config/src/repository.rs
@@ -1,0 +1,382 @@
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use sqlx::{Row as _, SqlitePool, sqlite::SqliteConnectOptions};
+use tracing::info;
+
+use crate::{
+    manager::ConfigManager,
+    models::{ConnectionConfig, DbTypeName},
+};
+
+const CREATE_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS connections (
+        id                 TEXT    PRIMARY KEY,
+        name               TEXT    NOT NULL,
+        db_type            TEXT    NOT NULL,
+        connection_string  TEXT,
+        host               TEXT,
+        port               INTEGER,
+        user_name          TEXT,
+        password_encrypted TEXT,
+        database_name      TEXT,
+        safe_dml           INTEGER NOT NULL DEFAULT 1,
+        read_only          INTEGER NOT NULL DEFAULT 0,
+        sort_order         INTEGER NOT NULL DEFAULT 0,
+        created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
+        last_used_at       INTEGER
+    )
+";
+
+/// Persists [`ConnectionConfig`] records to a SQLite `connections.db` file.
+///
+/// Cheap to clone — all clones share the same underlying connection pool.
+#[derive(Clone)]
+pub struct ConnectionRepository {
+    pool: SqlitePool,
+}
+
+impl ConnectionRepository {
+    /// Open (or create) the connections database at `path` and run schema migrations.
+    pub async fn open(path: &PathBuf) -> anyhow::Result<Self> {
+        let opts = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts)
+            .await
+            .context("failed to open connections.db")?;
+        sqlx::query(CREATE_TABLE)
+            .execute(&pool)
+            .await
+            .context("failed to migrate connections.db")?;
+        Ok(Self { pool })
+    }
+
+    /// Open the database and, if it is empty, import connections from `config.toml`.
+    ///
+    /// After import the original TOML connections are left in place (read-only migration —
+    /// `skip_serializing` on those fields means they are no longer written back).
+    pub async fn open_with_migration(path: &PathBuf, cm: &ConfigManager) -> anyhow::Result<Self> {
+        let repo = Self::open(path).await?;
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM connections")
+            .fetch_one(&repo.pool)
+            .await?;
+        if count == 0 {
+            let config = cm.load().context("failed to load config for migration")?;
+            if !config.connections.is_empty() {
+                let last_id = config.session.last_connection_id.clone();
+                for (i, cc) in config.connections.iter().enumerate() {
+                    repo.upsert_with_order(cc, i as i64).await?;
+                }
+                if let Some(ref last) = last_id {
+                    repo.touch_last_used(last).await.ok();
+                }
+                info!(
+                    count = config.connections.len(),
+                    "migrated connections from config.toml to connections.db"
+                );
+            }
+        }
+        Ok(repo)
+    }
+
+    /// Open an in-memory database (for tests only).
+    pub async fn open_memory() -> anyhow::Result<Self> {
+        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        sqlx::query(CREATE_TABLE).execute(&pool).await?;
+        Ok(Self { pool })
+    }
+
+    /// Return all saved connections ordered by `sort_order`, then `created_at`.
+    pub async fn all(&self) -> anyhow::Result<Vec<ConnectionConfig>> {
+        let rows = sqlx::query(
+            "SELECT id, name, db_type, connection_string, host, port, user_name,
+                    password_encrypted, database_name, safe_dml, read_only
+             FROM connections ORDER BY sort_order ASC, created_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter().map(row_to_config).collect()
+    }
+
+    /// Return the connection with the given `id`, or `None` if not found.
+    pub async fn find(&self, id: &str) -> anyhow::Result<Option<ConnectionConfig>> {
+        let row = sqlx::query(
+            "SELECT id, name, db_type, connection_string, host, port, user_name,
+                    password_encrypted, database_name, safe_dml, read_only
+             FROM connections WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|r| row_to_config(&r)).transpose()
+    }
+
+    /// Insert or update a connection.
+    ///
+    /// On conflict (same `id`), updates all fields **except** `safe_dml`, `read_only`,
+    /// and `sort_order` so that per-connection behaviour flags are preserved across reconnects.
+    /// Use [`update_flags`] to change those explicitly.
+    pub async fn upsert(&self, cc: &ConnectionConfig) -> anyhow::Result<()> {
+        let order = self.next_sort_order().await?;
+        self.upsert_with_order(cc, order).await
+    }
+
+    async fn upsert_with_order(&self, cc: &ConnectionConfig, order: i64) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO connections
+             (id, name, db_type, connection_string, host, port, user_name,
+              password_encrypted, database_name, safe_dml, read_only, sort_order)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               name               = excluded.name,
+               db_type            = excluded.db_type,
+               connection_string  = excluded.connection_string,
+               host               = excluded.host,
+               port               = excluded.port,
+               user_name          = excluded.user_name,
+               password_encrypted = excluded.password_encrypted,
+               database_name      = excluded.database_name",
+        )
+        .bind(&cc.id)
+        .bind(&cc.name)
+        .bind(db_type_to_str(&cc.db_type))
+        .bind(&cc.connection_string)
+        .bind(&cc.host)
+        .bind(cc.port.map(|p| p as i64))
+        .bind(&cc.user)
+        .bind(&cc.password_encrypted)
+        .bind(&cc.database)
+        .bind(cc.safe_dml as i32)
+        .bind(cc.read_only as i32)
+        .bind(order)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Delete the connection with the given `id`.
+    pub async fn delete(&self, id: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM connections WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Return the most-recently-used connection (highest `last_used_at`), or `None`.
+    pub async fn last_used(&self) -> anyhow::Result<Option<ConnectionConfig>> {
+        let row = sqlx::query(
+            "SELECT id, name, db_type, connection_string, host, port, user_name,
+                    password_encrypted, database_name, safe_dml, read_only
+             FROM connections WHERE last_used_at IS NOT NULL
+             ORDER BY last_used_at DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|r| row_to_config(&r)).transpose()
+    }
+
+    /// Update only the `safe_dml` and `read_only` flags for a connection.
+    pub async fn update_flags(
+        &self,
+        id: &str,
+        safe_dml: bool,
+        read_only: bool,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE connections SET safe_dml = ?, read_only = ? WHERE id = ?")
+            .bind(safe_dml as i32)
+            .bind(read_only as i32)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Record a successful connection by stamping `last_used_at = now()`.
+    pub async fn touch_last_used(&self, id: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE connections SET last_used_at = unixepoch() WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn next_sort_order(&self) -> anyhow::Result<i64> {
+        let max: Option<i64> = sqlx::query_scalar("SELECT MAX(sort_order) FROM connections")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(max.unwrap_or(-1) + 1)
+    }
+}
+
+// ── Row → model conversion ────────────────────────────────────────────────────
+
+fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<ConnectionConfig> {
+    let db_type_str: String = row.try_get("db_type")?;
+    let db_type = match db_type_str.as_str() {
+        "mysql" => DbTypeName::MySQL,
+        "sqlite" => DbTypeName::SQLite,
+        _ => DbTypeName::PostgreSQL,
+    };
+    let port_i: Option<i64> = row.try_get("port")?;
+    Ok(ConnectionConfig {
+        id: row.try_get("id")?,
+        name: row.try_get("name")?,
+        db_type,
+        connection_string: row.try_get("connection_string")?,
+        host: row.try_get("host")?,
+        port: port_i.map(|p| p as u16),
+        user: row.try_get("user_name")?,
+        password_encrypted: row.try_get("password_encrypted")?,
+        database: row.try_get("database_name")?,
+        safe_dml: row.try_get::<i64, _>("safe_dml")? != 0,
+        read_only: row.try_get::<i64, _>("read_only")? != 0,
+    })
+}
+
+fn db_type_to_str(dt: &DbTypeName) -> &'static str {
+    match dt {
+        DbTypeName::PostgreSQL => "postgresql",
+        DbTypeName::MySQL => "mysql",
+        DbTypeName::SQLite => "sqlite",
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::DbTypeName;
+
+    fn make_conn(id: &str) -> ConnectionConfig {
+        ConnectionConfig {
+            id: id.to_string(),
+            name: format!("conn-{id}"),
+            db_type: DbTypeName::SQLite,
+            connection_string: Some("sqlite::memory:".to_string()),
+            host: None,
+            port: None,
+            user: None,
+            password_encrypted: None,
+            database: None,
+            safe_dml: true,
+            read_only: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn repository_should_upsert_and_return_all() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        repo.upsert(&make_conn("c2")).await.unwrap();
+        let all = repo.all().await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].id, "c1");
+        assert_eq!(all[1].id, "c2");
+    }
+
+    #[tokio::test]
+    async fn repository_upsert_should_not_duplicate() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        let all = repo.all().await.unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn repository_upsert_should_preserve_flags_on_update() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        let mut cc = make_conn("c1");
+        cc.safe_dml = false;
+        cc.read_only = true;
+        repo.upsert(&cc).await.unwrap();
+
+        // Second upsert with defaults should NOT overwrite safe_dml/read_only.
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        let found = repo.find("c1").await.unwrap().unwrap();
+        assert!(!found.safe_dml);
+        assert!(found.read_only);
+    }
+
+    #[tokio::test]
+    async fn repository_find_should_return_none_for_unknown_id() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        assert!(repo.find("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn repository_delete_should_remove_entry() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        repo.delete("c1").await.unwrap();
+        assert!(repo.all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn repository_last_used_should_return_most_recent() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        repo.upsert(&make_conn("c2")).await.unwrap();
+        // c2 touched most recently
+        repo.touch_last_used("c1").await.unwrap();
+        // small delay so the unixepoch() values differ
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        repo.touch_last_used("c2").await.unwrap();
+        let last = repo.last_used().await.unwrap().unwrap();
+        assert_eq!(last.id, "c2");
+    }
+
+    #[tokio::test]
+    async fn repository_last_used_should_return_none_when_empty() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        assert!(repo.last_used().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn repository_update_flags_should_change_safe_dml_and_read_only() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        repo.upsert(&make_conn("c1")).await.unwrap();
+        repo.update_flags("c1", false, true).await.unwrap();
+        let found = repo.find("c1").await.unwrap().unwrap();
+        assert!(!found.safe_dml);
+        assert!(found.read_only);
+    }
+
+    #[tokio::test]
+    async fn repository_should_migrate_from_config_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let db_path = dir.path().join("connections.db");
+
+        // Write a config.toml directly — ConfigManager::save skips `connections`
+        // (skip_serializing), so we write raw TOML to simulate a pre-migration file.
+        let toml_content = r#"
+[session]
+last_connection_id = "c-toml"
+
+[[connections]]
+id = "c-toml"
+name = "Test"
+db_type = "sqlite"
+"#;
+        std::fs::write(&config_path, toml_content).unwrap();
+
+        let repo = ConnectionRepository::open_with_migration(
+            &db_path,
+            &ConfigManager::with_path(config_path),
+        )
+        .await
+        .unwrap();
+
+        let all = repo.all().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "c-toml");
+
+        // last_used_at should have been set.
+        let last = repo.last_used().await.unwrap();
+        assert_eq!(last.unwrap().id, "c-toml");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the flat `[[connections]]` TOML array with a SQLite-backed `ConnectionRepository` in `wf-config`. All saved connections are now persisted in `connections.db` and are always visible in the sidebar and DB manager — even when no database is currently running. Auto-connect on startup is driven by `last_used_at` instead of `last_connection_id`.

## Changes

- **`wf-config`**: new `ConnectionRepository` struct backed by `sqlx` / SQLite with `all`, `find`, `upsert`, `delete`, `last_used`, `update_flags`, `touch_last_used`, and `open_with_migration` (imports from old `config.toml` on first launch)
- **`wf-config` models**: added `safe_dml` / `read_only` to `ConnectionConfig`; `Config.connections` and `SessionConfig.last_connection_id` are `skip_serializing` (read for migration only, never written back)
- **`app/event.rs`**: `Event::Connected` refactored to struct variant carrying full connection list and flags
- **`app/controller.rs`**: added `repo: Arc<ConnectionRepository>` field; connect/remove/flag-update all go through the repository
- **`app/session.rs`**: removed `save_connection`, `remove_connection`, `restore` (all replaced by repository)
- **`app/main.rs`**: opens repository, loads initial connections and restore target at startup
- **`app/ui/mod.rs`**: `SidebarUiState` caches `config_connections`; sidebar, DB manager, `on_toggle_sidebar_node`, `on_connect_db`, `on_disconnect`, and `on_edit_connection` all use the cached list so non-connected saved connections are always accessible
- **Tests**: 8 new repository unit tests; updated `build_sidebar_tree` tests to use `ConnectionConfig`

## Related Issues

Closes #238
Resolves #237

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes