### PR TITLE
feat(db): consolidate all SQLite databases into wellfeather.db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6771,6 +6771,7 @@ dependencies = [
  "serde",
  "slint",
  "slint-build",
+ "sqlx",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -13,6 +13,7 @@ wf-completion      = { path = "../crates/wf-completion" }
 wf-history         = { path = "../crates/wf-history" }
 tokio              = { workspace = true }
 tokio-util         = { workspace = true }
+sqlx               = { workspace = true }
 chrono             = { workspace = true }
 anyhow             = { workspace = true }
 tracing            = { workspace = true }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -13,7 +13,7 @@
 //! Both channels are bounded (`capacity = CMD_CHANNEL_CAPACITY`). The controller task exits cleanly
 //! when all `Sender<Command>` clones are dropped (i.e. when the UI window closes).
 
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use chrono::Utc;
 use rust_i18n::t;
@@ -51,16 +51,9 @@ pub struct AppController {
     db: DbService,
     session: SessionManager,
     repo: Arc<ConnectionRepository>,
-    /// Path to `history.db`; opened asynchronously at the start of `run()`.
-    history_path: PathBuf,
-    /// `None` until `run()` opens the database; failures are non-fatal (logged).
-    history: Option<HistoryService>,
-    /// Path to `metadata.db`; opened asynchronously at the start of `run()`.
-    metadata_cache_path: PathBuf,
-    /// `None` until `run()` initialises the cache.
-    metadata_cache: Option<MetadataCache>,
-    /// `None` until `run()` initialises the cache (same `MetadataCache` clone).
-    completion: Option<CompletionService>,
+    history: HistoryService,
+    metadata_cache: MetadataCache,
+    completion: CompletionService,
     rx_cmd: mpsc::Receiver<Command>,
     tx_event: mpsc::Sender<Event>,
 }
@@ -69,30 +62,29 @@ impl AppController {
     /// Create the controller and return it together with the two channel endpoints
     /// that `main.rs` distributes: `Sender<Command>` → UI, `Receiver<Event>` → UI.
     ///
-    /// `history_path` is the filesystem path for `history.db`; the database is
-    /// opened (and the schema migrated) asynchronously at the start of [`Self::run`].
-    /// `metadata_cache_path` is the filesystem path for `metadata.db`.
+    /// All services are expected to be fully initialised (schema migrations run)
+    /// before being passed in. The shared `SqlitePool` backing them is managed by
+    /// the caller (`main.rs`).
     pub fn new(
         state: SharedState,
         db: DbService,
         session: SessionManager,
         repo: Arc<ConnectionRepository>,
-        history_path: PathBuf,
-        metadata_cache_path: PathBuf,
+        history: HistoryService,
+        metadata_cache: MetadataCache,
     ) -> (Self, mpsc::Sender<Command>, mpsc::Receiver<Event>) {
         let (tx_cmd, rx_cmd) = mpsc::channel(CMD_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = mpsc::channel(CMD_CHANNEL_CAPACITY);
+        let completion = CompletionService::new(metadata_cache.clone());
         (
             Self {
                 state,
                 db,
                 session,
                 repo,
-                history_path,
-                history: None,
-                metadata_cache_path,
-                metadata_cache: None,
-                completion: None,
+                history,
+                metadata_cache,
+                completion,
                 rx_cmd,
                 tx_event,
             },
@@ -103,55 +95,40 @@ impl AppController {
 
     /// Run the command loop as a tokio task (spawn with `tokio::spawn(controller.run())`).
     /// Exits when all `Sender<Command>` clones are dropped.
-    pub async fn run(mut self) {
-        // Open history.db at startup — failure is non-fatal (queries still work).
-        self.history = match HistoryService::open(&self.history_path).await {
-            Ok(h) => {
-                info!("history.db opened at {:?}", self.history_path);
-                Some(h)
-            }
-            Err(e) => {
-                warn!("failed to open history.db: {e}");
-                None
-            }
-        };
-
-        // Open metadata cache at startup — failure is non-fatal.
-        let cache = MetadataCache::new(self.metadata_cache_path.clone());
-        if let Err(e) = cache.preload_from_disk().await {
+    pub async fn run(self) {
+        if let Err(e) = self.metadata_cache.preload_from_disk().await {
             warn!("failed to preload metadata cache: {e}");
         }
-        self.completion = Some(CompletionService::new(cache.clone()));
-        self.metadata_cache = Some(cache);
 
-        while let Some(cmd) = self.rx_cmd.recv().await {
+        let mut this = self;
+        while let Some(cmd) = this.rx_cmd.recv().await {
             debug!("received command: {:?}", cmd);
             match cmd {
-                Command::Connect(conn, pw) => self.handle_connect(conn, pw).await,
-                Command::TestConnection(conn, pw) => self.handle_test_connection(conn, pw).await,
-                Command::Disconnect(id) => self.handle_disconnect(id).await,
-                Command::RemoveConnection(id) => self.handle_remove_connection(id).await,
-                Command::RunQuery(sql) => self.handle_run_query(sql).await,
-                Command::RunAll(sql) => self.handle_run_all(sql).await,
-                Command::RunSelection(sql) => self.handle_run_query(sql).await,
-                Command::CancelQuery => self.handle_cancel_query().await,
-                Command::UpdateConfig(update) => self.handle_update_config(update).await,
+                Command::Connect(conn, pw) => this.handle_connect(conn, pw).await,
+                Command::TestConnection(conn, pw) => this.handle_test_connection(conn, pw).await,
+                Command::Disconnect(id) => this.handle_disconnect(id).await,
+                Command::RemoveConnection(id) => this.handle_remove_connection(id).await,
+                Command::RunQuery(sql) => this.handle_run_query(sql).await,
+                Command::RunAll(sql) => this.handle_run_all(sql).await,
+                Command::RunSelection(sql) => this.handle_run_query(sql).await,
+                Command::CancelQuery => this.handle_cancel_query().await,
+                Command::UpdateConfig(update) => this.handle_update_config(update).await,
                 Command::FetchCompletion(sql, cursor_pos) => {
-                    self.handle_fetch_completion(sql, cursor_pos).await;
+                    this.handle_fetch_completion(sql, cursor_pos).await;
                 }
                 Command::FetchDdl {
                     tab_id,
                     conn_id,
                     name,
                     kind,
-                } => self.handle_fetch_ddl(tab_id, conn_id, name, kind).await,
+                } => this.handle_fetch_ddl(tab_id, conn_id, name, kind).await,
                 Command::FetchTableData {
                     tab_id,
                     conn_id,
                     table_name,
                     page_size,
                 } => {
-                    self.handle_fetch_table_data(tab_id, conn_id, table_name, page_size)
+                    this.handle_fetch_table_data(tab_id, conn_id, table_name, page_size)
                         .await
                 }
                 Command::ExportResult(_, _) => {} // handled client-side in UI layer
@@ -214,9 +191,7 @@ impl AppController {
                 tokio::spawn(async move {
                     match db.fetch_metadata(&fetch_id).await {
                         Ok(meta) => {
-                            if let Some(ref c) = cache
-                                && let Err(e) = c.store(&fetch_id, meta.clone()).await
-                            {
+                            if let Err(e) = cache.store(&fetch_id, meta.clone()).await {
                                 warn!(conn_id = %fetch_id, error = %e, "failed to store metadata");
                             }
                             let _ = tx.send(Event::MetadataLoaded(fetch_id.clone(), meta)).await;
@@ -337,19 +312,17 @@ impl AppController {
             let now = Utc::now().timestamp();
             match db.execute_with_cancel(&conn_id, &sql_to_run, token).await {
                 Ok(result) => {
-                    if let Some(ref h) = history {
-                        let exec = wf_db::models::QueryExecution {
-                            id: 0,
-                            sql: sql_hist,
-                            duration_ms: result.execution_time_ms,
-                            success: true,
-                            error_message: None,
-                            timestamp: now,
-                            connection_id: conn_id_hist,
-                        };
-                        if let Err(e) = h.insert(&exec).await {
-                            warn!("failed to save history: {e}");
-                        }
+                    let exec = wf_db::models::QueryExecution {
+                        id: 0,
+                        sql: sql_hist,
+                        duration_ms: result.execution_time_ms,
+                        success: true,
+                        error_message: None,
+                        timestamp: now,
+                        connection_id: conn_id_hist,
+                    };
+                    if let Err(e) = history.insert(&exec).await {
+                        warn!("failed to save history: {e}");
                     }
                     debug!("sending event: QueryFinished");
                     let _ = tx.send(Event::QueryFinished(result)).await;
@@ -360,19 +333,17 @@ impl AppController {
                 }
                 Err(e) => {
                     error!(error = %e, "query execution failed");
-                    if let Some(ref h) = history {
-                        let exec = wf_db::models::QueryExecution {
-                            id: 0,
-                            sql: sql_hist,
-                            duration_ms: 0,
-                            success: false,
-                            error_message: Some(e.to_string()),
-                            timestamp: now,
-                            connection_id: conn_id_hist,
-                        };
-                        if let Err(he) = h.insert(&exec).await {
-                            warn!("failed to save history: {he}");
-                        }
+                    let exec = wf_db::models::QueryExecution {
+                        id: 0,
+                        sql: sql_hist,
+                        duration_ms: 0,
+                        success: false,
+                        error_message: Some(e.to_string()),
+                        timestamp: now,
+                        connection_id: conn_id_hist,
+                    };
+                    if let Err(he) = history.insert(&exec).await {
+                        warn!("failed to save history: {he}");
                     }
                     debug!("sending event: QueryError");
                     let _ = tx.send(Event::QueryError(e.localized_message())).await;
@@ -443,19 +414,17 @@ impl AppController {
                 {
                     Ok(result) => {
                         if is_last {
-                            if let Some(ref h) = history {
-                                let exec = wf_db::models::QueryExecution {
-                                    id: 0,
-                                    sql: stmt.clone(),
-                                    duration_ms: result.execution_time_ms,
-                                    success: true,
-                                    error_message: None,
-                                    timestamp: now,
-                                    connection_id: conn_id_hist.clone(),
-                                };
-                                if let Err(e) = h.insert(&exec).await {
-                                    warn!("failed to save history: {e}");
-                                }
+                            let exec = wf_db::models::QueryExecution {
+                                id: 0,
+                                sql: stmt.clone(),
+                                duration_ms: result.execution_time_ms,
+                                success: true,
+                                error_message: None,
+                                timestamp: now,
+                                connection_id: conn_id_hist.clone(),
+                            };
+                            if let Err(e) = history.insert(&exec).await {
+                                warn!("failed to save history: {e}");
                             }
                             debug!("sending event: QueryFinished (run-all last stmt)");
                             let _ = tx.send(Event::QueryFinished(result)).await;
@@ -468,19 +437,17 @@ impl AppController {
                     }
                     Err(e) => {
                         error!(error = %e, "run-all statement failed");
-                        if let Some(ref h) = history {
-                            let exec = wf_db::models::QueryExecution {
-                                id: 0,
-                                sql: stmt.clone(),
-                                duration_ms: 0,
-                                success: false,
-                                error_message: Some(e.to_string()),
-                                timestamp: now,
-                                connection_id: conn_id_hist.clone(),
-                            };
-                            if let Err(he) = h.insert(&exec).await {
-                                warn!("failed to save history: {he}");
-                            }
+                        let exec = wf_db::models::QueryExecution {
+                            id: 0,
+                            sql: stmt.clone(),
+                            duration_ms: 0,
+                            success: false,
+                            error_message: Some(e.to_string()),
+                            timestamp: now,
+                            connection_id: conn_id_hist.clone(),
+                        };
+                        if let Err(he) = history.insert(&exec).await {
+                            warn!("failed to save history: {he}");
                         }
                         debug!("sending event: QueryError");
                         let _ = tx.send(Event::QueryError(e.localized_message())).await;
@@ -550,16 +517,14 @@ impl AppController {
     ///
     /// Looks up the active connection, calls [`CompletionService::complete`], and
     /// sends [`Event::CompletionReady`] with the (possibly empty) candidate list.
-    /// Silently no-ops when there is no active connection or no completion service.
+    /// Silently no-ops when there is no active connection.
     async fn handle_fetch_completion(&self, sql: String, cursor_pos: usize) {
         let conn_id = match self.state.conn.active() {
             Some(c) => c.id.clone(),
             None => return,
         };
-        if let Some(ref completion) = self.completion {
-            let items = completion.complete(&conn_id, &sql, cursor_pos).await;
-            let _ = self.tx_event.send(Event::CompletionReady(items)).await;
-        }
+        let items = self.completion.complete(&conn_id, &sql, cursor_pos).await;
+        let _ = self.tx_event.send(Event::CompletionReady(items)).await;
     }
 
     /// Handle a `FetchDdl` command.
@@ -693,14 +658,17 @@ fn apply_limit(sql: &str, limit: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
+    use std::sync::Arc;
 
+    use sqlx::SqlitePool;
     use tempfile::tempdir;
+    use wf_completion::cache::MetadataCache;
     use wf_config::{ConnectionRepository, manager::ConfigManager};
     use wf_db::{
         models::{DbConnection, DbType},
         service::DbService,
     };
+    use wf_history::service::HistoryService;
 
     use crate::{
         app::{command::Command, event::Event, session::SessionManager},
@@ -721,16 +689,14 @@ mod tests {
         Arc::new(ConnectionRepository::open_memory().await.unwrap())
     }
 
-    /// Return a path to a temporary `history.db` (file created lazily by the controller).
-    fn test_history_path() -> PathBuf {
-        let dir = tempdir().unwrap();
-        dir.keep().join("history.db")
+    async fn test_history() -> HistoryService {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        HistoryService::new(pool).await.unwrap()
     }
 
-    /// Return a path to a temporary `metadata.db` (file created lazily by the controller).
-    fn test_metadata_path() -> PathBuf {
-        let dir = tempdir().unwrap();
-        dir.keep().join("metadata.db")
+    async fn test_metadata_cache() -> MetadataCache {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MetadataCache::new(pool).await.unwrap()
     }
 
     fn sqlite_conn(id: &str) -> DbConnection {
@@ -747,7 +713,7 @@ mod tests {
         }
     }
 
-    // ── apply_limit ───────────────────────────────────────────────────────────
+    // ── apply_limit ────────────────────────────���────────────────────────��─────
 
     #[test]
     fn apply_limit_should_append_limit_to_select() {
@@ -802,7 +768,7 @@ mod tests {
         assert_eq!(apply_limit(sql, 500), sql);
     }
 
-    // ── TestConnection ────────────────────────────────────────────────────────
+    // ── TestConnection ──────────────────────────────────���─────────────────────
 
     #[tokio::test]
     async fn test_connection_should_send_ok_and_not_add_to_state() {
@@ -813,8 +779,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -839,8 +805,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         let bad = DbConnection {
@@ -879,8 +845,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -905,8 +871,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         let bad = DbConnection {
@@ -938,8 +904,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -966,7 +932,7 @@ mod tests {
         assert!(matches!(e2, Event::Disconnected(ref id) if id == "c2"));
     }
 
-    // ── RunQuery ──────────────────────────────────────────────────────────────
+    // ── RunQuery ──────────────────────────────────────────────────────────���───
 
     #[tokio::test]
     async fn run_query_should_send_query_started_then_finished() {
@@ -977,8 +943,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -1020,8 +986,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -1045,8 +1011,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd.send(Command::CancelQuery).await.unwrap();
@@ -1067,8 +1033,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd
@@ -1100,8 +1066,8 @@ mod tests {
             db,
             test_session(),
             test_repo().await,
-            test_history_path(),
-            test_metadata_path(),
+            test_history().await,
+            test_metadata_cache().await,
         );
 
         tx_cmd

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -1,16 +1,18 @@
 //! Session persistence helpers.
 //!
-//! [`SessionManager`] wraps [`ConfigManager`] and persists editor/tab state,
-//! page size, language, and theme settings to `config.toml`.
+//! [`SessionManager`] wraps [`ConfigManager`] and persists page size, language,
+//! theme, and reduce-motion settings to `config.toml`.
 //!
-//! Connection persistence (CRUD + last-used tracking) has moved to
+//! Tab and last-query persistence has moved to [`wf_history::session::SessionService`]
+//! (SQLite-backed via the shared `wellfeather.db` pool).
+//!
+//! Connection persistence (CRUD + last-used tracking) lives in
 //! [`wf_config::ConnectionRepository`] (SQLite-backed).
 //!
 //! Conversion between `wf_db::models::DbConnection` and `wf_config::models::ConnectionConfig`
 //! lives here because `app/` is the only crate that depends on both.
 
 use anyhow::Context as _;
-use serde::{Deserialize, Serialize};
 use tracing::info;
 use wf_config::{
     manager::ConfigManager,
@@ -18,19 +20,7 @@ use wf_config::{
 };
 use wf_db::models::{DbConnection, DbType};
 
-/// Serializable record for a single SQL Editor tab (written to `tabs.toml`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TabSessionEntry {
-    pub id: String,
-    pub title: String,
-    pub query_text: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct TabsFile {
-    active_index: usize,
-    tabs: Vec<TabSessionEntry>,
-}
+pub use wf_history::session::TabSessionEntry;
 
 /// Persists and restores the last active database connection across app restarts.
 ///
@@ -133,83 +123,6 @@ impl SessionManager {
             .context("failed to save reduce_motion")?;
         Ok(())
     }
-
-    /// Write the current editor query to `last_query.sql` in the app config directory.
-    ///
-    /// An empty query writes an empty file (not an error); `restore_query_file`
-    /// treats an empty or absent file as "no saved query".
-    pub fn save_query_file(&self, query: &str) -> anyhow::Result<()> {
-        let path = self.config_manager.dir().join("last_query.sql");
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create directory {}", parent.display()))?;
-        }
-        std::fs::write(&path, query.as_bytes())
-            .with_context(|| format!("failed to write {}", path.display()))?;
-        info!(len = query.len(), "last_query.sql saved");
-        Ok(())
-    }
-
-    /// Read `last_query.sql` from the app config directory.
-    ///
-    /// Returns `Ok(None)` when the file does not exist or is empty.
-    pub fn restore_query_file(&self) -> anyhow::Result<Option<String>> {
-        let path = self.config_manager.dir().join("last_query.sql");
-        if !path.exists() {
-            return Ok(None);
-        }
-        let query = std::fs::read_to_string(&path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        if query.is_empty() {
-            return Ok(None);
-        }
-        info!(len = query.len(), "last_query.sql restored");
-        Ok(Some(query))
-    }
-
-    /// Persist the current set of SQL Editor tabs to `tabs.toml`.
-    ///
-    /// `active_index` is the index within the serialized list (sql-editor tabs only).
-    /// Table View tabs are intentionally not persisted — they are easy to reopen.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the file cannot be written.
-    pub fn save_tabs(&self, active_index: usize, tabs: &[TabSessionEntry]) -> anyhow::Result<()> {
-        let path = self.config_manager.dir().join("tabs.toml");
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create directory {}", parent.display()))?;
-        }
-        let file = TabsFile {
-            active_index,
-            tabs: tabs.to_vec(),
-        };
-        let s = toml::to_string_pretty(&file).context("failed to serialize tabs")?;
-        std::fs::write(&path, s.as_bytes())
-            .with_context(|| format!("failed to write {}", path.display()))?;
-        info!(count = tabs.len(), "tabs.toml saved");
-        Ok(())
-    }
-
-    /// Read `tabs.toml` and return `(active_index, tabs)`.
-    ///
-    /// Returns `Ok(None)` when the file does not exist.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the file exists but cannot be parsed.
-    pub fn restore_tabs(&self) -> anyhow::Result<Option<(usize, Vec<TabSessionEntry>)>> {
-        let path = self.config_manager.dir().join("tabs.toml");
-        if !path.exists() {
-            return Ok(None);
-        }
-        let s = std::fs::read_to_string(&path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        let file: TabsFile = toml::from_str(&s).context("failed to parse tabs.toml")?;
-        info!(count = file.tabs.len(), "tabs.toml restored");
-        Ok(Some((file.active_index, file.tabs)))
-    }
 }
 
 impl Default for SessionManager {
@@ -282,55 +195,5 @@ mod tests {
             .unwrap();
         use wf_config::models::PageSize;
         assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
-    }
-
-    #[test]
-    fn save_query_file_should_persist_and_restore_query() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        sm.save_query_file("SELECT 1").unwrap();
-
-        let restored = sm.restore_query_file().unwrap();
-        assert_eq!(restored, Some("SELECT 1".to_string()));
-        assert!(dir.path().join("last_query.sql").exists());
-    }
-
-    #[test]
-    fn save_tabs_should_persist_and_restore() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-
-        let tabs = vec![
-            super::TabSessionEntry {
-                id: "t1".to_string(),
-                title: "Query 1".to_string(),
-                query_text: "SELECT 1".to_string(),
-            },
-            super::TabSessionEntry {
-                id: "t2".to_string(),
-                title: "Query 2".to_string(),
-                query_text: "SELECT 2".to_string(),
-            },
-        ];
-        sm.save_tabs(1, &tabs).unwrap();
-
-        let (active, restored) = sm.restore_tabs().unwrap().expect("should restore");
-        assert_eq!(active, 1);
-        assert_eq!(restored.len(), 2);
-        assert_eq!(restored[0].id, "t1");
-        assert_eq!(restored[1].query_text, "SELECT 2");
-    }
-
-    #[test]
-    fn restore_tabs_should_return_none_when_absent() {
-        let dir = tempdir().unwrap();
-        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
-            dir.path().join("config.toml"),
-        ));
-        assert!(sm.restore_tabs().unwrap().is_none());
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -30,8 +30,12 @@ use app::{
 };
 use state::AppState;
 use ui::UI;
+use wf_completion::cache::MetadataCache;
 use wf_config::{ConnectionRepository, crypto, manager::ConfigManager};
 use wf_db::service::DbService;
+use wf_history::{
+    find_history::FindHistoryService, service::HistoryService, session::SessionService,
+};
 
 /// Entry point. Runs on the main OS thread; the Slint event loop must stay here.
 fn main() -> anyhow::Result<()> {
@@ -63,12 +67,25 @@ fn main() -> anyhow::Result<()> {
         state.ui.set_theme(config.appearance.theme);
     }
 
-    // Open the connection repository, migrating from config.toml if it is the first launch.
+    // Open the single shared SQLite database for all persistence needs.
+    let pool = runtime.block_on(async {
+        sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(ConfigManager::app_dir().join("wellfeather.db"))
+                    .create_if_missing(true)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal),
+            )
+            .await
+    })?;
+
+    // Initialise all services from the shared pool (Composition Root).
     let repo: Arc<ConnectionRepository> =
-        Arc::new(runtime.block_on(ConnectionRepository::open_with_migration(
-            &ConfigManager::app_dir().join("connections.db"),
-            &ConfigManager::new(),
-        ))?);
+        Arc::new(runtime.block_on(ConnectionRepository::new(pool.clone()))?);
+    let history_svc = runtime.block_on(HistoryService::new(pool.clone()))?;
+    let find_history_svc = runtime.block_on(FindHistoryService::new(pool.clone()))?;
+    let session_svc = runtime.block_on(SessionService::new(pool.clone()))?;
+    let metadata_cache = runtime.block_on(MetadataCache::new(pool.clone()))?;
 
     // Load all saved connections for the initial sidebar/DB-manager list.
     let initial_connections = runtime.block_on(repo.all()).unwrap_or_default();
@@ -88,8 +105,8 @@ fn main() -> anyhow::Result<()> {
         db,
         session,
         repo,
-        ConfigManager::app_dir().join("history.db"),
-        ConfigManager::app_dir().join("metadata.db"),
+        history_svc,
+        metadata_cache,
     );
     tokio::spawn(controller.run());
 
@@ -109,6 +126,14 @@ fn main() -> anyhow::Result<()> {
         });
     }
 
-    let ui = UI::new(state, tx_cmd, rx_event, enc_key, initial_connections)?;
+    let ui = UI::new(
+        state,
+        tx_cmd,
+        rx_event,
+        enc_key,
+        initial_connections,
+        find_history_svc,
+        session_svc,
+    )?;
     ui.run()
 }

--- a/app/src/ui/components/find_replace_bar.slint
+++ b/app/src/ui/components/find_replace_bar.slint
@@ -129,13 +129,14 @@ export component FindReplaceBar inherits Rectangle {
                         width:  parent.width - 2 * Layout.padding-xs;
                         height: parent.height;
                         single-line: true;
-                        text:   root.query;
+                        text <=> root.query;
                         color:  Colors.text;
                         font-size: Typography.size-base;
                         vertical-alignment: center;
-                        edited => {
-                            root.query = self.text;
-                            root.find-search();
+                        edited => { root.find-search(); }
+                        accepted => {
+                            root.commit-search();
+                            root.find-next();
                         }
                     }
                 }
@@ -281,11 +282,15 @@ export component FindReplaceBar inherits Rectangle {
                         width:  parent.width - 2 * Layout.padding-xs;
                         height: parent.height;
                         single-line: true;
-                        text:   root.replace-text;
+                        text <=> root.replace-text;
                         color:  Colors.text;
                         font-size: Typography.size-base;
                         vertical-alignment: center;
-                        edited => { root.replace-text = self.text; }
+                        edited => {}
+                        accepted => {
+                            root.commit-replace();
+                            root.replace-one();
+                        }
                     }
                 }
 

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -16,6 +16,7 @@ use wf_completion::CompletionItem;
 use wf_config::crypto;
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
 use wf_history::find_history::FindHistoryService;
+use wf_history::session::SessionService;
 use wf_query::analyzer::{extract_statement_at, has_dangerous_dml};
 
 const COMPLETION_DEBOUNCE_MS: u64 = 300;
@@ -112,24 +113,6 @@ struct FindState {
     replace_draft: String,
 }
 
-/// Open the find history service lazily, caching it for reuse across calls.
-async fn get_find_history_svc(
-    svc_arc: &Arc<tokio::sync::Mutex<Option<FindHistoryService>>>,
-    db_path: &std::path::Path,
-) -> Option<FindHistoryService> {
-    let mut guard = svc_arc.lock().await;
-    if guard.is_none() {
-        match FindHistoryService::open(db_path).await {
-            Ok(s) => *guard = Some(s),
-            Err(e) => {
-                tracing::warn!("find history db open failed: {e}");
-                return None;
-            }
-        }
-    }
-    guard.as_ref().cloned()
-}
-
 impl FindState {
     /// Re-compute matches when any parameter changed; clamps `current`.
     fn update(&mut self, text: &str, query: &str, case_sensitive: bool, use_regex: bool) {
@@ -195,7 +178,7 @@ use crate::{
     app::{
         command::{Command, ConfigUpdate},
         event::{Event, StateEvent},
-        session::{SessionManager, config_to_db_conn},
+        session::config_to_db_conn,
     },
     state::SharedState,
 };
@@ -419,6 +402,8 @@ impl UI {
         rx_event: mpsc::Receiver<Event>,
         enc_key: [u8; 32],
         initial_connections: Vec<ConnectionConfig>,
+        find_history_svc: FindHistoryService,
+        session_svc: SessionService,
     ) -> Result<Self> {
         let window = crate::AppWindow::new()?;
 
@@ -435,12 +420,12 @@ impl UI {
         // handler on QueryFinished, read by the filter callbacks on the UI thread.
         let original_data: SharedOriginalData = Arc::new(Mutex::new(None));
 
-        // Restore or create tab state. Track whether tabs were loaded from file
-        // so we can fall back to last_query.sql on first launch.
+        // Restore or create tab state. Track whether tabs were loaded from DB
+        // so we can fall back to last_query on first launch.
+        let handle = tokio::runtime::Handle::current();
         let tabs_from_session;
         let tabs_state: Rc<RefCell<tabs_state::TabsState>> = {
-            let session = SessionManager::new();
-            match session.restore_tabs() {
+            match handle.block_on(session_svc.restore_tabs()) {
                 Ok(Some((active_index, entries))) => {
                     tabs_from_session = true;
                     Rc::new(RefCell::new(tabs_state::TabsState::from_session(
@@ -472,7 +457,7 @@ impl UI {
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
         Self::register_reduce_motion_callback(&window, tx_cmd.clone());
         Self::register_menu_callbacks(&window, tx_cmd.clone());
-        Self::register_close_handler(&window, Rc::clone(&tabs_state));
+        Self::register_close_handler(&window, Rc::clone(&tabs_state), session_svc.clone());
         Self::register_tab_callbacks(
             &window,
             tx_cmd.clone(),
@@ -522,8 +507,10 @@ impl UI {
                 None => {}
             }
         }
-        // Fall back to last_query.sql on first launch (no tabs.toml yet).
-        if !tabs_from_session && let Ok(Some(query)) = SessionManager::new().restore_query_file() {
+        // Fall back to last_query on first launch (no session tabs saved yet).
+        if !tabs_from_session
+            && let Ok(Some(query)) = handle.block_on(session_svc.restore_last_query())
+        {
             ui_global.set_editor_text(query.clone().into());
             tabs_state.borrow_mut().save_current_text(&query);
         }
@@ -559,7 +546,7 @@ impl UI {
             tx_cmd.clone(),
         );
         Self::register_language_callback(&window, tx_cmd.clone());
-        Self::register_find_replace_callbacks(&window);
+        Self::register_find_replace_callbacks(&window, find_history_svc);
         Self::register_status_callbacks(&window, state.clone());
         Self::spawn_event_handler(
             &window,
@@ -1213,8 +1200,10 @@ impl UI {
     fn register_close_handler(
         window: &crate::AppWindow,
         tabs_state: Rc<RefCell<tabs_state::TabsState>>,
+        session_svc: SessionService,
     ) {
         let window_weak = window.as_weak(); // clone required: on_close_requested closure
+        let handle = tokio::runtime::Handle::current();
         window.window().on_close_requested(move || {
             let text = window_weak
                 .upgrade()
@@ -1222,18 +1211,15 @@ impl UI {
                 .unwrap_or_default();
             // Flush the active editor text into the tab before persisting.
             tabs_state.borrow_mut().save_current_text(&text);
-            let sm = SessionManager::new();
-            {
-                let ts = tabs_state.borrow();
-                let (active_sql_idx, entries) = ts.session_entries();
-                if let Err(e) = sm.save_tabs(active_sql_idx, &entries) {
-                    tracing::warn!(error = %e, "failed to save tabs.toml on close");
+            let (active_sql_idx, entries) = tabs_state.borrow().session_entries();
+            handle.block_on(async {
+                if let Err(e) = session_svc.save_tabs(active_sql_idx, &entries).await {
+                    tracing::warn!(error = %e, "failed to save session tabs on close");
                 }
-            }
-            // Keep last_query.sql in sync for backwards compatibility.
-            if let Err(e) = sm.save_query_file(&text) {
-                tracing::warn!(error = %e, "failed to save last_query.sql on close");
-            }
+                if let Err(e) = session_svc.save_last_query(&text).await {
+                    tracing::warn!(error = %e, "failed to save last_query on close");
+                }
+            });
             slint::CloseRequestResponse::HideWindow
         });
     }
@@ -2732,21 +2718,20 @@ impl UI {
 
     // ── Find / replace callbacks ──────────────────────────────────────────────
 
-    fn register_find_replace_callbacks(window: &crate::AppWindow) {
+    fn register_find_replace_callbacks(
+        window: &crate::AppWindow,
+        find_history_svc: FindHistoryService,
+    ) {
         let ui_state = window.global::<crate::UiState>();
         let find_state: Rc<RefCell<FindState>> = Rc::new(RefCell::new(FindState::default()));
         let history: SharedHistorySnapshot =
             Arc::new(std::sync::Mutex::new(HistorySnapshot::default()));
-        let svc: Arc<tokio::sync::Mutex<Option<FindHistoryService>>> =
-            Arc::new(tokio::sync::Mutex::new(None));
-        let db_path = wf_config::manager::ConfigManager::app_dir().join("history.db");
 
         // ── load-find-history: reset nav state and load from SQLite on bar open
         {
             let find_state = find_state.clone(); // clone required: captured by on_load_find_history
-            let svc = svc.clone(); // clone required: moved into tokio::spawn
+            let svc = find_history_svc.clone(); // clone required: moved into tokio::spawn
             let history = history.clone(); // clone required: moved into tokio::spawn
-            let db_path = db_path.clone(); // clone required: moved into tokio::spawn
             ui_state.on_load_find_history(move || {
                 {
                     let mut state = find_state.borrow_mut();
@@ -2755,13 +2740,9 @@ impl UI {
                 }
                 let svc = svc.clone(); // clone required: moved into tokio::spawn
                 let history = history.clone(); // clone required: moved into tokio::spawn
-                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
                 tokio::spawn(async move {
-                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
-                        return;
-                    };
-                    let find_items = service.get("find", 30).await.unwrap_or_default();
-                    let replace_items = service.get("replace", 30).await.unwrap_or_default();
+                    let find_items = svc.get("find", 30).await.unwrap_or_default();
+                    let replace_items = svc.get("replace", 30).await.unwrap_or_default();
                     let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
                     snap.find = find_items;
                     snap.replace = replace_items;
@@ -2807,6 +2788,8 @@ impl UI {
         // ── find-next ────────────────────────────────────────────────────────
         {
             let find_state = find_state.clone(); // clone required: captured by on_find_next
+            let history = history.clone(); // clone required: captured by on_find_next
+            let svc = find_history_svc.clone(); // clone required: captured by on_find_next
             let window_weak = window.as_weak();
             ui_state.on_find_next(move || {
                 let Some(w) = window_weak.upgrade() else {
@@ -2836,12 +2819,31 @@ impl UI {
                 ui.set_find_total_matches(state.matches.len() as i32);
                 ui.set_find_sel_start(start as i32);
                 ui.set_find_sel_end(end as i32);
+                drop(state);
+                // Persist the query whenever the user navigates to a result.
+                if !query.is_empty() {
+                    {
+                        let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                        if !snap.find.contains(&query) {
+                            snap.find.insert(0, query.clone());
+                            snap.find.truncate(30);
+                        }
+                    }
+                    let svc = svc.clone(); // clone required: moved into tokio::spawn
+                    tokio::spawn(async move {
+                        if let Err(e) = svc.save("find", &query).await {
+                            tracing::warn!(error = %e, %query, "failed to save find history");
+                        }
+                    });
+                }
             });
         }
 
         // ── find-prev ────────────────────────────────────────────────────────
         {
             let find_state = find_state.clone(); // clone required: captured by on_find_prev
+            let history = history.clone(); // clone required: captured by on_find_prev
+            let svc = find_history_svc.clone(); // clone required: captured by on_find_prev
             let window_weak = window.as_weak();
             ui_state.on_find_prev(move || {
                 let Some(w) = window_weak.upgrade() else {
@@ -2872,6 +2874,23 @@ impl UI {
                 ui.set_find_total_matches(state.matches.len() as i32);
                 ui.set_find_sel_start(start as i32);
                 ui.set_find_sel_end(end as i32);
+                drop(state);
+                // Persist the query whenever the user navigates to a result.
+                if !query.is_empty() {
+                    {
+                        let mut snap = history.lock().unwrap_or_else(|p| p.into_inner());
+                        if !snap.find.contains(&query) {
+                            snap.find.insert(0, query.clone());
+                            snap.find.truncate(30);
+                        }
+                    }
+                    let svc = svc.clone(); // clone required: moved into tokio::spawn
+                    tokio::spawn(async move {
+                        if let Err(e) = svc.save("find", &query).await {
+                            tracing::warn!(error = %e, %query, "failed to save find history");
+                        }
+                    });
+                }
             });
         }
 
@@ -3063,8 +3082,7 @@ impl UI {
         {
             let find_state = find_state.clone(); // clone required: captured by on_commit_search
             let history = history.clone(); // clone required: captured by on_commit_search
-            let svc = svc.clone(); // clone required: captured by on_commit_search
-            let db_path = db_path.clone(); // clone required: captured by on_commit_search
+            let svc = find_history_svc.clone(); // clone required: captured by on_commit_search
             let window_weak = window.as_weak();
             ui_state.on_commit_search(move || {
                 let Some(w) = window_weak.upgrade() else {
@@ -3088,12 +3106,10 @@ impl UI {
                     }
                 }
                 let svc = svc.clone(); // clone required: moved into tokio::spawn
-                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
                 tokio::spawn(async move {
-                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
-                        return;
-                    };
-                    let _ = service.save("find", &query).await;
+                    if let Err(e) = svc.save("find", &query).await {
+                        tracing::warn!(error = %e, %query, "failed to save find history");
+                    }
                 });
             });
         }
@@ -3102,8 +3118,7 @@ impl UI {
         {
             let find_state = find_state.clone(); // clone required: captured by on_commit_replace
             let history = history.clone(); // clone required: captured by on_commit_replace
-            let svc = svc.clone(); // clone required: captured by on_commit_replace
-            let db_path = db_path.clone(); // clone required: captured by on_commit_replace
+            let svc = find_history_svc.clone(); // clone required: captured by on_commit_replace
             let window_weak = window.as_weak();
             ui_state.on_commit_replace(move || {
                 let Some(w) = window_weak.upgrade() else {
@@ -3127,12 +3142,10 @@ impl UI {
                     }
                 }
                 let svc = svc.clone(); // clone required: moved into tokio::spawn
-                let db_path = db_path.clone(); // clone required: moved into tokio::spawn
                 tokio::spawn(async move {
-                    let Some(service) = get_find_history_svc(&svc, &db_path).await else {
-                        return;
-                    };
-                    let _ = service.save("replace", &text).await;
+                    if let Err(e) = svc.save("replace", &text).await {
+                        tracing::warn!(error = %e, %text, "failed to save replace history");
+                    }
                 });
             });
         }

--- a/crates/wf-completion/src/cache.rs
+++ b/crates/wf-completion/src/cache.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use sqlx::SqlitePool;
-use sqlx::sqlite::SqliteConnectOptions;
 use wf_db::models::DbMetadata;
 
 // ---------------------------------------------------------------------------
@@ -14,21 +12,27 @@ use wf_db::models::DbMetadata;
 /// In-memory metadata cache with SQLite persistence.
 ///
 /// Memory is the primary store; SQLite is used for across-session durability.
-/// `new()` is synchronous — the SQLite file is opened lazily on first use.
+/// Cheap to clone — all clones share the same pool and in-memory map.
 #[derive(Clone)]
 pub struct MetadataCache {
     memory: Arc<RwLock<HashMap<String, DbMetadata>>>,
-    db_path: PathBuf,
+    pool: SqlitePool,
 }
 
+const CREATE_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS metadata_cache (
+        conn_id TEXT PRIMARY KEY,
+        data    BLOB NOT NULL
+    )";
+
 impl MetadataCache {
-    /// Create a cache backed by the SQLite file at `db_path`.
-    /// The file is created on first write if it does not exist.
-    pub fn new(db_path: PathBuf) -> Self {
-        Self {
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
+        sqlx::query(CREATE_TABLE).execute(&pool).await?;
+        Ok(Self {
             memory: Arc::new(RwLock::new(HashMap::new())),
-            db_path,
-        }
+            pool,
+        })
     }
 
     /// Persist `meta` for `conn_id`: write to memory then flush to SQLite.
@@ -38,12 +42,11 @@ impl MetadataCache {
             .unwrap_or_else(|p| p.into_inner())
             .insert(conn_id.to_string(), meta.clone());
 
-        let pool = self.open_pool().await?;
         let json = serde_json::to_vec(&meta)?;
         sqlx::query("INSERT OR REPLACE INTO metadata_cache (conn_id, data) VALUES (?, ?)")
             .bind(conn_id)
             .bind(json.as_slice())
-            .execute(&pool)
+            .execute(&self.pool)
             .await?;
         Ok(())
     }
@@ -63,11 +66,10 @@ impl MetadataCache {
             return Some(m);
         }
 
-        let pool = self.open_pool().await.ok()?;
         use sqlx::Row as _;
         let row = sqlx::query("SELECT data FROM metadata_cache WHERE conn_id = ?")
             .bind(conn_id)
-            .fetch_optional(&pool)
+            .fetch_optional(&self.pool)
             .await
             .ok()??;
 
@@ -81,21 +83,10 @@ impl MetadataCache {
     }
 
     /// Populate the in-memory cache from SQLite.  Call once at startup.
-    ///
-    /// Non-fatal: if the database file cannot be opened (e.g. first run), a
-    /// warning is logged and `Ok(())` is returned.
     pub async fn preload_from_disk(&self) -> Result<()> {
-        let pool = match self.open_pool().await {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::warn!("metadata cache not available: {e}");
-                return Ok(());
-            }
-        };
-
         use sqlx::Row as _;
         let rows = sqlx::query("SELECT conn_id, data FROM metadata_cache")
-            .fetch_all(&pool)
+            .fetch_all(&self.pool)
             .await?;
 
         let mut guard = self.memory.write().unwrap_or_else(|p| p.into_inner());
@@ -107,24 +98,6 @@ impl MetadataCache {
             }
         }
         Ok(())
-    }
-
-    // ── private ───────────────────────────────────────────────────────────────
-
-    async fn open_pool(&self) -> Result<SqlitePool> {
-        let opts = SqliteConnectOptions::new()
-            .filename(&self.db_path)
-            .create_if_missing(true);
-        let pool = SqlitePool::connect_with(opts).await?;
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS metadata_cache (
-                 conn_id TEXT PRIMARY KEY,
-                 data    BLOB NOT NULL
-             )",
-        )
-        .execute(&pool)
-        .await?;
-        Ok(pool)
     }
 }
 
@@ -160,10 +133,27 @@ mod tests {
         }
     }
 
+    async fn open_memory() -> MetadataCache {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MetadataCache::new(pool).await.unwrap()
+    }
+
+    async fn open_at(path: &std::path::Path) -> MetadataCache {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(path)
+                    .create_if_missing(true),
+            )
+            .await
+            .unwrap();
+        MetadataCache::new(pool).await.unwrap()
+    }
+
     #[tokio::test]
     async fn store_and_load_should_roundtrip_via_file() {
         let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("metadata.db"));
+        let cache = open_at(&dir.path().join("wellfeather.db")).await;
         let meta = make_meta("users");
 
         cache.store("conn-1", meta.clone()).await.unwrap();
@@ -178,14 +168,15 @@ mod tests {
     #[tokio::test]
     async fn load_should_fall_back_to_sqlite_after_restart() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("metadata.db");
+        let path = dir.path().join("wellfeather.db");
 
         // Instance A — store
-        let cache_a = MetadataCache::new(path.clone());
+        let cache_a = open_at(&path).await;
         cache_a.store("conn-1", make_meta("orders")).await.unwrap();
+        drop(cache_a);
 
         // Instance B — fresh memory, same file
-        let cache_b = MetadataCache::new(path);
+        let cache_b = open_at(&path).await;
         let loaded = cache_b.load("conn-1").await.unwrap();
 
         assert_eq!(loaded.tables[0].name, "orders");
@@ -194,27 +185,25 @@ mod tests {
     #[tokio::test]
     async fn preload_from_disk_should_populate_memory() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("metadata.db");
+        let path = dir.path().join("wellfeather.db");
 
-        let cache_a = MetadataCache::new(path.clone());
+        let cache_a = open_at(&path).await;
         cache_a
             .store("conn-1", make_meta("products"))
             .await
             .unwrap();
+        drop(cache_a);
 
-        let cache_b = MetadataCache::new(path);
+        let cache_b = open_at(&path).await;
         cache_b.preload_from_disk().await.unwrap();
 
-        // After preload, memory should have the entry — verify by checking
-        // that a subsequent load returns without hitting SQLite (same result).
         let loaded = cache_b.load("conn-1").await.unwrap();
         assert_eq!(loaded.tables[0].name, "products");
     }
 
     #[tokio::test]
     async fn load_should_return_none_for_unknown_conn_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("metadata.db"));
+        let cache = open_memory().await;
         let result = cache.load("does-not-exist").await;
         assert!(result.is_none());
     }

--- a/crates/wf-completion/src/service.rs
+++ b/crates/wf-completion/src/service.rs
@@ -205,7 +205,13 @@ pub(crate) fn extract_prefix(sql: &str, cursor_pos: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::SqlitePool;
     use wf_db::models::{ColumnInfo, TableInfo};
+
+    async fn open_memory_cache() -> MetadataCache {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MetadataCache::new(pool).await.unwrap()
+    }
 
     fn make_meta() -> DbMetadata {
         DbMetadata {
@@ -232,9 +238,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_return_keyword_candidates_without_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
-        let svc = CompletionService::new(cache);
+        let svc = CompletionService::new(open_memory_cache().await);
         let items = svc.complete("conn-1", "SEL", 3).await;
         let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"SELECT"), "expected SELECT in {labels:?}");
@@ -242,8 +246,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_return_table_candidates_from_cached_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let cache = open_memory_cache().await;
         cache.store("conn-1", make_meta()).await.unwrap();
         let svc = CompletionService::new(cache);
         // TableName context: "SELECT * FROM "
@@ -255,9 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_return_empty_column_candidates_when_no_metadata() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
-        let svc = CompletionService::new(cache);
+        let svc = CompletionService::new(open_memory_cache().await);
         // No metadata stored — ColumnName { Some("users") } → no columns
         let sql = "SELECT id FROM users WHERE ";
         let items = svc.complete("conn-x", sql, sql.len()).await;
@@ -288,8 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_return_next_clause_when_exact_table_name_at_cursor_end() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let cache = open_memory_cache().await;
         cache.store("conn-1", make_meta()).await.unwrap();
         let svc = CompletionService::new(cache);
         // Cursor at end of "users" — exact table match → NextClause candidates
@@ -306,8 +306,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_return_operator_when_exact_column_name_at_cursor_end() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let cache = open_memory_cache().await;
         cache.store("conn-1", make_meta()).await.unwrap();
         let svc = CompletionService::new(cache);
         // Cursor at end of "id" — exact column match → Operator candidates
@@ -322,8 +321,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_should_not_promote_partial_table_name_to_next_clause() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = MetadataCache::new(dir.path().join("m.db"));
+        let cache = open_memory_cache().await;
         cache.store("conn-1", make_meta()).await.unwrap();
         let svc = CompletionService::new(cache);
         // "use" is a prefix of "users" but not an exact match — must stay TableName

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -133,7 +133,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let mgr = ConfigManager::with_path(dir.path().join("config.toml"));
 
-        // connections is skip_serializing (migration-only), so it is excluded here.
         let original = Config {
             appearance: AppearanceConfig {
                 theme: Theme::Light,

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -109,9 +109,6 @@ pub struct EditorConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct SessionConfig {
-    /// Preserved for migration only — read from old config.toml but never written back.
-    #[serde(default, skip_serializing)]
-    pub last_connection_id: Option<String>,
     pub last_query: Option<String>,
 }
 
@@ -180,9 +177,6 @@ pub struct Config {
     pub editor: EditorConfig,
     pub session: SessionConfig,
     pub ui: UiConfig,
-    /// Preserved for migration only — read from old config.toml but never written back.
-    #[serde(default, skip_serializing)]
-    pub connections: Vec<ConnectionConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -201,10 +195,8 @@ mod tests {
         assert_eq!(cfg.appearance.font_size, 14);
         assert!(!cfg.appearance.reduce_motion);
         assert_eq!(cfg.editor.page_size, PageSize::Rows500);
-        assert_eq!(cfg.session.last_connection_id, None);
         assert_eq!(cfg.session.last_query, None);
         assert_eq!(cfg.ui.language, "en");
-        assert!(cfg.connections.is_empty());
     }
 
     #[test]
@@ -220,27 +212,10 @@ reduce_motion = true
 page_size = 1000
 
 [session]
-last_connection_id = "uuid-abc"
 last_query = "SELECT * FROM users"
 
 [ui]
 language = "ja"
-
-[[connections]]
-id = "uuid-abc"
-name = "my_postgres"
-db_type = "postgresql"
-host = "localhost"
-port = 5432
-user = "admin"
-password_encrypted = "AES256GCM:abc123"
-database = "mydb"
-
-[[connections]]
-id = "uuid-def"
-name = "local_sqlite"
-db_type = "sqlite"
-database = "local.db"
 "#;
         let cfg: Config = toml::from_str(toml).expect("failed to deserialize");
 
@@ -248,29 +223,12 @@ database = "local.db"
         assert_eq!(cfg.appearance.font_family, "Fira Code");
         assert_eq!(cfg.appearance.font_size, 16);
         assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
-        assert_eq!(cfg.session.last_connection_id, Some("uuid-abc".to_string()));
         assert_eq!(
             cfg.session.last_query,
             Some("SELECT * FROM users".to_string())
         );
         assert_eq!(cfg.ui.language, "ja");
         assert!(cfg.appearance.reduce_motion);
-
-        assert_eq!(cfg.connections.len(), 2);
-        let pg = &cfg.connections[0];
-        assert_eq!(pg.id, "uuid-abc");
-        assert_eq!(pg.name, "my_postgres");
-        assert_eq!(pg.db_type, DbTypeName::PostgreSQL);
-        assert_eq!(pg.host, Some("localhost".to_string()));
-        assert_eq!(pg.port, Some(5432));
-        assert_eq!(pg.user, Some("admin".to_string()));
-        assert_eq!(pg.password_encrypted, Some("AES256GCM:abc123".to_string()));
-        assert_eq!(pg.database, Some("mydb".to_string()));
-
-        let sq = &cfg.connections[1];
-        assert_eq!(sq.db_type, DbTypeName::SQLite);
-        assert_eq!(sq.host, None);
-        assert_eq!(sq.port, None);
     }
 
     #[test]
@@ -280,7 +238,6 @@ database = "local.db"
         assert_eq!(cfg.appearance.theme, Theme::Dark);
         assert_eq!(cfg.editor.page_size, PageSize::Rows500);
         assert_eq!(cfg.ui.language, "en");
-        assert!(cfg.connections.is_empty());
     }
 
     #[test]
@@ -307,8 +264,6 @@ database = "local.db"
 
     #[test]
     fn config_should_roundtrip_serialize_deserialize() {
-        // connections and session.last_connection_id are skip_serializing (migration-only
-        // fields), so they are intentionally excluded from the roundtrip assertion.
         let original = Config {
             appearance: AppearanceConfig {
                 theme: Theme::Light,
@@ -320,13 +275,11 @@ database = "local.db"
                 page_size: PageSize::Rows100,
             },
             session: SessionConfig {
-                last_connection_id: None,
                 last_query: Some("SELECT 1".to_string()),
             },
             ui: UiConfig {
                 language: "ja".to_string(),
             },
-            connections: vec![],
         };
 
         let serialized = toml::to_string(&original).expect("failed to serialize");

--- a/crates/wf-config/src/repository.rs
+++ b/crates/wf-config/src/repository.rs
@@ -1,13 +1,7 @@
-use std::path::PathBuf;
-
 use anyhow::Context as _;
-use sqlx::{Row as _, SqlitePool, sqlite::SqliteConnectOptions};
-use tracing::info;
+use sqlx::{Row as _, SqlitePool};
 
-use crate::{
-    manager::ConfigManager,
-    models::{ConnectionConfig, DbTypeName},
-};
+use crate::models::{ConnectionConfig, DbTypeName};
 
 const CREATE_TABLE: &str = "
     CREATE TABLE IF NOT EXISTS connections (
@@ -28,7 +22,7 @@ const CREATE_TABLE: &str = "
     )
 ";
 
-/// Persists [`ConnectionConfig`] records to a SQLite `connections.db` file.
+/// Persists [`ConnectionConfig`] records to SQLite.
 ///
 /// Cheap to clone — all clones share the same underlying connection pool.
 #[derive(Clone)]
@@ -37,54 +31,19 @@ pub struct ConnectionRepository {
 }
 
 impl ConnectionRepository {
-    /// Open (or create) the connections database at `path` and run schema migrations.
-    pub async fn open(path: &PathBuf) -> anyhow::Result<Self> {
-        let opts = SqliteConnectOptions::new()
-            .filename(path)
-            .create_if_missing(true);
-        let pool = SqlitePool::connect_with(opts)
-            .await
-            .context("failed to open connections.db")?;
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> anyhow::Result<Self> {
         sqlx::query(CREATE_TABLE)
             .execute(&pool)
             .await
-            .context("failed to migrate connections.db")?;
+            .context("failed to migrate connections table")?;
         Ok(Self { pool })
     }
 
-    /// Open the database and, if it is empty, import connections from `config.toml`.
-    ///
-    /// After import the original TOML connections are left in place (read-only migration —
-    /// `skip_serializing` on those fields means they are no longer written back).
-    pub async fn open_with_migration(path: &PathBuf, cm: &ConfigManager) -> anyhow::Result<Self> {
-        let repo = Self::open(path).await?;
-        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM connections")
-            .fetch_one(&repo.pool)
-            .await?;
-        if count == 0 {
-            let config = cm.load().context("failed to load config for migration")?;
-            if !config.connections.is_empty() {
-                let last_id = config.session.last_connection_id.clone();
-                for (i, cc) in config.connections.iter().enumerate() {
-                    repo.upsert_with_order(cc, i as i64).await?;
-                }
-                if let Some(ref last) = last_id {
-                    repo.touch_last_used(last).await.ok();
-                }
-                info!(
-                    count = config.connections.len(),
-                    "migrated connections from config.toml to connections.db"
-                );
-            }
-        }
-        Ok(repo)
-    }
-
-    /// Open an in-memory database (for tests only).
+    /// In-memory database (for tests only).
     pub async fn open_memory() -> anyhow::Result<Self> {
         let pool = SqlitePool::connect("sqlite::memory:").await?;
-        sqlx::query(CREATE_TABLE).execute(&pool).await?;
-        Ok(Self { pool })
+        Self::new(pool).await
     }
 
     /// Return all saved connections ordered by `sort_order`, then `created_at`.
@@ -320,7 +279,6 @@ mod tests {
         let repo = ConnectionRepository::open_memory().await.unwrap();
         repo.upsert(&make_conn("c1")).await.unwrap();
         repo.upsert(&make_conn("c2")).await.unwrap();
-        // c2 touched most recently
         repo.touch_last_used("c1").await.unwrap();
         // small delay so the unixepoch() values differ
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
@@ -343,40 +301,5 @@ mod tests {
         let found = repo.find("c1").await.unwrap().unwrap();
         assert!(!found.safe_dml);
         assert!(found.read_only);
-    }
-
-    #[tokio::test]
-    async fn repository_should_migrate_from_config_toml() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config.toml");
-        let db_path = dir.path().join("connections.db");
-
-        // Write a config.toml directly — ConfigManager::save skips `connections`
-        // (skip_serializing), so we write raw TOML to simulate a pre-migration file.
-        let toml_content = r#"
-[session]
-last_connection_id = "c-toml"
-
-[[connections]]
-id = "c-toml"
-name = "Test"
-db_type = "sqlite"
-"#;
-        std::fs::write(&config_path, toml_content).unwrap();
-
-        let repo = ConnectionRepository::open_with_migration(
-            &db_path,
-            &ConfigManager::with_path(config_path),
-        )
-        .await
-        .unwrap();
-
-        let all = repo.all().await.unwrap();
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].id, "c-toml");
-
-        // last_used_at should have been set.
-        let last = repo.last_used().await.unwrap();
-        assert_eq!(last.unwrap().id, "c-toml");
     }
 }

--- a/crates/wf-history/src/find_history.rs
+++ b/crates/wf-history/src/find_history.rs
@@ -1,10 +1,7 @@
-use std::path::Path;
-
 use anyhow::Result;
 use sqlx::SqlitePool;
-use sqlx::sqlite::SqliteConnectOptions;
 
-/// Persists find/replace bar search terms to a SQLite table in `history.db`.
+/// Persists find/replace bar search terms to a SQLite table.
 ///
 /// Cheap to clone — all clones share the same underlying connection pool.
 #[derive(Clone)]
@@ -21,14 +18,8 @@ const CREATE_TABLE: &str = "
     )";
 
 impl FindHistoryService {
-    /// Open (or create) the history database at `db_path` and run schema migrations.
-    ///
-    /// Shares the same file as [`crate::service::HistoryService`].
-    pub async fn open(db_path: &Path) -> Result<Self> {
-        let opts = SqliteConnectOptions::new()
-            .filename(db_path)
-            .create_if_missing(true);
-        let pool = SqlitePool::connect_with(opts).await?;
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
         Self::migrate(&pool).await?;
         Ok(Self { pool })
     }
@@ -64,8 +55,7 @@ impl FindHistoryService {
     #[cfg(test)]
     async fn open_memory() -> Result<Self> {
         let pool = SqlitePool::connect("sqlite::memory:").await?;
-        Self::migrate(&pool).await?;
-        Ok(Self { pool })
+        Self::new(pool).await
     }
 }
 

--- a/crates/wf-history/src/lib.rs
+++ b/crates/wf-history/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod find_history;
 pub mod service;
+pub mod session;

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -1,15 +1,12 @@
-use std::path::Path;
-
 use anyhow::Result;
 use sqlx::SqlitePool;
-use sqlx::sqlite::SqliteConnectOptions;
 use wf_db::models::QueryExecution;
 
 // ---------------------------------------------------------------------------
 // HistoryService
 // ---------------------------------------------------------------------------
 
-/// Persists [`QueryExecution`] records to a SQLite `history.db` file.
+/// Persists [`QueryExecution`] records to SQLite.
 ///
 /// Cheap to clone — all clones share the same underlying connection pool.
 #[derive(Clone)]
@@ -29,15 +26,8 @@ const CREATE_TABLE: &str = "
     )";
 
 impl HistoryService {
-    /// Open (or create) the history database at `db_path` and run schema migrations.
-    ///
-    /// Creates the file if it does not exist.  Returns an error if the path is
-    /// not writable or if the migration query fails.
-    pub async fn open(db_path: &Path) -> Result<Self> {
-        let opts = SqliteConnectOptions::new()
-            .filename(db_path)
-            .create_if_missing(true);
-        let pool = SqlitePool::connect_with(opts).await?;
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
         Self::migrate(&pool).await?;
         Ok(Self { pool })
     }
@@ -96,12 +86,10 @@ impl HistoryService {
         Ok(executions)
     }
 
-    /// In-memory database variant for unit tests only.
     #[cfg(test)]
     async fn open_memory() -> Result<Self> {
         let pool = SqlitePool::connect("sqlite::memory:").await?;
-        Self::migrate(&pool).await?;
-        Ok(Self { pool })
+        Self::new(pool).await
     }
 }
 

--- a/crates/wf-history/src/session.rs
+++ b/crates/wf-history/src/session.rs
@@ -1,0 +1,225 @@
+use anyhow::Context as _;
+use sqlx::{Row as _, SqlitePool};
+
+/// A single SQL Editor tab persisted across app restarts.
+#[derive(Debug, Clone)]
+pub struct TabSessionEntry {
+    pub id: String,
+    pub title: String,
+    pub query_text: String,
+}
+
+const CREATE_TABS: &str = "
+    CREATE TABLE IF NOT EXISTS session_tabs (
+        sort_order  INTEGER NOT NULL,
+        id          TEXT    NOT NULL,
+        title       TEXT    NOT NULL,
+        query_text  TEXT    NOT NULL DEFAULT '',
+        is_active   INTEGER NOT NULL DEFAULT 0
+    )
+";
+
+const CREATE_STATE: &str = "
+    CREATE TABLE IF NOT EXISTS session_state (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+";
+
+/// Persists tab state and last-query text to SQLite.
+///
+/// Cheap to clone — all clones share the same underlying connection pool.
+#[derive(Clone)]
+pub struct SessionService {
+    pool: SqlitePool,
+}
+
+impl SessionService {
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> anyhow::Result<Self> {
+        sqlx::query(CREATE_TABS)
+            .execute(&pool)
+            .await
+            .context("failed to create session_tabs table")?;
+        sqlx::query(CREATE_STATE)
+            .execute(&pool)
+            .await
+            .context("failed to create session_state table")?;
+        Ok(Self { pool })
+    }
+
+    /// Persist the editor tabs. Replaces all previously saved tabs.
+    ///
+    /// `active_index` is the index within `tabs` (SQL Editor tabs only) that was active.
+    pub async fn save_tabs(
+        &self,
+        active_index: usize,
+        tabs: &[TabSessionEntry],
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM session_tabs")
+            .execute(&mut *tx)
+            .await?;
+        for (i, tab) in tabs.iter().enumerate() {
+            let is_active = if i == active_index { 1i32 } else { 0i32 };
+            sqlx::query(
+                "INSERT INTO session_tabs (sort_order, id, title, query_text, is_active)
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(i as i64)
+            .bind(&tab.id)
+            .bind(&tab.title)
+            .bind(&tab.query_text)
+            .bind(is_active)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Restore tabs from the previous session.
+    ///
+    /// Returns `None` when no tabs have been saved yet.
+    pub async fn restore_tabs(&self) -> anyhow::Result<Option<(usize, Vec<TabSessionEntry>)>> {
+        let rows = sqlx::query(
+            "SELECT sort_order, id, title, query_text, is_active
+             FROM session_tabs ORDER BY sort_order ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let mut active_index = 0usize;
+        let entries: Vec<TabSessionEntry> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, row)| {
+                let is_active: i64 = row.try_get("is_active").unwrap_or(0);
+                if is_active != 0 {
+                    active_index = i;
+                }
+                Ok(TabSessionEntry {
+                    id: row.try_get("id")?,
+                    title: row.try_get("title")?,
+                    query_text: row.try_get("query_text")?,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Some((active_index, entries)))
+    }
+
+    /// Persist the last active editor query text.
+    pub async fn save_last_query(&self, query: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO session_state (key, value) VALUES ('last_query', ?)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(query)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Restore the last active editor query text.
+    ///
+    /// Returns `None` when no query has been saved or it is empty.
+    pub async fn restore_last_query(&self) -> anyhow::Result<Option<String>> {
+        let value: Option<String> =
+            sqlx::query_scalar("SELECT value FROM session_state WHERE key = 'last_query'")
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(value.filter(|s| !s.is_empty()))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_memory() -> SessionService {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        SessionService::new(pool).await.unwrap()
+    }
+
+    fn make_tab(id: &str, title: &str, query: &str) -> TabSessionEntry {
+        TabSessionEntry {
+            id: id.to_string(),
+            title: title.to_string(),
+            query_text: query.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_service_should_restore_tabs_after_save() {
+        let svc = open_memory().await;
+        let tabs = vec![
+            make_tab("t1", "Query 1", "SELECT 1"),
+            make_tab("t2", "Query 2", "SELECT 2"),
+        ];
+        svc.save_tabs(1, &tabs).await.unwrap();
+
+        let (active, restored) = svc.restore_tabs().await.unwrap().expect("should restore");
+        assert_eq!(active, 1);
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[0].id, "t1");
+        assert_eq!(restored[1].query_text, "SELECT 2");
+    }
+
+    #[tokio::test]
+    async fn session_service_restore_tabs_should_return_none_when_empty() {
+        let svc = open_memory().await;
+        assert!(svc.restore_tabs().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn session_service_save_tabs_should_replace_previous() {
+        let svc = open_memory().await;
+        svc.save_tabs(0, &[make_tab("t1", "Q1", "SELECT 1")])
+            .await
+            .unwrap();
+        svc.save_tabs(0, &[make_tab("t2", "Q2", "SELECT 2")])
+            .await
+            .unwrap();
+
+        let (_, restored) = svc.restore_tabs().await.unwrap().expect("should restore");
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].id, "t2");
+    }
+
+    #[tokio::test]
+    async fn session_service_should_save_and_restore_last_query() {
+        let svc = open_memory().await;
+        svc.save_last_query("SELECT * FROM users").await.unwrap();
+        let q = svc.restore_last_query().await.unwrap();
+        assert_eq!(q, Some("SELECT * FROM users".to_string()));
+    }
+
+    #[tokio::test]
+    async fn session_service_restore_last_query_should_return_none_when_absent() {
+        let svc = open_memory().await;
+        assert!(svc.restore_last_query().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn session_service_restore_last_query_should_return_none_for_empty_string() {
+        let svc = open_memory().await;
+        svc.save_last_query("").await.unwrap();
+        assert!(svc.restore_last_query().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn session_service_save_last_query_should_overwrite_previous() {
+        let svc = open_memory().await;
+        svc.save_last_query("SELECT 1").await.unwrap();
+        svc.save_last_query("SELECT 2").await.unwrap();
+        let q = svc.restore_last_query().await.unwrap();
+        assert_eq!(q, Some("SELECT 2".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Consolidates all per-feature SQLite databases (`find_history.db`, `metadata_cache.db`, `history.db`, `connections.db`) into a single shared `wellfeather.db` opened once at startup in `main.rs` and injected as a `SqlitePool` clone into every service. Also removes the stale file-based session persistence (`tabs.toml`, `last_query.sql`) and the config.toml connection migration shim, replacing them with a new `SessionService` backed by the same shared pool. Fixes two regressions in the find bar: history not being saved, and history text not appearing in the input on arrow-key navigation.

## Changes

- **`crates/wf-history/src/session.rs`** (new): `SessionService` with `save_tabs` / `restore_tabs` / `save_last_query` / `restore_last_query` backed by `session_tabs` and `session_state` tables; 7 unit tests
- **`crates/wf-history/src/lib.rs`**: export `pub mod session`
- **`app/src/main.rs`**: open one `SqlitePool` (WAL mode) at startup; inject `pool.clone()` into `ConnectionRepository`, `HistoryService`, `FindHistoryService`, `SessionService`, and `MetadataCache`
- **`app/src/app/session.rs`**: remove `save_tabs`, `restore_tabs`, `save_query_file`, `restore_query_file`, `TabsFile`; re-export `TabSessionEntry` from `wf-history`; remove config.toml migration shim references
- **`crates/wf-config/src/models.rs`**: remove `Config.connections` and `SessionConfig.last_connection_id` (migration-only fields)
- **`crates/wf-config/src/repository.rs`**: remove `new_with_migration()` and related migration test
- **`app/src/ui/mod.rs`**: accept `SessionService` in `UI::new()`; restore tabs/last-query via `handle.block_on()`; close handler saves via `handle.block_on()` (blocks briefly to guarantee write before window hides)
- **`app/src/ui/components/find_replace_bar.slint`**: fix history text not appearing — switch `text: root.query` to `text <=> root.query` (two-way binding so Rust-side `set_find_query` updates the displayed text); add `accepted` handlers to both `TextInput` elements for reliable Enter-key handling; save history on next/prev navigation in addition to Enter
- **`app/src/ui/mod.rs`** find callbacks: save history in `on_find_next` / `on_find_prev`; replace silent `let _ =` error drops with `tracing::warn!`

## Related Issues

Closes #245
Closes #246
Closes #247

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes