### PR TITLE
feat(ui): add floating find/replace bar with search history (Ctrl+F)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6765,6 +6765,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "chrono",
+ "regex",
  "rfd",
  "rust-i18n",
  "serde",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,7 @@ uuid               = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 toml               = "1"
 rust-i18n          = "4.0.0"
+regex              = "1.12.3"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -368,3 +368,27 @@ msgstr "Execute"
 msgctxt "MenuBar"
 msgid "Reduce Motion"
 msgstr "Reduce Motion"
+
+msgctxt "FindReplaceBar"
+msgid "No results"
+msgstr "No results"
+
+msgctxt "FindReplaceBar"
+msgid "Replace"
+msgstr "Replace"
+
+msgctxt "FindReplaceBar"
+msgid "Replace All"
+msgstr "Replace All"
+
+msgctxt "FindReplaceBar"
+msgid "Find"
+msgstr "Find"
+
+msgctxt "FindReplaceBar"
+msgid "Find (↑↓ for history)"
+msgstr "Find (↑↓ for history)"
+
+msgctxt "FindReplaceBar"
+msgid "Replace (↑↓ for history)"
+msgstr "Replace (↑↓ for history)"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -368,3 +368,27 @@ msgstr "実行"
 msgctxt "MenuBar"
 msgid "Reduce Motion"
 msgstr "モーション軽減"
+
+msgctxt "FindReplaceBar"
+msgid "No results"
+msgstr "一致なし"
+
+msgctxt "FindReplaceBar"
+msgid "Replace"
+msgstr "置換"
+
+msgctxt "FindReplaceBar"
+msgid "Replace All"
+msgstr "すべて置換"
+
+msgctxt "FindReplaceBar"
+msgid "Find"
+msgstr "検索"
+
+msgctxt "FindReplaceBar"
+msgid "Find (↑↓ for history)"
+msgstr "検索（↑↓で履歴）"
+
+msgctxt "FindReplaceBar"
+msgid "Replace (↑↓ for history)"
+msgstr "置換（↑↓で履歴）"

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -23,6 +23,7 @@ import { AddConnectionDialog } from "components/dialogs/add_connection_dialog.sl
 import { AllRowsDialog }       from "components/dialogs/all_rows_dialog.slint";
 import { SafeDmlDialog }       from "components/dialogs/safe_dml_dialog.slint";
 import { DbManagerDialog }     from "components/dialogs/db_manager_dialog.slint";
+import { FindReplaceBar }     from "components/find_replace_bar.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -153,6 +154,31 @@ export global UiState {
     in-out property <bool>   conn-safe-dml: true;
     /// Active connection read_only setting (set by Rust on connect).
     in-out property <bool>   conn-read-only: false;
+
+    // ── Find / replace bar ────────────────────────────────────────────────────
+    in-out property <bool>   show-find-bar:         false;
+    in-out property <bool>   find-bar-with-replace: false;
+    in-out property <string> find-query:            "";
+    in-out property <string> find-replace-text:     "";
+    in-out property <bool>   find-case-sensitive:   false;
+    in-out property <bool>   find-use-regex:        false;
+    in-out property <int>    find-current-match:    0;
+    in-out property <int>    find-total-matches:    0;
+    in-out property <int>    find-sel-start:        -1;
+    in-out property <int>    find-sel-end:          -1;
+    callback load-find-history();
+    callback find-search();
+    callback find-next();
+    callback find-prev();
+    callback find-history-prev();
+    callback find-history-next();
+    callback replace-history-prev();
+    callback replace-history-next();
+    callback commit-search();
+    callback commit-replace();
+    callback replace-one();
+    callback replace-all();
+
     /// User confirmed dangerous DML execution.
     callback confirm-safe-dml();
     /// User dismissed the dangerous DML confirm popup.
@@ -416,6 +442,13 @@ export component AppWindow inherits Window {
                 EventResult.accept
             } else if (event.modifiers.control
                     && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && UiState.active-tab-kind-sql
+                    && event.text == "f") {
+                UiState.show-find-bar = true;
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
                     && !event.modifiers.alt) {
                 if (event.text == "1" && UiState.tabs.length > 0) {
                     UiState.switch-tab(0);
@@ -595,12 +628,52 @@ export component AppWindow inherits Window {
                 completion-selected  <=> UiState.completion-selected;
                 editor-cursor-target <=> UiState.editor-cursor-target;
                 accept-completion(text, pos, offset, tname) => { UiState.accept-completion(text, pos, offset, tname); }
+                find-sel-start <=> UiState.find-sel-start;
+                find-sel-end   <=> UiState.find-sel-end;
+                find-bar-open:     UiState.show-find-bar;
+                close-find-bar => {
+                    UiState.show-find-bar = false;
+                    UiState.find-sel-start = -1;
+                    UiState.find-sel-end = -1;
+                }
                 focus-sidebar => { root.focused-pane = 0; sidebar-inst.grab-focus(); }
                 focus-result  => {
                     if (UiState.result-panel-open) {
                         root.focused-pane = 2;
                         result-table-inst.grab-focus();
                     }
+                }
+            }
+
+            // ── Find / replace bar overlay ────────────────────────────────────
+            if UiState.show-find-bar && UiState.active-tab-kind-sql: FindReplaceBar {
+                x: parent.width - 388px;
+                y: 4px;
+                width: 380px;
+                with-replace:   UiState.find-bar-with-replace;
+                query          <=> UiState.find-query;
+                replace-text   <=> UiState.find-replace-text;
+                case-sensitive <=> UiState.find-case-sensitive;
+                use-regex      <=> UiState.find-use-regex;
+                current-match:     UiState.find-current-match;
+                total-matches:     UiState.find-total-matches;
+                load-history         => { UiState.load-find-history(); }
+                find-search          => { UiState.find-search(); }
+                find-next            => { UiState.find-next(); }
+                find-prev            => { UiState.find-prev(); }
+                find-history-prev    => { UiState.find-history-prev(); }
+                find-history-next    => { UiState.find-history-next(); }
+                replace-history-prev => { UiState.replace-history-prev(); }
+                replace-history-next => { UiState.replace-history-next(); }
+                commit-search        => { UiState.commit-search(); }
+                commit-replace       => { UiState.commit-replace(); }
+                replace-one          => { UiState.replace-one(); }
+                replace-all          => { UiState.replace-all(); }
+                close-bar => {
+                    UiState.show-find-bar = false;
+                    UiState.find-sel-start = -1;
+                    UiState.find-sel-end = -1;
+                    editor-inst.grab-focus();
                 }
             }
 

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -90,6 +90,27 @@ export component Editor inherits Rectangle {
     callback focus-sidebar();
     callback focus-result();
 
+    // ── Find bar integration ──────────────────────────────────────────────────
+    /// True when the find bar is open; allows Esc to close it from the editor.
+    in property <bool> find-bar-open: false;
+    /// Fired when Esc is pressed while the find bar is open and editor has focus.
+    callback close-find-bar();
+
+    /// Byte offsets of the current find-bar match highlight (-1 = clear selection).
+    in-out property <int> find-sel-start: -1;
+    in-out property <int> find-sel-end:   -1;
+
+    changed find-sel-start => {
+        if (root.find-sel-start < 0) {
+            inner-input.set-selection-offsets(
+                inner-input.cursor-position-byte-offset,
+                inner-input.cursor-position-byte-offset
+            );
+        } else if (root.find-sel-end >= root.find-sel-start) {
+            inner-input.set-selection-offsets(root.find-sel-start, root.find-sel-end);
+        }
+    }
+
     // ── Out properties consumed by the external gutter in app.slint ──────────
     out property <length> gutter-scroll-y:  editor-scroll.viewport-y;
     out property <length> gutter-line-h:    root.line-h;
@@ -525,6 +546,11 @@ export component Editor inherits Rectangle {
                     if (event.text == Key.LeftArrow) { root.focus-sidebar(); EventResult.accept }
                     else if (event.text == Key.DownArrow) { root.focus-result(); EventResult.accept }
                     else { EventResult.reject }
+                } else if (event.text == Key.Escape
+                        && root.find-bar-open
+                        && !root.completion-visible) {
+                    root.close-find-bar();
+                    EventResult.accept
                 } else {
                     EventResult.reject
                 }

--- a/app/src/ui/components/find_replace_bar.slint
+++ b/app/src/ui/components/find_replace_bar.slint
@@ -1,0 +1,324 @@
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
+
+export component FindReplaceBar inherits Rectangle {
+    in-out property <string> query:          "";
+    in-out property <string> replace-text:   "";
+    in-out property <bool>   with-replace:   false;
+    in-out property <bool>   case-sensitive: false;
+    in-out property <bool>   use-regex:      false;
+    in property    <int>     current-match:  0;
+    in property    <int>     total-matches:  0;
+    callback load-history();
+    callback find-search();
+    callback find-next();
+    callback find-prev();
+    callback find-history-prev();
+    callback find-history-next();
+    callback replace-history-prev();
+    callback replace-history-next();
+    callback commit-search();
+    callback commit-replace();
+    callback replace-one();
+    callback replace-all();
+    callback close-bar();
+
+    background:    Colors.surface0;
+    border-radius: Layout.radius-md;
+    border-width:  1px;
+    border-color:  Colors.surface1;
+    drop-shadow-blur:  8px;
+    drop-shadow-color: Colors.shadow;
+
+    height: root.with-replace ? 68px : 34px;
+
+    init => {
+        query-input.focus();
+        root.load-history();
+    }
+
+    query-fs := FocusScope {
+        focus-on-click: false;
+
+        capture-key-pressed(event) => {
+            if (event.text == Key.Escape) {
+                root.close-bar();
+                EventResult.accept
+            } else if (event.text == Key.Return && event.modifiers.shift) {
+                root.find-prev();
+                EventResult.accept
+            } else if (event.text == Key.Return && !event.modifiers.shift) {
+                if (query-input.has-focus) {
+                    root.commit-search();
+                    root.find-next();
+                } else {
+                    root.commit-replace();
+                    root.replace-one();
+                }
+                EventResult.accept
+            } else if (event.text == Key.DownArrow) {
+                if (query-input.has-focus) {
+                    root.find-history-next();
+                } else {
+                    root.replace-history-next();
+                }
+                EventResult.accept
+            } else if (event.text == Key.UpArrow) {
+                if (query-input.has-focus) {
+                    root.find-history-prev();
+                } else {
+                    root.replace-history-prev();
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+        VerticalLayout {
+            spacing: 0;
+
+            // ── Find row ──────────────────────────────────────────────────────
+            HorizontalLayout {
+                height: 34px;
+                padding-left:   Layout.padding-xs;
+                padding-right:  Layout.padding-xs;
+                padding-top:    6px;
+                padding-bottom: 6px;
+                spacing: Layout.spacing-xs;
+
+                // Replace-row toggle (▶ / ▼) — VSCode style
+                Rectangle {
+                    width: 20px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: toggle-ta.has-hover ? Colors.surface1 : transparent;
+                    Image {
+                        width:  Layout.icon-sm;
+                        height: Layout.icon-sm;
+                        source: root.with-replace ? Icons.chevron-down : Icons.chevron-right;
+                        image-fit: contain;
+                        colorize: Colors.subtext0;
+                    }
+                    toggle-ta := TouchArea {
+                        clicked => { root.with-replace = !root.with-replace; }
+                    }
+                }
+
+                // Find input
+                Rectangle {
+                    horizontal-stretch: 1;
+                    height: 22px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  query-input.has-focus ? Colors.blue : Colors.surface1;
+                    background:    Colors.base;
+
+                    if root.query == "": Text {
+                        x: Layout.padding-xs;
+                        width:  parent.width - 2 * Layout.padding-xs;
+                        height: parent.height;
+                        text: query-input.has-focus
+                            ? @tr("Find (↑↓ for history)")
+                            : @tr("Find");
+                        color: Colors.overlay0;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+
+                    query-input := TextInput {
+                        x: Layout.padding-xs;
+                        width:  parent.width - 2 * Layout.padding-xs;
+                        height: parent.height;
+                        single-line: true;
+                        text:   root.query;
+                        color:  Colors.text;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                        edited => {
+                            root.query = self.text;
+                            root.find-search();
+                        }
+                    }
+                }
+
+                // Aa (case-sensitive) toggle
+                Rectangle {
+                    width: 22px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  root.case-sensitive ? Colors.blue : Colors.surface1;
+                    background:    root.case-sensitive ? Colors.blue : transparent;
+                    Text {
+                        text: "Aa";
+                        color: root.case-sensitive ? Colors.base : Colors.subtext0;
+                        font-size: Typography.size-xs;
+                        horizontal-alignment: center;
+                        vertical-alignment:   center;
+                    }
+                    TouchArea {
+                        clicked => {
+                            root.case-sensitive = !root.case-sensitive;
+                            root.find-search();
+                        }
+                    }
+                }
+
+                // .* (regex) toggle
+                Rectangle {
+                    width: 22px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  root.use-regex ? Colors.blue : Colors.surface1;
+                    background:    root.use-regex ? Colors.blue : transparent;
+                    Text {
+                        text: ".*";
+                        color: root.use-regex ? Colors.base : Colors.subtext0;
+                        font-size: Typography.size-xs;
+                        horizontal-alignment: center;
+                        vertical-alignment:   center;
+                    }
+                    TouchArea {
+                        clicked => {
+                            root.use-regex = !root.use-regex;
+                            root.find-search();
+                        }
+                    }
+                }
+
+                // Match count "N / M"
+                Text {
+                    text: root.total-matches == 0
+                        ? @tr("No results")
+                        : "\{root.current-match} / \{root.total-matches}";
+                    color: root.total-matches == 0 ? Colors.overlay0 : Colors.subtext0;
+                    font-size: Typography.size-sm;
+                    vertical-alignment: center;
+                    width: 52px;
+                    horizontal-alignment: right;
+                }
+
+                // ▲ prev
+                Rectangle {
+                    width: 22px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: prev-ta.has-hover ? Colors.surface1 : transparent;
+                    Image {
+                        width:  Layout.icon-sm;
+                        height: Layout.icon-sm;
+                        source: Icons.chevron-down;
+                        image-fit: contain;
+                        colorize: Colors.subtext0;
+                        transform-rotation: 180deg;
+                    }
+                    prev-ta := TouchArea { clicked => { root.find-prev(); } }
+                }
+
+                // ▼ next
+                Rectangle {
+                    width: 22px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: next-ta.has-hover ? Colors.surface1 : transparent;
+                    Image {
+                        width:  Layout.icon-sm;
+                        height: Layout.icon-sm;
+                        source: Icons.chevron-down;
+                        image-fit: contain;
+                        colorize: Colors.subtext0;
+                    }
+                    next-ta := TouchArea { clicked => { root.find-next(); } }
+                }
+
+                // ✕ close
+                Rectangle {
+                    width: 22px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: close-ta.has-hover ? Colors.surface1 : transparent;
+                    Image {
+                        width:  Layout.icon-sm;
+                        height: Layout.icon-sm;
+                        source: Icons.close;
+                        image-fit: contain;
+                        colorize: Colors.subtext0;
+                    }
+                    close-ta := TouchArea { clicked => { root.close-bar(); } }
+                }
+            }
+
+            // ── Replace row (shown when toggle is open) ───────────────────────
+            if root.with-replace: HorizontalLayout {
+                height: 34px;
+                padding-left:   Layout.padding-xs;
+                padding-right:  Layout.padding-xs;
+                padding-top:    6px;
+                padding-bottom: 6px;
+                spacing: Layout.spacing-xs;
+
+                // Spacer aligns replace input with find input
+                Rectangle { width: 20px; }
+
+                // Replace input
+                Rectangle {
+                    horizontal-stretch: 1;
+                    height: 22px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  replace-input.has-focus ? Colors.blue : Colors.surface1;
+                    background:    Colors.base;
+
+                    if root.replace-text == "": Text {
+                        x: Layout.padding-xs;
+                        width:  parent.width - 2 * Layout.padding-xs;
+                        height: parent.height;
+                        text: replace-input.has-focus
+                            ? @tr("Replace (↑↓ for history)")
+                            : @tr("Replace");
+                        color: Colors.overlay0;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+
+                    replace-input := TextInput {
+                        x: Layout.padding-xs;
+                        width:  parent.width - 2 * Layout.padding-xs;
+                        height: parent.height;
+                        single-line: true;
+                        text:   root.replace-text;
+                        color:  Colors.text;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                        edited => { root.replace-text = self.text; }
+                    }
+                }
+
+                // Replace button
+                Rectangle {
+                    width: 64px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: rep-one-ta.has-hover ? Colors.surface2 : Colors.surface1;
+                    Text {
+                        text: @tr("Replace");
+                        color: Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment:   center;
+                    }
+                    rep-one-ta := TouchArea { clicked => { root.replace-one(); } }
+                }
+
+                // Replace All button
+                Rectangle {
+                    width: 80px; height: 22px;
+                    border-radius: Layout.radius-sm;
+                    background: rep-all-ta.has-hover ? Colors.surface2 : Colors.surface1;
+                    Text {
+                        text: @tr("Replace All");
+                        color: Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment:   center;
+                    }
+                    rep-all-ta := TouchArea { clicked => { root.replace-all(); } }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc;
 use wf_completion::CompletionItem;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
+use wf_history::find_history::FindHistoryService;
 use wf_query::analyzer::{extract_statement_at, has_dangerous_dml};
 
 const COMPLETION_DEBOUNCE_MS: u64 = 300;
@@ -80,6 +81,113 @@ struct OriginalQueryData {
 }
 
 type SharedOriginalData = Arc<Mutex<Option<OriginalQueryData>>>;
+
+// ── Find / replace helpers ────────────────────────────────────────────────────
+
+/// History data shared between the tokio task that loads from SQLite and the
+/// UI-thread callbacks that navigate it.  Arc<Mutex<>> because it crosses the
+/// async boundary; actual navigation index lives in FindState (UI thread only).
+#[derive(Default)]
+struct HistorySnapshot {
+    find: Vec<String>, // newest-first (index 0 = most recently inserted)
+    replace: Vec<String>,
+}
+
+type SharedHistorySnapshot = Arc<std::sync::Mutex<HistorySnapshot>>;
+
+/// Cached state for the find bar — avoids re-scanning on next/prev when the
+/// query and text have not changed.
+#[derive(Default)]
+struct FindState {
+    last_text: String,
+    last_query: String,
+    last_case_sensitive: bool,
+    last_use_regex: bool,
+    matches: Vec<(usize, usize)>, // (start_byte, end_byte)
+    current: usize,
+    // History navigation (UI thread only)
+    find_hist_idx: Option<usize>, // None = not browsing; Some(i) = position in snapshot.find
+    replace_hist_idx: Option<usize>,
+    find_draft: String, // query captured before history browsing started
+    replace_draft: String,
+}
+
+/// Open the find history service lazily, caching it for reuse across calls.
+async fn get_find_history_svc(
+    svc_arc: &Arc<tokio::sync::Mutex<Option<FindHistoryService>>>,
+    db_path: &std::path::Path,
+) -> Option<FindHistoryService> {
+    let mut guard = svc_arc.lock().await;
+    if guard.is_none() {
+        match FindHistoryService::open(db_path).await {
+            Ok(s) => *guard = Some(s),
+            Err(e) => {
+                tracing::warn!("find history db open failed: {e}");
+                return None;
+            }
+        }
+    }
+    guard.as_ref().cloned()
+}
+
+impl FindState {
+    /// Re-compute matches when any parameter changed; clamps `current`.
+    fn update(&mut self, text: &str, query: &str, case_sensitive: bool, use_regex: bool) {
+        if text == self.last_text
+            && query == self.last_query
+            && case_sensitive == self.last_case_sensitive
+            && use_regex == self.last_use_regex
+        {
+            return;
+        }
+        self.matches = compute_matches(text, query, case_sensitive, use_regex);
+        self.last_text = text.to_string();
+        self.last_query = query.to_string();
+        self.last_case_sensitive = case_sensitive;
+        self.last_use_regex = use_regex;
+        if self.matches.is_empty() {
+            self.current = 0;
+        } else {
+            self.current = self.current.min(self.matches.len() - 1);
+        }
+    }
+
+    fn params_changed(&self, query: &str, case_sensitive: bool, use_regex: bool) -> bool {
+        query != self.last_query
+            || case_sensitive != self.last_case_sensitive
+            || use_regex != self.last_use_regex
+    }
+}
+
+/// Returns all (start_byte, end_byte) positions where `query` matches in `text`.
+pub(crate) fn compute_matches(
+    text: &str,
+    query: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+) -> Vec<(usize, usize)> {
+    if query.is_empty() {
+        return vec![];
+    }
+    let pattern = if use_regex {
+        if case_sensitive {
+            query.to_string()
+        } else {
+            format!("(?i){query}")
+        }
+    } else {
+        let escaped = regex::escape(query);
+        if case_sensitive {
+            escaped
+        } else {
+            format!("(?i){escaped}")
+        }
+    };
+    match regex::Regex::new(&pattern) {
+        Ok(re) => re.find_iter(text).map(|m| (m.start(), m.end())).collect(),
+        Err(_) => vec![],
+    }
+}
 
 use wf_config::models::{ConnectionConfig, DbTypeName, Theme};
 
@@ -451,6 +559,7 @@ impl UI {
             tx_cmd.clone(),
         );
         Self::register_language_callback(&window, tx_cmd.clone());
+        Self::register_find_replace_callbacks(&window);
         Self::register_status_callbacks(&window, state.clone());
         Self::spawn_event_handler(
             &window,
@@ -2619,6 +2728,489 @@ impl UI {
             // Persist to config.toml via controller.
             send_cmd(&tx_cmd, Command::UpdateConfig(ConfigUpdate::Language(lang)));
         });
+    }
+
+    // ── Find / replace callbacks ──────────────────────────────────────────────
+
+    fn register_find_replace_callbacks(window: &crate::AppWindow) {
+        let ui_state = window.global::<crate::UiState>();
+        let find_state: Rc<RefCell<FindState>> = Rc::new(RefCell::new(FindState::default()));
+        let history: SharedHistorySnapshot =
+            Arc::new(std::sync::Mutex::new(HistorySnapshot::default()));
+        let svc: Arc<tokio::sync::Mutex<Option<FindHistoryService>>> =
+            Arc::new(tokio::sync::Mutex::new(None));
+        let db_path = wf_config::manager::ConfigManager::app_dir().join("history.db");
+
+        // ── load-find-history: reset nav state and load from SQLite on bar open
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_load_find_history
+            let svc = svc.clone(); // clone required: moved into tokio::spawn
+            let history = history.clone(); // clone required: moved into tokio::spawn
+            let db_path = db_path.clone(); // clone required: moved into tokio::spawn
+            ui_state.on_load_find_history(move || {
+                {
+                    let mut state = find_state.borrow_mut();
+                    state.find_hist_idx = None;
+                    state.replace_hist_idx = None;
+                }
+                let svc = svc.clone(); // clone required: moved into tokio::spawn
+                let history = history.clone(); // clone required: moved into tokio::spawn
+                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
+                tokio::spawn(async move {
+                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
+                        return;
+                    };
+                    let find_items = service.get("find", 30).await.unwrap_or_default();
+                    let replace_items = service.get("replace", 30).await.unwrap_or_default();
+                    let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                    snap.find = find_items;
+                    snap.replace = replace_items;
+                });
+            });
+        }
+
+        // ── find-search: recompute all matches, go to first ──────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_find_search
+            let window_weak = window.as_weak();
+            ui_state.on_find_search(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_editor_text().to_string();
+                let query = ui.get_find_query().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+
+                let mut state = find_state.borrow_mut();
+                state.find_hist_idx = None; // typing resets history browsing
+                state.last_query = String::new(); // force re-computation
+                state.update(&text, &query, cs, rx);
+
+                if state.matches.is_empty() {
+                    ui.set_find_current_match(0);
+                    ui.set_find_total_matches(0);
+                    ui.set_find_sel_start(-1);
+                    ui.set_find_sel_end(-1);
+                    return;
+                }
+                state.current = 0;
+                let (start, end) = state.matches[0];
+                ui.set_find_current_match(1);
+                ui.set_find_total_matches(state.matches.len() as i32);
+                ui.set_find_sel_start(start as i32);
+                ui.set_find_sel_end(end as i32);
+            });
+        }
+
+        // ── find-next ────────────────────────────────────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_find_next
+            let window_weak = window.as_weak();
+            ui_state.on_find_next(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_editor_text().to_string();
+                let query = ui.get_find_query().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+
+                let mut state = find_state.borrow_mut();
+                let params_changed = state.params_changed(&query, cs, rx);
+                state.update(&text, &query, cs, rx);
+                if state.matches.is_empty() {
+                    ui.set_find_current_match(0);
+                    ui.set_find_total_matches(0);
+                    ui.set_find_sel_start(-1);
+                    ui.set_find_sel_end(-1);
+                    return;
+                }
+                if !params_changed {
+                    state.current = (state.current + 1) % state.matches.len();
+                }
+                let (start, end) = state.matches[state.current];
+                ui.set_find_current_match((state.current + 1) as i32);
+                ui.set_find_total_matches(state.matches.len() as i32);
+                ui.set_find_sel_start(start as i32);
+                ui.set_find_sel_end(end as i32);
+            });
+        }
+
+        // ── find-prev ────────────────────────────────────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_find_prev
+            let window_weak = window.as_weak();
+            ui_state.on_find_prev(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_editor_text().to_string();
+                let query = ui.get_find_query().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+
+                let mut state = find_state.borrow_mut();
+                state.update(&text, &query, cs, rx);
+                if state.matches.is_empty() {
+                    ui.set_find_current_match(0);
+                    ui.set_find_total_matches(0);
+                    ui.set_find_sel_start(-1);
+                    ui.set_find_sel_end(-1);
+                    return;
+                }
+                state.current = if state.current == 0 {
+                    state.matches.len() - 1
+                } else {
+                    state.current - 1
+                };
+                let (start, end) = state.matches[state.current];
+                ui.set_find_current_match((state.current + 1) as i32);
+                ui.set_find_total_matches(state.matches.len() as i32);
+                ui.set_find_sel_start(start as i32);
+                ui.set_find_sel_end(end as i32);
+            });
+        }
+
+        // ── find-history-prev (↑ in find input) ──────────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_find_history_prev
+            let history = history.clone(); // clone required: captured by on_find_history_prev
+            let window_weak = window.as_weak();
+            ui_state.on_find_history_prev(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                if snap.find.is_empty() {
+                    return;
+                }
+                let mut state = find_state.borrow_mut();
+                let new_idx = match state.find_hist_idx {
+                    None => {
+                        state.find_draft = ui.get_find_query().to_string();
+                        0
+                    }
+                    Some(i) => (i + 1).min(snap.find.len() - 1),
+                };
+                state.find_hist_idx = Some(new_idx);
+                let query = snap.find[new_idx].clone();
+                drop(snap);
+                drop(state);
+
+                ui.set_find_query(query.clone().into());
+                let text = ui.get_editor_text().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+                let mut state = find_state.borrow_mut();
+                state.last_query = String::new();
+                state.update(&text, &query, cs, rx);
+                if state.matches.is_empty() {
+                    ui.set_find_current_match(0);
+                    ui.set_find_total_matches(0);
+                    ui.set_find_sel_start(-1);
+                    ui.set_find_sel_end(-1);
+                } else {
+                    state.current = 0;
+                    let (start, end) = state.matches[0];
+                    ui.set_find_current_match(1);
+                    ui.set_find_total_matches(state.matches.len() as i32);
+                    ui.set_find_sel_start(start as i32);
+                    ui.set_find_sel_end(end as i32);
+                }
+            });
+        }
+
+        // ── find-history-next (↓ in find input) ──────────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_find_history_next
+            let history = history.clone(); // clone required: captured by on_find_history_next
+            let window_weak = window.as_weak();
+            ui_state.on_find_history_next(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let mut state = find_state.borrow_mut();
+                match state.find_hist_idx {
+                    None => (),
+                    Some(0) => {
+                        state.find_hist_idx = None;
+                        let draft = state.find_draft.clone();
+                        drop(state);
+
+                        ui.set_find_query(draft.clone().into());
+                        let text = ui.get_editor_text().to_string();
+                        let cs = ui.get_find_case_sensitive();
+                        let rx = ui.get_find_use_regex();
+                        let mut st = find_state.borrow_mut();
+                        st.last_query = String::new();
+                        st.update(&text, &draft, cs, rx);
+                        if st.matches.is_empty() {
+                            ui.set_find_current_match(0);
+                            ui.set_find_total_matches(0);
+                            ui.set_find_sel_start(-1);
+                            ui.set_find_sel_end(-1);
+                        } else {
+                            st.current = 0;
+                            let (start, end) = st.matches[0];
+                            ui.set_find_current_match(1);
+                            ui.set_find_total_matches(st.matches.len() as i32);
+                            ui.set_find_sel_start(start as i32);
+                            ui.set_find_sel_end(end as i32);
+                        }
+                    }
+                    Some(i) => {
+                        let snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                        let new_idx = i - 1;
+                        state.find_hist_idx = Some(new_idx);
+                        let query = snap.find[new_idx].clone();
+                        drop(snap);
+                        drop(state);
+
+                        ui.set_find_query(query.clone().into());
+                        let text = ui.get_editor_text().to_string();
+                        let cs = ui.get_find_case_sensitive();
+                        let rx = ui.get_find_use_regex();
+                        let mut st = find_state.borrow_mut();
+                        st.last_query = String::new();
+                        st.update(&text, &query, cs, rx);
+                        if st.matches.is_empty() {
+                            ui.set_find_current_match(0);
+                            ui.set_find_total_matches(0);
+                            ui.set_find_sel_start(-1);
+                            ui.set_find_sel_end(-1);
+                        } else {
+                            st.current = 0;
+                            let (start, end) = st.matches[0];
+                            ui.set_find_current_match(1);
+                            ui.set_find_total_matches(st.matches.len() as i32);
+                            ui.set_find_sel_start(start as i32);
+                            ui.set_find_sel_end(end as i32);
+                        }
+                    }
+                }
+            });
+        }
+
+        // ── replace-history-prev (↑ in replace input) ────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_replace_history_prev
+            let history = history.clone(); // clone required: captured by on_replace_history_prev
+            let window_weak = window.as_weak();
+            ui_state.on_replace_history_prev(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                if snap.replace.is_empty() {
+                    return;
+                }
+                let mut state = find_state.borrow_mut();
+                let new_idx = match state.replace_hist_idx {
+                    None => {
+                        state.replace_draft = ui.get_find_replace_text().to_string();
+                        0
+                    }
+                    Some(i) => (i + 1).min(snap.replace.len() - 1),
+                };
+                state.replace_hist_idx = Some(new_idx);
+                let text = snap.replace[new_idx].clone();
+                drop(snap);
+                drop(state);
+                ui.set_find_replace_text(text.into());
+            });
+        }
+
+        // ── replace-history-next (↓ in replace input) ────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_replace_history_next
+            let history = history.clone(); // clone required: captured by on_replace_history_next
+            let window_weak = window.as_weak();
+            ui_state.on_replace_history_next(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let mut state = find_state.borrow_mut();
+                match state.replace_hist_idx {
+                    None => (),
+                    Some(0) => {
+                        state.replace_hist_idx = None;
+                        let draft = state.replace_draft.clone();
+                        drop(state);
+                        ui.set_find_replace_text(draft.into());
+                    }
+                    Some(i) => {
+                        let snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                        let new_idx = i - 1;
+                        state.replace_hist_idx = Some(new_idx);
+                        let text = snap.replace[new_idx].clone();
+                        drop(snap);
+                        drop(state);
+                        ui.set_find_replace_text(text.into());
+                    }
+                }
+            });
+        }
+
+        // ── commit-search: persist find query on Enter ────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_commit_search
+            let history = history.clone(); // clone required: captured by on_commit_search
+            let svc = svc.clone(); // clone required: captured by on_commit_search
+            let db_path = db_path.clone(); // clone required: captured by on_commit_search
+            let window_weak = window.as_weak();
+            ui_state.on_commit_search(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let query = ui.get_find_query().to_string();
+                if query.is_empty() {
+                    return;
+                }
+                {
+                    let mut state = find_state.borrow_mut();
+                    state.find_hist_idx = None;
+                    state.find_draft = String::new();
+                }
+                {
+                    let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                    if !snap.find.contains(&query) {
+                        snap.find.insert(0, query.clone());
+                        snap.find.truncate(30);
+                    }
+                }
+                let svc = svc.clone(); // clone required: moved into tokio::spawn
+                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
+                tokio::spawn(async move {
+                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
+                        return;
+                    };
+                    let _ = service.save("find", &query).await;
+                });
+            });
+        }
+
+        // ── commit-replace: persist replace text on Enter ─────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_commit_replace
+            let history = history.clone(); // clone required: captured by on_commit_replace
+            let svc = svc.clone(); // clone required: captured by on_commit_replace
+            let db_path = db_path.clone(); // clone required: captured by on_commit_replace
+            let window_weak = window.as_weak();
+            ui_state.on_commit_replace(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_find_replace_text().to_string();
+                if text.is_empty() {
+                    return;
+                }
+                {
+                    let mut state = find_state.borrow_mut();
+                    state.replace_hist_idx = None;
+                    state.replace_draft = String::new();
+                }
+                {
+                    let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                    if !snap.replace.contains(&text) {
+                        snap.replace.insert(0, text.clone());
+                        snap.replace.truncate(30);
+                    }
+                }
+                let svc = svc.clone(); // clone required: moved into tokio::spawn
+                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
+                tokio::spawn(async move {
+                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
+                        return;
+                    };
+                    let _ = service.save("replace", &text).await;
+                });
+            });
+        }
+
+        // ── replace-one ──────────────────────────────────────────────────────
+        {
+            let find_state = find_state.clone(); // clone required: captured by on_replace_one
+            let window_weak = window.as_weak();
+            ui_state.on_replace_one(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_editor_text().to_string();
+                let query = ui.get_find_query().to_string();
+                let replace = ui.get_find_replace_text().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+
+                let mut state = find_state.borrow_mut();
+                state.update(&text, &query, cs, rx);
+                if state.matches.is_empty() {
+                    return;
+                }
+                let (start, end) = state.matches[state.current];
+                let mut new_text = text;
+                new_text.replace_range(start..end, &replace);
+                ui.set_editor_text(new_text.into());
+
+                let updated = ui.get_editor_text().to_string();
+                state.last_query = String::new(); // invalidate cache
+                state.update(&updated, &query, cs, rx);
+                if state.matches.is_empty() {
+                    ui.set_find_current_match(0);
+                    ui.set_find_total_matches(0);
+                    ui.set_find_sel_start(-1);
+                    ui.set_find_sel_end(-1);
+                    return;
+                }
+                state.current = state.current.min(state.matches.len() - 1);
+                let (s, e) = state.matches[state.current];
+                ui.set_find_current_match((state.current + 1) as i32);
+                ui.set_find_total_matches(state.matches.len() as i32);
+                ui.set_find_sel_start(s as i32);
+                ui.set_find_sel_end(e as i32);
+            });
+        }
+
+        // ── replace-all ──────────────────────────────────────────────────────
+        {
+            let window_weak = window.as_weak();
+            ui_state.on_replace_all(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let text = ui.get_editor_text().to_string();
+                let query = ui.get_find_query().to_string();
+                let replace = ui.get_find_replace_text().to_string();
+                let cs = ui.get_find_case_sensitive();
+                let rx = ui.get_find_use_regex();
+
+                let matches = compute_matches(&text, &query, cs, rx);
+                if matches.is_empty() {
+                    return;
+                }
+                // Replace from end to start to preserve byte offsets.
+                let mut new_text = text;
+                for (start, end) in matches.into_iter().rev() {
+                    new_text.replace_range(start..end, &replace);
+                }
+                ui.set_editor_text(new_text.into());
+                ui.set_find_current_match(0);
+                ui.set_find_total_matches(0);
+                ui.set_find_sel_start(-1);
+                ui.set_find_sel_end(-1);
+            });
+        }
     }
 
     // ── Status callbacks (TODO) ───────────────────────────────────────────────

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -408,3 +408,45 @@ fn append_editor_text_should_not_double_newline_when_content_ends_with_newline()
         "SELECT 1\nSELECT * FROM t"
     );
 }
+
+// ── compute_matches tests ─────────────────────────────────────────────────────
+
+#[test]
+fn compute_matches_should_return_empty_for_empty_query() {
+    assert!(compute_matches("hello world", "", false, false).is_empty());
+}
+
+#[test]
+fn compute_matches_should_find_all_occurrences() {
+    let m = compute_matches("abcabc", "abc", true, false);
+    assert_eq!(m, vec![(0, 3), (3, 6)]);
+}
+
+#[test]
+fn compute_matches_should_be_case_insensitive_by_default() {
+    let m = compute_matches("Hello HELLO hello", "hello", false, false);
+    assert_eq!(m.len(), 3);
+}
+
+#[test]
+fn compute_matches_should_respect_case_sensitive_flag() {
+    let m = compute_matches("Hello HELLO hello", "hello", true, false);
+    assert_eq!(m.len(), 1);
+    assert_eq!(m[0], (12, 17));
+}
+
+#[test]
+fn compute_matches_should_support_regex_pattern() {
+    let m = compute_matches("foo123bar456", r"\d+", false, true);
+    assert_eq!(m, vec![(3, 6), (9, 12)]);
+}
+
+#[test]
+fn compute_matches_should_return_empty_for_invalid_regex() {
+    assert!(compute_matches("hello", "[invalid", false, true).is_empty());
+}
+
+#[test]
+fn compute_matches_should_return_empty_for_no_match() {
+    assert!(compute_matches("hello", "xyz", false, false).is_empty());
+}

--- a/crates/wf-history/src/find_history.rs
+++ b/crates/wf-history/src/find_history.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
+
+/// Persists find/replace bar search terms to a SQLite table in `history.db`.
+///
+/// Cheap to clone — all clones share the same underlying connection pool.
+#[derive(Clone)]
+pub struct FindHistoryService {
+    pool: SqlitePool,
+}
+
+const CREATE_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS find_history (
+        id    INTEGER PRIMARY KEY AUTOINCREMENT,
+        query TEXT    NOT NULL,
+        kind  TEXT    NOT NULL CHECK(kind IN ('find','replace')),
+        UNIQUE(query, kind)
+    )";
+
+impl FindHistoryService {
+    /// Open (or create) the history database at `db_path` and run schema migrations.
+    ///
+    /// Shares the same file as [`crate::service::HistoryService`].
+    pub async fn open(db_path: &Path) -> Result<Self> {
+        let opts = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(opts).await?;
+        Self::migrate(&pool).await?;
+        Ok(Self { pool })
+    }
+
+    async fn migrate(pool: &SqlitePool) -> Result<()> {
+        sqlx::query(CREATE_TABLE).execute(pool).await?;
+        Ok(())
+    }
+
+    /// Store a search term.  Silently ignores duplicates (INSERT OR IGNORE).
+    pub async fn save(&self, kind: &str, query: &str) -> Result<()> {
+        sqlx::query("INSERT OR IGNORE INTO find_history (query, kind) VALUES (?, ?)")
+            .bind(query)
+            .bind(kind)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Return up to `limit` most recently inserted unique terms, newest first.
+    pub async fn get(&self, kind: &str, limit: usize) -> Result<Vec<String>> {
+        let rows =
+            sqlx::query("SELECT query FROM find_history WHERE kind = ? ORDER BY id DESC LIMIT ?")
+                .bind(kind)
+                .bind(limit as i64)
+                .fetch_all(&self.pool)
+                .await?;
+
+        use sqlx::Row as _;
+        Ok(rows.iter().map(|r| r.get("query")).collect())
+    }
+
+    #[cfg(test)]
+    async fn open_memory() -> Result<Self> {
+        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        Self::migrate(&pool).await?;
+        Ok(Self { pool })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn save_and_get_should_roundtrip() {
+        let svc = FindHistoryService::open_memory().await.unwrap();
+        svc.save("find", "SELECT").await.unwrap();
+        svc.save("find", "FROM users").await.unwrap();
+        let items = svc.get("find", 10).await.unwrap();
+        assert_eq!(items, vec!["FROM users", "SELECT"]);
+    }
+
+    #[tokio::test]
+    async fn save_should_ignore_duplicate() {
+        let svc = FindHistoryService::open_memory().await.unwrap();
+        svc.save("find", "SELECT").await.unwrap();
+        svc.save("find", "SELECT").await.unwrap();
+        let items = svc.get("find", 10).await.unwrap();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_should_respect_limit() {
+        let svc = FindHistoryService::open_memory().await.unwrap();
+        for i in 0..5 {
+            svc.save("find", &format!("query {i}")).await.unwrap();
+        }
+        let items = svc.get("find", 3).await.unwrap();
+        assert_eq!(items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn find_and_replace_histories_should_be_separate() {
+        let svc = FindHistoryService::open_memory().await.unwrap();
+        svc.save("find", "SELECT").await.unwrap();
+        svc.save("replace", "hello").await.unwrap();
+        assert_eq!(svc.get("find", 10).await.unwrap(), vec!["SELECT"]);
+        assert_eq!(svc.get("replace", 10).await.unwrap(), vec!["hello"]);
+    }
+}

--- a/crates/wf-history/src/lib.rs
+++ b/crates/wf-history/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod find_history;
 pub mod service;

--- a/docs/specs/keybindings.md
+++ b/docs/specs/keybindings.md
@@ -32,6 +32,8 @@ These shortcuts work from any pane (no modal must be open).
 | `Ctrl+J` | Toggle result panel open / closed |
 | `↑` / `↓` | Move cursor up / down one line (timer-based, no key-repeat lag) |
 | `Shift+↑` / `Shift+↓` | Extend selection up / down one line |
+| `Ctrl+F` | Open find bar |
+| `Esc` (editor focused, find bar open) | Close find bar |
 
 ### Standard text-editing shortcuts (via OS / TextInput)
 
@@ -47,6 +49,21 @@ These shortcuts work from any pane (no modal must be open).
 | `Ctrl+←` / `Ctrl+→` | Move by word |
 | `Home` / `End` | Move to line start / end |
 | `Ctrl+Home` / `Ctrl+End` | Move to document start / end |
+
+---
+
+## Find / Replace Bar
+
+Appears in the top-right corner of the SQL editor when `Ctrl+F` is pressed.
+Click the **▶** toggle on the left of the find row to expand the replace row (VSCode style).
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Navigate to next match (commits term to history) |
+| `Shift+Enter` | Navigate to previous match |
+| `↑` | Scroll back through search history |
+| `↓` | Scroll forward through search history |
+| `Esc` | Close find bar |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a floating find/replace bar to the SQL editor, triggered by `Ctrl+F`. The bar overlays the editor at the top-right without pushing content down. It supports case-sensitive and regex search, match highlighting via `set-selection-offsets`, next/prev navigation, single and bulk replace, and VSCode-style search history with ↑/↓ navigation persisted in SQLite.

## Changes

- **`app/src/ui/components/find_replace_bar.slint`** (new): Floating bar component with find row, collapsible replace row (▶/▼ toggle), `Aa`/`.*` toggles, match counter, and history-aware placeholder text
- **`crates/wf-history/src/find_history.rs`** (new): `FindHistoryService` backed by a `find_history` SQLite table in `history.db`; `save` uses INSERT OR IGNORE, `get` returns newest-first up to a limit
- **`app/src/ui/app.slint`**: Added UiState find/replace properties and callbacks; instantiated `FindReplaceBar` as overlay in the SQL editor container; added `Ctrl+F` handler
- **`app/src/ui/components/editor.slint`**: Added `find-bar-open`, `close-find-bar`, `find-sel-start/end` properties; `changed find-sel-start` drives `set-selection-offsets` to highlight the current match; `Esc` closes the bar when it is open
- **`app/src/ui/mod.rs`**: `register_find_replace_callbacks` — full implementation including `find-search`, `find-next/prev`, `find/replace-history-prev/next`, `commit-search/replace`, `replace-one/all`; history uses `Arc<Mutex<HistorySnapshot>>` for cross-thread sharing and lazy `FindHistoryService` init
- **`app/src/ui/tests.rs`**: 7 unit tests for `compute_matches` (empty query, all occurrences, case sensitivity, regex, invalid regex, no match)
- **`app/lang/{en,ja}/LC_MESSAGES/wellfeather.po`**: Added "No results", "Replace", "Replace All", "Find", "Find (↑↓ for history)", "Replace (↑↓ for history)" strings
- **`docs/specs/keybindings.md`**: Added Find/Replace Bar section and updated Editor shortcuts

## Related Issues

Closes #199

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes