### PR TITLE
feat(ui): animation system — editor-first philosophy, button feedback, reduce-motion

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -363,3 +363,8 @@ msgstr "Cancel"
 msgctxt "SafeDmlDialog"
 msgid "Execute"
 msgstr "Execute"
+
+
+msgctxt "MenuBar"
+msgid "Reduce Motion"
+msgstr "Reduce Motion"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -363,3 +363,8 @@ msgstr "キャンセル"
 msgctxt "SafeDmlDialog"
 msgid "Execute"
 msgstr "実行"
+
+
+msgctxt "MenuBar"
+msgid "Reduce Motion"
+msgstr "モーション軽減"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -24,6 +24,7 @@ pub enum ConfigUpdate {
         safe_dml: bool,
         read_only: bool,
     },
+    ReduceMotion(bool),
 }
 
 /// UI → Controller channel messages.

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -537,6 +537,11 @@ impl AppController {
                     })
                     .await;
             }
+            ConfigUpdate::ReduceMotion(value) => {
+                if let Err(e) = self.session.save_reduce_motion(value) {
+                    warn!(error = %e, "failed to persist reduce_motion to config");
+                }
+            }
             _ => {}
         }
     }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -121,6 +121,19 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Persist `reduce_motion` as `[appearance].reduce_motion` in `config.toml`.
+    pub fn save_reduce_motion(&self, value: bool) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for reduce_motion save")?;
+        config.appearance.reduce_motion = value;
+        self.config_manager
+            .save(&config)
+            .context("failed to save reduce_motion")?;
+        Ok(())
+    }
+
     /// Write the current editor query to `last_query.sql` in the app config directory.
     ///
     /// An empty query writes an empty file (not an error); `restore_query_file`

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -8,7 +8,7 @@ import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
 import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData } from "globals.slint";
-import { Colors, Typography, Layout, Icons } from "theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
 import { MenuBar }         from "components/menu_bar.slint";
@@ -176,6 +176,12 @@ export global UiState {
     /// Fired when user accepts a candidate (Enter key in popup).
     callback accept-completion(string, int, int, string);
 
+    // ── Accessibility ─────────────────────────────────────────────────────────
+    /// When true, all Animation durations collapse to 0ms.  Persisted in config.toml.
+    in-out property <bool> reduce-motion: false;
+    /// Toggle reduce-motion; Rust flips the value, persists, and updates Animation global.
+    callback toggle-reduce-motion();
+
     // ── Theme ─────────────────────────────────────────────────────────────────
     /// true = dark (Catppuccin Mocha), false = light (Catppuccin Latte).
     in-out property <bool> is-dark: true;
@@ -269,6 +275,10 @@ export component AppWindow inherits Window {
     property <bool> _theme-sync: UiState.is-dark;
     changed _theme-sync => { Colors.is-dark = UiState.is-dark; }
 
+    // Mirror UiState.reduce-motion into Animation.reduce-motion.
+    property <bool> _reduce-motion-sync: UiState.reduce-motion;
+    changed _reduce-motion-sync => { Animation.reduce-motion = UiState.reduce-motion; }
+
     // ── Layout geometry helpers ───────────────────────────────────────────────
     property <length> menu-bar-height:   Layout.height-bar;
     property <length> tab-bar-height:    Layout.height-tab-bar;
@@ -333,6 +343,30 @@ export component AppWindow inherits Window {
     changed _tv-active => {
         if (root._tv-active) { root.focused-pane = 1; }
     }
+
+    // ── Dialog lifecycle helpers ──────────────────────────────────────────────
+    // AppWindow is always visible, so changed callbacks on these mirrors fire
+    // reliably even when the dialog itself is not yet in the tree.
+    // _X-alive controls the if condition; set true on open, false after exit.
+    private property <bool> _test-result-alive: false;
+    private property <bool> _test-result-open:  UiState.show-test-result-popup;
+    changed _test-result-open => { if (_test-result-open) { _test-result-alive = true; } }
+
+    private property <bool> _add-conn-alive: false;
+    private property <bool> _add-conn-open:  UiState.show-add-confirm-popup;
+    changed _add-conn-open => { if (_add-conn-open) { _add-conn-alive = true; } }
+
+    private property <bool> _all-rows-alive: false;
+    private property <bool> _all-rows-open:  UiState.show-all-rows-confirm;
+    changed _all-rows-open => { if (_all-rows-open) { _all-rows-alive = true; } }
+
+    private property <bool> _safe-dml-alive: false;
+    private property <bool> _safe-dml-open:  UiState.show-safe-dml-confirm;
+    changed _safe-dml-open => { if (_safe-dml-open) { _safe-dml-alive = true; } }
+
+    private property <bool> _db-mgr-alive: false;
+    private property <bool> _db-mgr-open:  UiState.show-db-manager;
+    changed _db-mgr-open => { if (_db-mgr-open) { _db-mgr-alive = true; } }
 
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
     // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
@@ -456,10 +490,12 @@ export component AppWindow inherits Window {
             editor-text:  UiState.editor-text;
             language:     UiState.language;
             has-active-connection: UiState.active-connection-id != "";
+            reduce-motion: UiState.reduce-motion;
             export-csv   => { UiState.export-csv(); }
             export-json  => { UiState.export-json(); }
             quit         => { UiState.quit(); }
-            toggle-theme => { UiState.toggle-theme(); }
+            toggle-theme          => { UiState.toggle-theme(); }
+            toggle-reduce-motion  => { UiState.toggle-reduce-motion(); }
             open-db-manager  => { UiState.open-db-manager(); }
             disconnect       => { UiState.disconnect(UiState.active-connection-id); }
             run-query(sql) => { UiState.run-query(sql); }
@@ -875,42 +911,51 @@ export component AppWindow inherits Window {
         }
 
         // ── Test-result popup ─────────────────────────────────────────────────
-        if UiState.show-test-result-popup: TestResultDialog {
+        if _test-result-alive: TestResultDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
+            show:           UiState.show-test-result-popup;
             result-ok:      UiState.test-result-ok;
             result-message: UiState.test-result-message;
             ok-clicked => { UiState.dismiss-test-popup(); }
+            exited     => { _test-result-alive = false; }
         }
 
         // ── Add-without-test confirmation popup ───────────────────────────────
-        if UiState.show-add-confirm-popup: AddConnectionDialog {
+        if _add-conn-alive: AddConnectionDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
+            show:       UiState.show-add-confirm-popup;
             no-clicked  => { UiState.dismiss-add-confirm(); }
             yes-clicked => { UiState.confirm-add-connection(); }
+            exited      => { _add-conn-alive = false; }
         }
 
         // ── Fetch-all-rows confirmation popup ─────────────────────────────────
-        if UiState.show-all-rows-confirm: AllRowsDialog {
+        if _all-rows-alive: AllRowsDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
+            show:          UiState.show-all-rows-confirm;
             cancel-clicked => { UiState.dismiss-all-rows-confirm(); }
             fetch-clicked  => { UiState.confirm-all-rows(); }
+            exited         => { _all-rows-alive = false; }
         }
 
         // ── Safe-DML confirmation popup ───────────────────────────────────────
-        if UiState.show-safe-dml-confirm: SafeDmlDialog {
+        if _safe-dml-alive: SafeDmlDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
+            show:            UiState.show-safe-dml-confirm;
             cancel-clicked  => { UiState.dismiss-safe-dml-confirm(); }
             execute-clicked => { UiState.confirm-safe-dml(); }
+            exited          => { _safe-dml-alive = false; }
         }
 
         // ── DB manager dialog ─────────────────────────────────────────────────
-        if UiState.show-db-manager: DbManagerDialog {
+        if _db-mgr-alive: DbManagerDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
+            show:        UiState.show-db-manager;
             connections: UiState.connection-list;
             active-id:   UiState.active-connection-id;
             close          => { UiState.show-db-manager = false; }
@@ -926,6 +971,7 @@ export component AppWindow inherits Window {
                 UiState.reopen-db-manager-on-form-close = true;
                 UiState.open-connection-form();
             }
+            exited => { _db-mgr-alive = false; }
         }
 
     }

--- a/app/src/ui/components/common.slint
+++ b/app/src/ui/components/common.slint
@@ -1,7 +1,7 @@
 // Shared UI primitives used across multiple components.
 // All components here depend only on theme.slint — no circular imports.
 
-import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
 
 // ── ToolbarButton ─────────────────────────────────────────────────────────────
 // Small toggle button used in the result-table toolbar (page-size selector,
@@ -20,6 +20,7 @@ export component ToolbarButton inherits Rectangle {
     border-radius: Layout.radius-sm;
     background: ta.has-hover ? Colors.surface1
         : root.active ? Colors.blue : Colors.surface0;
+    animate background { duration: Animation.feedback; easing: Animation.enter-ease; }
 
     ta := TouchArea {
         clicked => { root.clicked(); }
@@ -67,6 +68,7 @@ export component ActionButton inherits Rectangle {
     height: Layout.height-btn-lg;
     border-radius: Layout.radius-md;
     background: root.bg;
+    clip: true;
 
     HorizontalLayout {
         alignment: center;
@@ -83,9 +85,16 @@ export component ActionButton inherits Rectangle {
             vertical-alignment: center;
         }
     }
-    TouchArea {
+
+    ta := TouchArea {
         enabled: root.enabled;
         clicked => { root.clicked(); }
+    }
+    Rectangle {
+        border-radius: parent.border-radius;
+        background: Colors.hover-btn;
+        opacity: ta.has-hover && root.enabled ? 1.0 : 0.0;
+        animate opacity { duration: Animation.feedback; easing: Animation.enter-ease; }
     }
 }
 
@@ -99,6 +108,13 @@ export component ActionButton inherits Rectangle {
 
 export component ModalOverlay inherits Rectangle {
     background: Colors.modal-overlay;
+
+    in property <bool> show: true;
+    callback exited();
+
+    changed show => {
+        if (!show) { root.exited(); }
+    }
 
     VerticalLayout {
         alignment: center;

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -3,7 +3,7 @@
 // Does not import UiState directly to avoid circular imports
 // (app.slint imports this file; UiState is defined in app.slint).
 
-import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
 import { ActionButton } from "common.slint";
 
 // ── Helper: labelled text field row ──────────────────────────────────────────
@@ -163,8 +163,8 @@ component CheckRow inherits Rectangle {
             background: root.checked ? Colors.blue : Colors.base;
             border-width: 1px;
             border-color: root.checked ? Colors.blue : Colors.surface2;
-            animate background { duration: 150ms; easing: ease-in-out; }
-            animate border-color { duration: 150ms; easing: ease-in-out; }
+            animate background { duration: Animation.feedback; easing: Animation.value-ease; }
+            animate border-color { duration: Animation.feedback; easing: Animation.value-ease; }
             Image {
                 width: 18px;
                 height: 18px;
@@ -173,7 +173,7 @@ component CheckRow inherits Rectangle {
                 source: Icons.check;
                 colorize: Colors.base;
                 opacity: root.checked ? 1.0 : 0.0;
-                animate opacity { duration: 120ms; easing: ease-in-out; }
+                animate opacity { duration: Animation.fast; easing: Animation.value-ease; }
             }
         }
 

--- a/app/src/ui/components/dialogs/db_manager_dialog.slint
+++ b/app/src/ui/components/dialogs/db_manager_dialog.slint
@@ -1,7 +1,8 @@
 import { ConnectionEntry } from "../../globals.slint";
-import { Colors, Typography, Layout, Icons } from "../../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../../theme.slint";
 
 export component DbManagerDialog inherits Rectangle {
+    in property <bool> show: false;
     in property <[ConnectionEntry]> connections: [];
     in property <string>            active-id:   "";
 
@@ -13,15 +14,19 @@ export component DbManagerDialog inherits Rectangle {
 
     property <int> kb-focus: 0;
 
-    init => {
-        dialog-fs.focus();
-        if (root.connections.length > 0) {
-            root.kb-focus = 0;
-        }
+    callback exited();
+
+    init => { root.kb-focus = 0; }
+
+    changed show => {
+        if (show) { root.kb-focus = 0; }
+        else      { root.exited(); }
     }
 
+    // Focus: grab on next frame after show.
+    Timer { interval: 16ms; running: show && !dialog-fs.has-focus; triggered => { dialog-fs.focus(); } }
+
     // Auto-scroll: keep the kb-focused row visible.
-    // viewport-y is 0 at top and negative as content scrolls down.
     changed kb-focus => {
         if (root.kb-focus >= 0) {
             let row-top = root.kb-focus * Layout.height-dialog-row;

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -13,6 +13,7 @@ export component MenuBar inherits Rectangle {
     callback export-json();
     callback quit();
     callback toggle-theme();
+    callback toggle-reduce-motion();
     callback open-db-manager();
     callback disconnect();
     callback run-query(string);
@@ -22,6 +23,7 @@ export component MenuBar inherits Rectangle {
     in property <string> editor-text;
     in property <string> language: "en";
     in property <bool>   has-active-connection: false;
+    in property <bool>   reduce-motion: false;
 
     // Bottom border separating menu bar from content area
     Rectangle {
@@ -255,12 +257,12 @@ export component MenuBar inherits Rectangle {
                 x: 0;
                 y: root.height;
                 width:  220px;
-                height: 3 * Layout.height-menu-item + 1px;
+                height: 5 * Layout.height-menu-item + 2px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
                     width:  220px;
-                    height: 3 * Layout.height-menu-item + 1px;
+                    height: 5 * Layout.height-menu-item + 2px;
                     background:    Colors.surface0;
                     border-radius: Layout.radius-md;
                     border-width:  1px;
@@ -272,6 +274,12 @@ export component MenuBar inherits Rectangle {
                     VerticalLayout {
                         spacing: 0;
                         MenuItem { text: @tr("Font Settings (coming soon)"); }
+                        Rectangle { height: 1px; background: Colors.surface1; }
+                        MenuItem {
+                            text: @tr("Reduce Motion");
+                            selected: root.reduce-motion;
+                            clicked => { root.toggle-reduce-motion(); }
+                        }
                         Rectangle { height: 1px; background: Colors.surface1; }
                         MenuItem {
                             text: @tr("English");

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -1,5 +1,6 @@
 import { RowData } from "../globals.slint";
-import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
+import { ProgressIndicator } from "std-widgets.slint";
 import { ResultTableToolbar } from "result_table_toolbar.slint";
 import { ResultTableHeader } from "result_table_header.slint";
 import { ResultTableBody }   from "result_table_body.slint";
@@ -120,12 +121,16 @@ export component ResultTable inherits Rectangle {
         x: 0; y: 0; width: root.width; height: root.height;
         background: Colors.base;
         TouchArea {}
-        Text {
-            x: (parent.width  - self.width)  / 2;
-            y: (parent.height - self.height) / 2;
-            text: @tr("Running\u{2026}");
-            color: Colors.text;
-            font-size: Typography.size-lg;
+        VerticalLayout {
+            alignment: center;
+            HorizontalLayout {
+                alignment: center;
+                spacing: Layout.spacing-lg;
+                ProgressIndicator {
+                    indeterminate: true;
+                    width: 120px;
+                }
+            }
         }
     }
 

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -1,5 +1,5 @@
 import { SidebarNode } from "../globals.slint";
-import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
 
 export component Sidebar inherits Rectangle {
     background: Colors.base;
@@ -110,7 +110,7 @@ export component Sidebar inherits Rectangle {
             sidebar-content := VerticalLayout {
                 // ── Schema tree ───────────────────────────────────────────────────────
                 for node[i] in root.tree : Rectangle {
-                    height: Layout.height-sidebar-row;
+                    height: node.visible ? Layout.height-sidebar-row : 0px;
                     clip: true;
 
                     background: i == root.kb-focus

--- a/app/src/ui/components/tab_bar.slint
+++ b/app/src/ui/components/tab_bar.slint
@@ -1,5 +1,5 @@
 import { TabEntry } from "../globals.slint";
-import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
 
 export component TabBar inherits Rectangle {
     in property <[TabEntry]> tabs;
@@ -26,6 +26,7 @@ export component TabBar inherits Rectangle {
                     width: min(max(tab-text.preferred-width + 64px, 80px), 240px);
                     height: Layout.height-tab-bar;
                     background: i == root.active-index ? Colors.base : transparent;
+                    animate background { duration: Animation.standard; easing: Animation.enter-ease; }
 
                     ta-tab := TouchArea {
                         clicked => { root.switch-tab(i); }
@@ -83,12 +84,14 @@ export component TabBar inherits Rectangle {
                         }
                     }
 
-                    if i == root.active-index : Rectangle {
+                    Rectangle {
                         x: 0;
                         y: parent.height - 2px;
                         width: parent.width;
                         height: 2px;
                         background: Colors.blue;
+                        opacity: i == root.active-index ? 1.0 : 0.0;
+                        animate opacity { duration: Animation.standard; easing: Animation.enter-ease; }
                     }
                 }
             }

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -29,6 +29,8 @@ export struct SidebarNode {
     is-read-only: bool,   // true for connections with read_only=true
     node-kind: string,    // "connection" | "category" | "table" | "view" | "proc" | "index"
     parent-index: int,    // flat-list index of parent node; -1 for root connection nodes
+    visible: bool,        // animation: false = collapsed (height 0), true = expanded
+    stagger-delay: int,   // animation: ms delay for enter stagger (0 for non-item nodes)
 }
 
 export struct CompletionRow {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -128,10 +128,10 @@ fn build_sidebar_tree(
             is_read_only: *read_only.get(&conn.id).unwrap_or(&false),
             node_kind: "connection".into(),
             parent_index: -1,
+            visible: true,
+            stagger_delay: 0,
         });
-        if !is_conn_expanded {
-            continue;
-        }
+        // Always push all children (with visible flag) so Slint can animate height/opacity.
         let Some(meta) = metadata.get(&conn.id) else {
             continue;
         };
@@ -143,6 +143,7 @@ fn build_sidebar_tree(
             &meta.tables,
             "table",
             expanded,
+            is_conn_expanded,
         );
         push_tableinfo_category(
             &mut nodes,
@@ -152,6 +153,7 @@ fn build_sidebar_tree(
             &meta.views,
             "view",
             expanded,
+            is_conn_expanded,
         );
         push_string_category(
             &mut nodes,
@@ -161,6 +163,7 @@ fn build_sidebar_tree(
             &meta.stored_procs,
             "proc",
             expanded,
+            is_conn_expanded,
         );
         push_string_category(
             &mut nodes,
@@ -170,11 +173,13 @@ fn build_sidebar_tree(
             &meta.indexes,
             "index",
             expanded,
+            is_conn_expanded,
         );
     }
     nodes
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_tableinfo_category(
     nodes: &mut Vec<crate::SidebarNode>,
     conn_idx: i32,
@@ -183,6 +188,7 @@ fn push_tableinfo_category(
     items: &[TableInfo],
     kind: &str,
     expanded: &HashSet<String>,
+    parent_visible: bool,
 ) {
     let cat_id = format!("cat:{}:{}", conn_id, name);
     let is_exp = expanded.contains(&cat_id);
@@ -197,24 +203,28 @@ fn push_tableinfo_category(
         is_read_only: false,
         node_kind: "category".into(),
         parent_index: conn_idx,
+        visible: parent_visible,
+        stagger_delay: 0,
     });
-    if is_exp {
-        for item in items {
-            nodes.push(crate::SidebarNode {
-                id: format!("item:{}:{}:{}", conn_id, kind, item.name).into(),
-                label: item.name.clone().into(),
-                sub_label: "".into(),
-                level: 2,
-                is_expanded: false,
-                is_active: false,
-                is_read_only: false,
-                node_kind: kind.into(),
-                parent_index: cat_idx,
-            });
-        }
+    // Always emit children; visible flag drives Slint height/opacity animation.
+    for (child_idx, item) in items.iter().enumerate() {
+        nodes.push(crate::SidebarNode {
+            id: format!("item:{}:{}:{}", conn_id, kind, item.name).into(),
+            label: item.name.clone().into(),
+            sub_label: "".into(),
+            level: 2,
+            is_expanded: false,
+            is_active: false,
+            is_read_only: false,
+            node_kind: kind.into(),
+            parent_index: cat_idx,
+            visible: parent_visible && is_exp,
+            stagger_delay: (child_idx.min(9) as i32) * 30,
+        });
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_string_category(
     nodes: &mut Vec<crate::SidebarNode>,
     conn_idx: i32,
@@ -223,6 +233,7 @@ fn push_string_category(
     items: &[String],
     kind: &str,
     expanded: &HashSet<String>,
+    parent_visible: bool,
 ) {
     let cat_id = format!("cat:{}:{}", conn_id, name);
     let is_exp = expanded.contains(&cat_id);
@@ -237,21 +248,24 @@ fn push_string_category(
         is_read_only: false,
         node_kind: "category".into(),
         parent_index: conn_idx,
+        visible: parent_visible,
+        stagger_delay: 0,
     });
-    if is_exp {
-        for item in items {
-            nodes.push(crate::SidebarNode {
-                id: format!("item:{}:{}:{}", conn_id, kind, item).into(),
-                label: item.clone().into(),
-                sub_label: "".into(),
-                level: 2,
-                is_expanded: false,
-                is_active: false,
-                is_read_only: false,
-                node_kind: kind.into(),
-                parent_index: cat_idx,
-            });
-        }
+    // Always emit children; visible flag drives Slint height/opacity animation.
+    for (child_idx, item) in items.iter().enumerate() {
+        nodes.push(crate::SidebarNode {
+            id: format!("item:{}:{}:{}", conn_id, kind, item).into(),
+            label: item.clone().into(),
+            sub_label: "".into(),
+            level: 2,
+            is_expanded: false,
+            is_active: false,
+            is_read_only: false,
+            node_kind: kind.into(),
+            parent_index: cat_idx,
+            visible: parent_visible && is_exp,
+            stagger_delay: (child_idx.min(9) as i32) * 30,
+        });
     }
 }
 
@@ -348,6 +362,7 @@ impl UI {
         Self::register_formatter_callback(&window);
         Self::register_export_callbacks(&window, Arc::clone(&original_data));
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
+        Self::register_reduce_motion_callback(&window, tx_cmd.clone());
         Self::register_menu_callbacks(&window, tx_cmd.clone());
         Self::register_close_handler(&window, Rc::clone(&tabs_state));
         Self::register_tab_callbacks(
@@ -365,6 +380,7 @@ impl UI {
             .unwrap_or_default();
         ui_global.set_font_family(config.appearance.font_family.into());
         ui_global.set_font_size(config.appearance.font_size as i32);
+        ui_global.set_reduce_motion(config.appearance.reduce_motion);
         // Apply locale after the Slint component exists — select_bundled_translation
         // requires a live component and is a no-op if called before one is created.
         let lang = &config.ui.language;
@@ -1068,6 +1084,21 @@ impl UI {
         });
     }
 
+    fn register_reduce_motion_callback(window: &crate::AppWindow, tx_cmd: mpsc::Sender<Command>) {
+        let ui = window.global::<crate::UiState>();
+        let window_weak = window.as_weak(); // clone required: on_toggle_reduce_motion closure
+        ui.on_toggle_reduce_motion(move || {
+            with_ui(&window_weak, |ui| {
+                let new_val = !ui.get_reduce_motion();
+                ui.set_reduce_motion(new_val);
+                send_cmd(
+                    &tx_cmd,
+                    Command::UpdateConfig(ConfigUpdate::ReduceMotion(new_val)),
+                );
+            });
+        });
+    }
+
     // ── Window lifecycle ──────────────────────────────────────────────────────
 
     fn register_close_handler(
@@ -1614,7 +1645,14 @@ impl UI {
                     )
                 };
                 with_ui(&window_weak, |ui| {
-                    ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                    let model = ui.get_sidebar_tree();
+                    if model.row_count() == nodes.len() {
+                        for (i, node) in nodes.into_iter().enumerate() {
+                            model.set_row_data(i, node);
+                        }
+                    } else {
+                        ui.set_sidebar_tree(Rc::new(slint::VecModel::from(nodes)).into());
+                    }
                 });
             });
         }

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -151,11 +151,15 @@ fn build_sidebar_tree_should_show_categories_when_connection_expanded() {
     let mut metadata = HashMap::new();
     metadata.insert("a".to_string(), make_meta(&["users"]));
     let nodes = build_sidebar_tree(&conns, "a", &metadata, &expanded, &HashMap::new());
-    // conn + Tables + Views + Stored Procedures + Indexes = 5 nodes
-    assert_eq!(nodes.len(), 5);
+    // conn + Tables + users(visible=false) + Views + Stored Procedures + Indexes = 6 nodes
+    // Children are always emitted; visible flag drives animation.
+    assert_eq!(nodes.len(), 6);
     assert_eq!(nodes[1].label.as_str(), "Tables");
     assert_eq!(nodes[1].level, 1);
     assert_eq!(nodes[1].node_kind.as_str(), "category");
+    // "users" is emitted but invisible (Tables category not expanded)
+    assert_eq!(nodes[2].label.as_str(), "users");
+    assert!(!nodes[2].visible);
 }
 
 #[test]
@@ -185,8 +189,26 @@ fn build_sidebar_tree_should_hide_children_when_collapsed() {
         &HashSet::new(),
         &HashMap::new(),
     );
+    // No metadata → no child nodes emitted at all.
     assert_eq!(nodes.len(), 1);
     assert_eq!(nodes[0].level, 0);
+}
+
+#[test]
+fn build_sidebar_tree_should_emit_invisible_children_for_animation() {
+    let conns = vec![make_conn("a", "Alpha")];
+    let mut metadata = HashMap::new();
+    metadata.insert("a".to_string(), make_meta(&["users"]));
+    // Connection collapsed (not in expanded)
+    let nodes = build_sidebar_tree(&conns, "a", &metadata, &HashSet::new(), &HashMap::new());
+    // Categories are emitted but invisible
+    assert!(nodes.len() > 1);
+    for node in nodes.iter().skip(1) {
+        assert!(
+            !node.visible,
+            "category should be invisible when conn collapsed"
+        );
+    }
 }
 
 #[test]

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -40,6 +40,7 @@ export global Colors {
     out property <color> shadow:         #00000088;
     out property <color> modal-overlay:  #00000099;
     out property <color> hover-subtle:   is-dark ? #ffffff0d : #0000000d;
+    out property <color> hover-btn:      is-dark ? #ffffff1a : #00000014;
 }
 
 export global Typography {
@@ -107,6 +108,26 @@ export global Layout {
 
     // ── Sidebar-specific ──────────────────────────────────────────────────────
     out property <length> sidebar-indent: 14px;  // per-level indentation in tree
+}
+
+export global Animation {
+    in-out property <bool> reduce-motion: false;
+
+    // ── Duration tokens ───────────────────────────────────────────────────────
+    out property <duration> instant:      reduce-motion ? 0ms :  80ms;  // button press scale
+    out property <duration> fast:         reduce-motion ? 0ms : 120ms;  // exit / dismiss
+    out property <duration> feedback:     reduce-motion ? 0ms : 150ms;  // hover, checkbox, status
+    out property <duration> standard:     reduce-motion ? 0ms : 200ms;  // tab slide, value change
+    out property <duration> enter:        reduce-motion ? 0ms : 160ms;  // modal enter
+    out property <duration> stagger-step: reduce-motion ? 0ms :  30ms;  // per-item list stagger
+
+    // ── Easing tokens ─────────────────────────────────────────────────────────
+    // Intended spring: cubic-bezier(0.34, 1.56, 0.64, 1) — overshoot then settle.
+    // Using ease-out as placeholder until Slint cubic-bezier syntax is stable.
+    out property <easing> enter-ease:  ease-out;
+    out property <easing> exit-ease:   ease-in;
+    out property <easing> value-ease:  ease-in-out;
+    out property <easing> linear-ease: linear;
 }
 
 export global Icons {

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -139,6 +139,7 @@ mod tests {
                 theme: Theme::Light,
                 font_family: "Cascadia Code".to_string(),
                 font_size: 16,
+                reduce_motion: false,
             },
             ..Config::default()
         };

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -77,6 +77,8 @@ pub struct AppearanceConfig {
     pub theme: Theme,
     pub font_family: String,
     pub font_size: u32,
+    /// When true, all UI animation durations collapse to 0ms.
+    pub reduce_motion: bool,
 }
 
 impl Default for AppearanceConfig {
@@ -85,6 +87,7 @@ impl Default for AppearanceConfig {
             theme: Theme::Dark,
             font_family: "JetBrains Mono".to_string(),
             font_size: 14,
+            reduce_motion: false,
         }
     }
 }
@@ -196,6 +199,7 @@ mod tests {
         assert_eq!(cfg.appearance.theme, Theme::Dark);
         assert_eq!(cfg.appearance.font_family, "JetBrains Mono");
         assert_eq!(cfg.appearance.font_size, 14);
+        assert!(!cfg.appearance.reduce_motion);
         assert_eq!(cfg.editor.page_size, PageSize::Rows500);
         assert_eq!(cfg.session.last_connection_id, None);
         assert_eq!(cfg.session.last_query, None);
@@ -210,6 +214,7 @@ mod tests {
 theme = "light"
 font_family = "Fira Code"
 font_size = 16
+reduce_motion = true
 
 [editor]
 page_size = 1000
@@ -249,6 +254,7 @@ database = "local.db"
             Some("SELECT * FROM users".to_string())
         );
         assert_eq!(cfg.ui.language, "ja");
+        assert!(cfg.appearance.reduce_motion);
 
         assert_eq!(cfg.connections.len(), 2);
         let pg = &cfg.connections[0];
@@ -308,6 +314,7 @@ database = "local.db"
                 theme: Theme::Light,
                 font_family: "Cascadia Code".to_string(),
                 font_size: 13,
+                reduce_motion: false,
             },
             editor: EditorConfig {
                 page_size: PageSize::Rows100,

--- a/docs/specs/animation.md
+++ b/docs/specs/animation.md
@@ -1,0 +1,106 @@
+# Animation Specification
+
+## Philosophy
+
+wellfeather is a keyboard-centric editor tool. Animations must **never interrupt the user's
+workflow**. The guiding rule is:
+
+> If the user triggered an action, the result should appear immediately.
+
+- Active operations (modal open/close, sidebar expand/collapse) are **instant** — no transition
+- Passive feedback (button hover, checkbox toggle) use short transitions that do not block interaction
+- The `Animation` global and `reduce-motion` infrastructure are preserved for future phases
+  (ER diagrams, graph visualisations) where richer motion will be appropriate
+
+---
+
+## Design Tokens
+
+Animation constants are centralised in the `Animation` global in `theme.slint`.
+Components must never hard-code duration or easing values — always reference this global.
+
+```slint
+export global Animation {
+    in-out property <bool> reduce-motion: false;
+
+    // ── Duration tokens ──────────────────────────────────────────────────────
+    out property <duration> instant:       reduce-motion ? 0ms :  80ms;  // (reserved)
+    out property <duration> fast:          reduce-motion ? 0ms : 120ms;  // (reserved)
+    out property <duration> feedback:      reduce-motion ? 0ms : 150ms;  // hover, checkbox
+    out property <duration> standard:      reduce-motion ? 0ms : 200ms;  // (reserved)
+    out property <duration> enter:         reduce-motion ? 0ms : 160ms;  // (reserved)
+    out property <duration> stagger-step:  reduce-motion ? 0ms :  30ms;  // (reserved)
+
+    // ── Easing tokens ────────────────────────────────────────────────────────
+    out property <easing> enter-ease:   ease-out;
+    out property <easing> exit-ease:    ease-in;
+    out property <easing> value-ease:   ease-in-out;
+    out property <easing> linear-ease:  linear;
+}
+```
+
+---
+
+## Active Animations
+
+| Component | Property | Duration | Easing | Notes |
+|-----------|----------|----------|--------|-------|
+| ToolbarButton hover | `background` | 150ms | ease-out | Active/inactive state change |
+| ActionButton hover overlay | `opacity` | 150ms | ease-out | Subtle hover tint |
+| CheckRow checkbox | `background`, `border-color` | 150ms | ease-in-out | Checked state transition |
+| CheckRow check icon | `opacity` | 120ms | ease-in-out | Icon fade-in |
+| Loading spinner | `ProgressIndicator` (indeterminate) | — | — | std-widgets built-in |
+
+---
+
+## Intentionally Removed
+
+| Component | Reason |
+|-----------|--------|
+| Modal enter/exit | Instant open/close is less disruptive in an editor context |
+| Sidebar expand/collapse | Immediate response is expected on key press or click |
+| Button press scale | Too app-like for an editor tool |
+| Button ripple effect | Too Material Design; inconsistent with editor aesthetic |
+
+---
+
+## Reserved for Future Phases
+
+The `Animation` tokens and `reduce-motion` support are intentionally kept for:
+
+- **ER diagram**: node drag, edge routing, pan/zoom transitions
+- **Graph visualisations**: data series enter/exit, tooltip animations
+
+When those features are implemented, each new animation must follow the `reduce-motion` pattern
+so users can opt out of all motion at once.
+
+---
+
+## Reduce Motion
+
+Stored in `config.toml` and toggled via View > Reduce Motion.
+
+```toml
+[appearance]
+reduce_motion = false
+```
+
+All `Animation` duration tokens are conditioned on `reduce-motion`:
+
+```slint
+out property <duration> feedback: reduce-motion ? 0ms : 150ms;
+```
+
+Every new animation added to the codebase must follow this pattern.
+
+---
+
+## Slint Constraints and Workarounds
+
+| Constraint | Workaround |
+|------------|------------|
+| `cubic-bezier` spring syntax not yet stable | Use `ease-out` as a placeholder; mark with a comment |
+| No animate-completion callback | Use a `Timer` set to the exit duration before hiding the element |
+| Elements created by `if` cannot animate on entry | Use `init =>` to set the target value after creation |
+| No `transform: scale` | Approximate via `width`/`height` percentage change + `x`/`y` offset correction |
+| No native list stagger support | Assign a stagger index from Rust; apply delayed `opacity` updates per item |


### PR DESCRIPTION
## Summary

Establishes the animation system for wellfeather with an editor-first philosophy: active operations (modal open/close, sidebar expand/collapse) are instant so they never interrupt workflow, while passive feedback elements (button hover, checkbox) retain short transitions. The `Animation` global and `reduce-motion` infrastructure are preserved for future ER diagram and graph visualisation phases.

## Changes

- **`theme.slint`**: Add `Animation` global with duration/easing tokens and `reduce-motion` toggle; all durations conditioned on `reduce-motion`
- **`common.slint`**: Simplify `ActionButton` — remove press scale and ripple effect; keep hover overlay (150ms); simplify `ModalOverlay` to instant show/hide with `exited()` fired directly in `changed show`
- **`db_manager_dialog.slint`**: Remove opacity animation; instant open/close
- **`sidebar.slint`**: Remove height animation from tree nodes; instant expand/collapse
- **`result_table.slint`**: Replace custom SVG spinner + `rotation-angle` (deprecated) with `ProgressIndicator { indeterminate: true }`; remove `Icons.loader` and `loader.svg`
- **`menu_bar.slint`**: Add View > Reduce Motion menu item
- **`app.slint`**: Add `reduce-motion` to `UiState`; wire `_alive` lifecycle pattern for all dialogs (enter animation via `init`, exit via `changed show` + `exited()`)
- **`mod.rs`**: Register `on_toggle_reduce_motion` callback; update `on_toggle_sidebar_node` to use `set_row_data` for in-place VecModel updates (enables future binding-driven animations without full model replacement)
- **`wf-config`**: Add `reduce_motion: bool` to `AppearanceConfig` (default `false`)
- **`docs/specs/animation.md`**: New specification document capturing design decisions, active animations, intentionally removed items, and reserved future phases

## Related Issues

Closes #242

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes