### PR TITLE
fix(ui): replace checkbox glyph with SVG icon and add transition animation

### DIFF
--- a/app/assets/icons/check.svg
+++ b/app/assets/icons/check.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.0303 8.78039L8.99993 16.8107L5.4696 13.2804L6.53026 12.2197L8.99993 14.6894L15.9696 7.71973L17.0303 8.78039Z" fill="#080341"/>
+</svg>

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -163,14 +163,17 @@ component CheckRow inherits Rectangle {
             background: root.checked ? Colors.blue : Colors.base;
             border-width: 1px;
             border-color: root.checked ? Colors.blue : Colors.surface2;
-            Text {
-                width: parent.width;
-                height: parent.height;
-                text: root.checked ? "\u{2713}" : "";
-                color: Colors.base;
-                font-size: Typography.size-md;
-                horizontal-alignment: center;
-                vertical-alignment: center;
+            animate background { duration: 150ms; easing: ease-in-out; }
+            animate border-color { duration: 150ms; easing: ease-in-out; }
+            Image {
+                width: 18px;
+                height: 18px;
+                x: (parent.width - self.width) / 2;
+                y: (parent.height - self.height) / 2;
+                source: Icons.check;
+                colorize: Colors.base;
+                opacity: root.checked ? 1.0 : 0.0;
+                animate opacity { duration: 120ms; easing: ease-in-out; }
             }
         }
 

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -111,6 +111,7 @@ export global Layout {
 
 export global Icons {
     out property <image> alert-error:      @image-url("../../assets/icons/alert-error.svg");
+    out property <image> check:             @image-url("../../assets/icons/check.svg");
     out property <image> brand-mysql:      @image-url("../../assets/icons/brand-mysql.svg");
     out property <image> brand-postgresql: @image-url("../../assets/icons/brand-postgresql.svg");
     out property <image> brand-sqlite:     @image-url("../../assets/icons/brand-sqlite.svg");


### PR DESCRIPTION
## Summary

The Safe DML and Read-only checkboxes in the Edit Connection modal were rendering the check mark as a Unicode glyph (`✓`, U+2713), which was not reliably visible due to font glyph availability. This PR replaces the text-based check mark with the `check.svg` icon and adds smooth CSS-style transition animations via Slint's `animate` keyword.

## Changes

- `app/assets/icons/check.svg`: Added check mark SVG icon
- `app/src/ui/theme.slint`: Registered `Icons.check` pointing to the new SVG
- `app/src/ui/components/connection_form.slint` (`CheckRow`): Replaced `Text { "\u{2713}" }` with `Image { source: Icons.check }` (18×18px, colorized to `Colors.base`); added 150ms `ease-in-out` transition on `background` and `border-color`, and 120ms opacity fade-in on the check icon

## Related Issues

<!-- No dedicated issue — observed visually and fixed inline -->

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes