### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-02
+
+### v0.8.0 - Multi-tab Interface
+
+- Multi-tab UI: SQL Editor tabs and Table View tabs (open, switch, close, Ctrl+T / Ctrl+W)
+- Table View tab: data grid, DDL viewer, column list, and per-tab page-size selector
+- DDL viewer: sidebar single-click shows CREATE statement in bottom pane with copy button
+- Safe DML mode: WHERE-less UPDATE/DELETE triggers a confirmation dialog before execution
+- Read-only connection mode: write statements blocked at controller level; lock icon in sidebar and status bar
+- SVG icon set applied across the full UI (sidebar, buttons, status bar)
+- Delete connection from the DB manager modal
+- Platform system font applied at startup (Segoe UI on Windows, Helvetica Neue on macOS) to fix fontique rendering
+- Layout / Typography / Icons design tokens centralised in theme.slint
+- Connection storage migrated from config.toml to SQLite-backed ConnectionRepository
+- All saved connections visible in sidebar and DB manager even when no DB is running
+- Auto-connect on startup driven by last_used_at (most recently connected) instead of last_connection_id
+- Tab session persistence: open tabs and active tab index saved and restored across restarts
+
 ## [0.7.0] - 2026-04-29
 
 First public release. Covers milestones v0.1.0 through v0.7.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6760,7 +6760,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wellfeather"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -6786,7 +6786,7 @@ dependencies = [
 
 [[package]]
 name = "wf-completion"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "wf-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "wf-db"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "wf-history"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "wf-query"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.93.0"
 description = "A lightweight, keyboard-centric SQL client built with Rust and Slint"


### PR DESCRIPTION
## Summary

Prepares the v0.8.0 release. Covers the full Multi-tab Interface milestone plus connection storage migration and offline connection visibility.

## Changes

- `Cargo.toml`: version 0.7.0 → 0.8.0
- `CHANGELOG.md`: add [0.8.0] section with v0.8.0 milestone changes

## Related Issues

Closes #239

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes