### PR TITLE
feat(ui): add snippet system with save dialog, draggable bar, and list/edit modals

### DIFF
--- a/app/assets/icons/snippet.svg
+++ b/app/assets/icons/snippet.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 5C9 3.89543 9.89543 3 11 3H13C14.1046 3 15 3.89543 15 5V7H9V5Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 5H7C5.89543 5 5 5.89543 5 7V19C5 20.1046 5.89543 21 7 21H12H17C18.1046 21 19 20.1046 19 19V7C19 5.89543 18.1046 5 17 5H15" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 12L8 14L10 16" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 12L16 14L14 16" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -392,3 +392,99 @@ msgstr "Find (↑↓ for history)"
 msgctxt "FindReplaceBar"
 msgid "Replace (↑↓ for history)"
 msgstr "Replace (↑↓ for history)"
+
+msgctxt "Sidebar"
+msgid "Snippets"
+msgstr "Snippets"
+
+msgctxt "SnippetEditDialog"
+msgid "Edit Snippet"
+msgstr "Edit Snippet"
+
+msgctxt "SnippetEditDialog"
+msgid "Comment"
+msgstr "Comment"
+
+msgctxt "SnippetEditDialog"
+msgid "Query"
+msgstr "Query"
+
+msgctxt "SnippetEditDialog"
+msgid "Comment (optional)"
+msgstr "Comment (optional)"
+
+msgctxt "SnippetEditDialog"
+msgid "Save"
+msgstr "Save"
+
+msgctxt "SnippetEditDialog"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "MenuBar"
+msgid "Snippets"
+msgstr "Snippets"
+
+msgctxt "MenuBar"
+msgid "Add Snippet (Ctrl+D)"
+msgstr "Add Snippet (Ctrl+D)"
+
+msgctxt "MenuBar"
+msgid "Show Snippets"
+msgstr "Show Snippets"
+
+msgctxt "SnippetSaveDialog"
+msgid "Save Snippet"
+msgstr "Save Snippet"
+
+msgctxt "SnippetSaveDialog"
+msgid "What is the purpose of this query?"
+msgstr "What is the purpose of this query?"
+
+msgctxt "SnippetSaveDialog"
+msgid "Comment (optional)"
+msgstr "Comment (optional)"
+
+msgctxt "SnippetSaveDialog"
+msgid "Save"
+msgstr "Save"
+
+msgctxt "SnippetSaveDialog"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "SnippetListDialog"
+msgid "Snippets"
+msgstr "Snippets"
+
+msgctxt "SnippetListDialog"
+msgid "No snippets yet"
+msgstr "No snippets yet"
+
+msgctxt "SnippetListDialog"
+msgid "Edit"
+msgstr "Edit"
+
+msgctxt "SnippetListDialog"
+msgid "Delete"
+msgstr "Delete"
+
+msgctxt "SnippetListDialog"
+msgid "Add Snippet (Ctrl+D)"
+msgstr "Add Snippet (Ctrl+D)"
+
+msgctxt "SnippetBar"
+msgid "Snippets"
+msgstr "Snippets"
+
+msgctxt "SnippetBar"
+msgid "No snippets yet"
+msgstr "No snippets yet"
+
+msgctxt "SnippetBar"
+msgid "Paste"
+msgstr "Paste"
+
+msgctxt "SnippetBar"
+msgid "Run"
+msgstr "Run"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -392,3 +392,99 @@ msgstr "検索（↑↓で履歴）"
 msgctxt "FindReplaceBar"
 msgid "Replace (↑↓ for history)"
 msgstr "置換（↑↓で履歴）"
+
+msgctxt "Sidebar"
+msgid "Snippets"
+msgstr "スニペット"
+
+msgctxt "SnippetEditDialog"
+msgid "Edit Snippet"
+msgstr "スニペットを編集"
+
+msgctxt "SnippetEditDialog"
+msgid "Comment"
+msgstr "コメント"
+
+msgctxt "SnippetEditDialog"
+msgid "Query"
+msgstr "クエリ"
+
+msgctxt "SnippetEditDialog"
+msgid "Comment (optional)"
+msgstr "コメント（任意）"
+
+msgctxt "SnippetEditDialog"
+msgid "Save"
+msgstr "保存"
+
+msgctxt "SnippetEditDialog"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "MenuBar"
+msgid "Snippets"
+msgstr "スニペット"
+
+msgctxt "MenuBar"
+msgid "Add Snippet (Ctrl+D)"
+msgstr "スニペットを追加 (Ctrl+D)"
+
+msgctxt "MenuBar"
+msgid "Show Snippets"
+msgstr "スニペットを表示"
+
+msgctxt "SnippetSaveDialog"
+msgid "Save Snippet"
+msgstr "スニペットを保存"
+
+msgctxt "SnippetSaveDialog"
+msgid "What is the purpose of this query?"
+msgstr "このクエリの用途は何ですか？"
+
+msgctxt "SnippetSaveDialog"
+msgid "Comment (optional)"
+msgstr "コメント（任意）"
+
+msgctxt "SnippetSaveDialog"
+msgid "Save"
+msgstr "保存"
+
+msgctxt "SnippetSaveDialog"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "SnippetListDialog"
+msgid "Snippets"
+msgstr "スニペット"
+
+msgctxt "SnippetListDialog"
+msgid "No snippets yet"
+msgstr "スニペットがありません"
+
+msgctxt "SnippetListDialog"
+msgid "Edit"
+msgstr "編集"
+
+msgctxt "SnippetListDialog"
+msgid "Delete"
+msgstr "削除"
+
+msgctxt "SnippetListDialog"
+msgid "Add Snippet (Ctrl+D)"
+msgstr "スニペットを追加 (Ctrl+D)"
+
+msgctxt "SnippetBar"
+msgid "Snippets"
+msgstr "スニペット"
+
+msgctxt "SnippetBar"
+msgid "No snippets yet"
+msgstr "スニペットがありません"
+
+msgctxt "SnippetBar"
+msgid "Paste"
+msgstr "貼り付け"
+
+msgctxt "SnippetBar"
+msgid "Run"
+msgstr "実行"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -31,7 +31,7 @@ use app::{
 use state::AppState;
 use ui::UI;
 use wf_completion::cache::MetadataCache;
-use wf_config::{ConnectionRepository, crypto, manager::ConfigManager};
+use wf_config::{ConnectionRepository, SnippetRepository, crypto, manager::ConfigManager};
 use wf_db::service::DbService;
 use wf_history::{
     find_history::FindHistoryService, service::HistoryService, session::SessionService,
@@ -85,6 +85,8 @@ fn main() -> anyhow::Result<()> {
     let history_svc = runtime.block_on(HistoryService::new(pool.clone()))?;
     let find_history_svc = runtime.block_on(FindHistoryService::new(pool.clone()))?;
     let session_svc = runtime.block_on(SessionService::new(pool.clone()))?;
+    let snippet_repo: Arc<SnippetRepository> =
+        Arc::new(runtime.block_on(SnippetRepository::new(pool.clone()))?);
     let metadata_cache = runtime.block_on(MetadataCache::new(pool.clone()))?;
 
     // Load all saved connections for the initial sidebar/DB-manager list.
@@ -134,6 +136,7 @@ fn main() -> anyhow::Result<()> {
         initial_connections,
         find_history_svc,
         session_svc,
+        snippet_repo,
     )?;
     ui.run()
 }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData, SnippetEntry } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -23,7 +23,11 @@ import { AddConnectionDialog } from "components/dialogs/add_connection_dialog.sl
 import { AllRowsDialog }       from "components/dialogs/all_rows_dialog.slint";
 import { SafeDmlDialog }       from "components/dialogs/safe_dml_dialog.slint";
 import { DbManagerDialog }     from "components/dialogs/db_manager_dialog.slint";
-import { FindReplaceBar }     from "components/find_replace_bar.slint";
+import { FindReplaceBar }          from "components/find_replace_bar.slint";
+import { SnippetSaveDialog }     from "components/snippet_save_dialog.slint";
+import { SnippetListDialog }     from "components/snippet_list_dialog.slint";
+import { SnippetEditDialog }     from "components/snippet_edit_dialog.slint";
+import { SnippetBar }            from "components/snippet_bar.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -154,6 +158,42 @@ export global UiState {
     in-out property <bool>   conn-safe-dml: true;
     /// Active connection read_only setting (set by Rust on connect).
     in-out property <bool>   conn-read-only: false;
+
+    // ── Snippets ─────────────────────────────────────────────────────────────
+    in-out property <[SnippetEntry]> snippets: [];
+    /// Show the save dialog. Rust pre-fills name from first 40 chars of SQL.
+    callback open-snippet-save(int, int);   // anchor-pos, cursor-pos
+    /// Persist the snippet after user confirms in the save dialog.
+    callback save-snippet(string, string, string);  // name, comment, sql
+    /// Remove a snippet from the list modal.
+    callback delete-snippet-item(string);      // id
+    /// Save edits (comment + sql) for an existing snippet.
+    callback save-snippet-edit(string, string, string);   // id, comment, sql
+    /// Insert snippet SQL at the editor cursor position.
+    callback load-snippet-sql(string, int);
+    /// Set editor text to snippet SQL and execute immediately.
+    callback execute-snippet-sql(string);
+    /// Persist the Snippet Bar position after dragging.
+    callback save-snippet-bar-position(float, float);
+
+    // ── Snippet save dialog ──────────────────────────────────────────────────
+    in-out property <bool>   show-snippet-save:    false;
+    in-out property <string> snippet-save-name:    "";
+    in-out property <string> snippet-save-comment: "";
+    in-out property <string> snippet-save-sql:     "";
+
+    // ── Snippet list dialog ──────────────────────────────────────────────────
+    in-out property <bool>   show-snippet-list:    false;
+    // ── Snippet edit dialog ──────────────────────────────────────────────────
+    in-out property <bool>   show-snippet-edit:    false;
+    in-out property <string> snippet-edit-id:      "";
+    in-out property <string> snippet-edit-comment: "";
+    in-out property <string> snippet-edit-sql:     "";
+
+    // ── Snippet Bar ──────────────────────────────────────────────────────────
+    in-out property <bool>  show-snippet-bar: false;
+    in-out property <float> snippet-bar-x:    0.0;
+    in-out property <float> snippet-bar-y:    100.0;
 
     // ── Find / replace bar ────────────────────────────────────────────────────
     in-out property <bool>   show-find-bar:         false;
@@ -394,6 +434,18 @@ export component AppWindow inherits Window {
     private property <bool> _db-mgr-open:  UiState.show-db-manager;
     changed _db-mgr-open => { if (_db-mgr-open) { _db-mgr-alive = true; } }
 
+    private property <bool> _bk-save-alive:   false;
+    private property <bool> _bk-save-open:    UiState.show-snippet-save;
+    changed _bk-save-open => { if (_bk-save-open) { _bk-save-alive = true; } }
+
+    private property <bool> _bk-list-alive:   false;
+    private property <bool> _bk-list-open:    UiState.show-snippet-list;
+    changed _bk-list-open => { if (_bk-list-open) { _bk-list-alive = true; } }
+
+    private property <bool> _bk-edit-alive: false;
+    private property <bool> _bk-edit-open:  UiState.show-snippet-edit;
+    changed _bk-edit-open => { if (_bk-edit-open) { _bk-edit-alive = true; } }
+
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
     // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
     // of which inner FocusScope — editor, table-view, sidebar, result — has focus.
@@ -413,7 +465,10 @@ export component AppWindow inherits Window {
                     || UiState.show-test-result-popup
                     || UiState.show-add-confirm-popup
                     || UiState.show-all-rows-confirm
-                    || UiState.show-safe-dml-confirm) {
+                    || UiState.show-safe-dml-confirm
+                    || UiState.show-snippet-save
+                    || UiState.show-snippet-list
+                    || UiState.show-snippet-edit) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -446,6 +501,12 @@ export component AppWindow inherits Window {
                     && UiState.active-tab-kind-sql
                     && event.text == "f") {
                 UiState.show-find-bar = true;
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "b") {
+                UiState.show-snippet-bar = !UiState.show-snippet-bar;
                 EventResult.accept
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -535,6 +596,8 @@ export component AppWindow inherits Window {
             run-all(sql)   => { UiState.run-all(sql); }
             cancel-query   => { UiState.cancel-query(); }
             set-language(lang) => { UiState.set-language(lang); }
+            add-snippet   => { UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos); }
+            show-snippets => { UiState.show-snippet-list = true; }
         }
 
         // ── Tab bar (above the editor only) ──────────────────────────────────
@@ -555,8 +618,8 @@ export component AppWindow inherits Window {
             y: menu-bar-height;
             width:  sidebar-width;
             height: content-height + tab-bar-height;
-            tree:        UiState.sidebar-tree;
-            is-loading:  UiState.sidebar-loading;
+            tree:               UiState.sidebar-tree;
+            is-loading:         UiState.sidebar-loading;
             toggle-node(id) => { UiState.toggle-sidebar-node(id); }
             table-double-clicked(name) => { UiState.table-double-clicked(name); }
             add-connection => { UiState.open-connection-form(); }
@@ -636,6 +699,7 @@ export component AppWindow inherits Window {
                     UiState.find-sel-start = -1;
                     UiState.find-sel-end = -1;
                 }
+                open-snippet-save(a, c) => { UiState.open-snippet-save(a, c); }
                 focus-sidebar => { root.focused-pane = 0; sidebar-inst.grab-focus(); }
                 focus-result  => {
                     if (UiState.result-panel-open) {
@@ -1045,6 +1109,98 @@ export component AppWindow inherits Window {
                 UiState.open-connection-form();
             }
             exited => { _db-mgr-alive = false; }
+        }
+
+        // ── Snippet save dialog ──────────────────────────────────────────────
+        if _bk-save-alive: SnippetSaveDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:    UiState.show-snippet-save;
+            comment <=> UiState.snippet-save-comment;
+            save => {
+                UiState.save-snippet(
+                    UiState.snippet-save-name,
+                    UiState.snippet-save-comment,
+                    UiState.snippet-save-sql
+                );
+                UiState.show-snippet-save    = false;
+                UiState.snippet-save-comment = "";
+            }
+            cancelled => { UiState.show-snippet-save = false; }
+            exited    => { _bk-save-alive = false; }
+        }
+
+        // ── Snippet list dialog ───────────────────────────────────────────────
+        if _bk-list-alive: SnippetListDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:           UiState.show-snippet-list;
+            snippets:       UiState.snippets;
+            code-font-size: UiState.font-size * 1px;
+            rename-snippet(id, comment, sql) => {
+                UiState.show-snippet-list    = false;
+                UiState.snippet-edit-id      = id;
+                UiState.snippet-edit-comment = comment;
+                UiState.snippet-edit-sql     = sql;
+                UiState.show-snippet-edit    = true;
+            }
+            delete-snippet(id) => { UiState.delete-snippet-item(id); }
+            insert-sql(sql)  => {
+                UiState.show-snippet-list = false;
+                UiState.load-snippet-sql(sql, editor-inst.cursor-pos);
+            }
+            execute-sql(sql) => {
+                UiState.show-snippet-list = false;
+                UiState.execute-snippet-sql(sql);
+            }
+            add-snippet => {
+                UiState.show-snippet-list = false;
+                UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos);
+            }
+            close  => { UiState.show-snippet-list = false; }
+            exited => { _bk-list-alive = false; }
+        }
+
+        // ── Snippet edit dialog ──────────────────────────────────────────────
+        if _bk-edit-alive: SnippetEditDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:           UiState.show-snippet-edit;
+            comment        <=> UiState.snippet-edit-comment;
+            sql            <=> UiState.snippet-edit-sql;
+            code-font-size:    UiState.font-size * 1px;
+            save => {
+                UiState.save-snippet-edit(
+                    UiState.snippet-edit-id,
+                    UiState.snippet-edit-comment,
+                    UiState.snippet-edit-sql
+                );
+                UiState.show-snippet-edit = false;
+            }
+            cancelled => {
+                UiState.show-snippet-edit = false;
+                UiState.show-snippet-list = true;
+            }
+            exited    => { _bk-edit-alive = false; }
+        }
+
+        // ── Snippet Bar (draggable floating panel) ────────────────────────────
+        if UiState.show-snippet-bar: SnippetBar {
+            x: UiState.snippet-bar-x * 1px;
+            y: UiState.snippet-bar-y * 1px;
+            snippets: UiState.snippets;
+            position-changed(new-x, new-y) => {
+                UiState.snippet-bar-x = clamp(
+                    new-x, 0.0, (root.width - 460px) / 1px
+                );
+                UiState.snippet-bar-y = clamp(
+                    new-y, 0.0, (root.height - 80px) / 1px
+                );
+                UiState.save-snippet-bar-position(UiState.snippet-bar-x, UiState.snippet-bar-y);
+            }
+            insert-sql(sql)  => { UiState.load-snippet-sql(sql, editor-inst.cursor-pos); }
+            execute-sql(sql) => { UiState.execute-snippet-sql(sql); }
+            close => { UiState.show-snippet-bar = false; }
         }
 
     }

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -86,9 +86,20 @@ export component Editor inherits Rectangle {
     /// Fired when the user presses Ctrl+Shift+F to reformat the SQL.
     callback format-sql();
 
+    /// Fired when the user presses Ctrl+D to save a snippet.
+    /// Passes anchor and cursor byte offsets captured BEFORE TextInput processes the key,
+    /// preserving the selection state.
+    callback open-snippet-save(int, int);
+
     // Pane navigation initiated from inside the editor.
     callback focus-sidebar();
     callback focus-result();
+
+    // ── Selection / cursor exposure (for snippet save) ──────────────────────
+    /// Anchor byte offset; equals cursor-pos when nothing is selected.
+    out property <int> anchor-pos: inner-input.anchor-position-byte-offset;
+    /// Cursor byte offset.
+    out property <int> cursor-pos: inner-input.cursor-position-byte-offset;
 
     // ── Find bar integration ──────────────────────────────────────────────────
     /// True when the find bar is open; allows Esc to close it from the editor.
@@ -546,6 +557,15 @@ export component Editor inherits Rectangle {
                     if (event.text == Key.LeftArrow) { root.focus-sidebar(); EventResult.accept }
                     else if (event.text == Key.DownArrow) { root.focus-result(); EventResult.accept }
                     else { EventResult.reject }
+                } else if (event.text == "d"
+                        && event.modifiers.control
+                        && !event.modifiers.shift
+                        && !event.modifiers.alt) {
+                    root.open-snippet-save(
+                        inner-input.anchor-position-byte-offset,
+                        inner-input.cursor-position-byte-offset
+                    );
+                    EventResult.accept
                 } else if (event.text == Key.Escape
                         && root.find-bar-open
                         && !root.completion-visible) {

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -20,6 +20,8 @@ export component MenuBar inherits Rectangle {
     callback run-all(string);
     callback cancel-query();
     callback set-language(string);
+    callback add-snippet();
+    callback show-snippets();
     in property <string> editor-text;
     in property <string> language: "en";
     in property <bool>   has-active-connection: false;
@@ -178,6 +180,56 @@ export component MenuBar inherits Rectangle {
                         if root.has-active-connection: MenuItem {
                             text: @tr("Disconnect");
                             clicked => { root.disconnect(); }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Snippets ─────────────────────────────────────────────────────────
+        Rectangle {
+            width: 90px;
+            background: bm-ta.has-hover ? Colors.surface1 : transparent;
+            border-radius: Layout.radius-sm;
+
+            Text {
+                text: @tr("Snippets");
+                color: Colors.text;
+                font-size:   Typography.size-base;
+                horizontal-alignment: center;
+                vertical-alignment:   center;
+            }
+            bm-ta := TouchArea {
+                clicked => { bm-popup.show(); }
+            }
+            bm-popup := PopupWindow {
+                x: 0;
+                y: root.height;
+                width:  200px;
+                height: 2 * Layout.height-menu-item + 1px;
+                close-policy: PopupClosePolicy.close-on-click;
+
+                Rectangle {
+                    width:  200px;
+                    height: 2 * Layout.height-menu-item + 1px;
+                    background:    Colors.surface0;
+                    border-radius: Layout.radius-md;
+                    border-width:  1px;
+                    border-color:  Colors.surface2;
+                    drop-shadow-blur:  8px;
+                    drop-shadow-color: Colors.shadow;
+                    clip: true;
+
+                    VerticalLayout {
+                        spacing: 0;
+                        MenuItem {
+                            text: @tr("Add Snippet (Ctrl+D)");
+                            clicked => { root.add-snippet(); }
+                        }
+                        Rectangle { height: 1px; background: Colors.surface1; }
+                        MenuItem {
+                            text: @tr("Show Snippets");
+                            clicked => { root.show-snippets(); }
                         }
                     }
                 }

--- a/app/src/ui/components/sidebar.slint
+++ b/app/src/ui/components/sidebar.slint
@@ -4,8 +4,8 @@ import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
 export component Sidebar inherits Rectangle {
     background: Colors.base;
 
-    in property <[SidebarNode]> tree:       [];
-    in property <bool>          is-loading: false;
+    in property <[SidebarNode]>    tree:               [];
+    in property <bool>             is-loading:         false;
     callback toggle-node(string);
     callback table-double-clicked(string);
     callback add-connection();

--- a/app/src/ui/components/snippet_bar.slint
+++ b/app/src/ui/components/snippet_bar.slint
@@ -1,0 +1,244 @@
+import { SnippetEntry } from "../globals.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
+
+/// Draggable floating panel listing snippets for quick insert or execute.
+/// Click a row to reveal Paste / Run buttons as an in-row overlay.
+/// Paste inserts SQL at the editor cursor; Run replaces the editor and executes.
+/// Drag the title bar to reposition; fires position-changed(new-x, new-y) on each move.
+export component SnippetBar inherits Rectangle {
+    in property  <[SnippetEntry]> snippets: [];
+    callback position-changed(float, float);
+    callback insert-sql(string);
+    callback execute-sql(string);
+    callback close();
+
+    width:  460px;
+    height: min(520px, 33px + 1px + inner-items.preferred-height);
+    background:    Colors.surface0;
+    border-radius: Layout.radius-md;
+    border-width:  1px;
+    border-color:  Colors.surface1;
+    drop-shadow-blur:  12px;
+    drop-shadow-color: Colors.shadow;
+    clip: true;
+
+    // Click offset within the bar at the moment the drag starts; held constant through the drag.
+    private property <length> press-x: 0px;
+    private property <length> press-y: 0px;
+    // ID of the currently expanded (overlay-showing) snippet row. "" = none.
+    private property <string> selected-id: "";
+
+    VerticalLayout {
+        // ── Title bar (draggable) ─────────────────────────────────────────────
+        Rectangle {
+            height: 32px;
+            background: Colors.mantle;
+
+            HorizontalLayout {
+                padding-left:  Layout.padding-md;
+                padding-right: Layout.padding-xs;
+                alignment: center;
+
+                Text {
+                    text: @tr("Snippets");
+                    color: Colors.text;
+                    font-size: Typography.size-lg;
+                    font-weight: 600;
+                    horizontal-stretch: 1;
+                    vertical-alignment: center;
+                }
+            }
+
+            drag-ta := TouchArea {
+                width: parent.width;
+                height: parent.height;
+                pointer-event(e) => {
+                    if (e.kind == PointerEventKind.down) {
+                        root.press-x = self.mouse-x;
+                        root.press-y = self.mouse-y;
+                    }
+                }
+                moved => {
+                    // root.x + self.mouse-x is absolute mouse position in parent coords.
+                    // Subtracting the immutable click offset gives the target bar position.
+                    root.position-changed(
+                        (root.x + self.mouse-x - root.press-x) / 1px,
+                        (root.y + self.mouse-y - root.press-y) / 1px
+                    );
+                }
+                mouse-cursor: move;
+            }
+        }
+
+        Rectangle { height: 1px; background: Colors.surface1; }
+
+        // ── Scrollable snippet list ───────────────────────────────────────────
+        Flickable {
+            vertical-stretch: 1;
+            interactive: true;
+            viewport-height: max(inner-items.preferred-height, self.height);
+
+            inner-items := VerticalLayout {
+                spacing: 0;
+
+                if root.snippets.length == 0: Rectangle {
+                    height: 64px;
+                    Text {
+                        width: parent.width; height: parent.height;
+                        text: @tr("No snippets yet");
+                        color: Colors.overlay0;
+                        font-size: Typography.size-base;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                }
+
+                for bk in root.snippets: Rectangle {
+                    height: row-vl.preferred-height;
+
+                    // ── Hover background + click-to-expand ────────────────────
+                    Rectangle {
+                        background: row-ta.has-hover && bk.id != root.selected-id
+                            ? Colors.hover-subtle : transparent;
+                        width: parent.width; height: parent.height;
+                        row-ta := TouchArea {
+                            clicked => { root.selected-id = bk.id; }
+                        }
+                    }
+
+                    // ── Row content (always visible beneath the overlay) ──────
+                    row-vl := VerticalLayout {
+                        x: 0; y: 0; width: parent.width;
+                        spacing: 0;
+
+                        // Header: icon + title
+                        HorizontalLayout {
+                            height: Layout.height-dialog-row;
+                            padding-left:  Layout.padding-md;
+                            padding-right: Layout.padding-sm;
+                            spacing: Layout.spacing-md;
+
+                            VerticalLayout {
+                                alignment: center;
+                                Image {
+                                    width: Layout.icon-md; height: Layout.icon-md;
+                                    source: Icons.snippet;
+                                    colorize: Colors.blue;
+                                    image-fit: contain;
+                                }
+                            }
+
+                            Text {
+                                horizontal-stretch: 1;
+                                text: bk.comment != "" ? bk.comment : bk.name;
+                                color: bk.comment != "" ? Colors.text : Colors.subtext0;
+                                font-size: Typography.size-xl;
+                                font-weight: 700;
+                                overflow: elide;
+                                vertical-alignment: center;
+                            }
+                        }
+
+                        // SQL body (word-wrapped monospace)
+                        HorizontalLayout {
+                            padding-left:  Layout.padding-md;
+                            padding-right: Layout.padding-sm;
+                            padding-bottom: Layout.padding-sm;
+                            spacing: Layout.spacing-md;
+
+                            Rectangle { width: Layout.icon-md; }
+
+                            Text {
+                                text: bk.sql;
+                                color: Colors.subtext1;
+                                font-size: Typography.size-base;
+                                font-family: "JetBrains Mono";
+                                wrap: word-wrap;
+                                overflow: clip;
+                            }
+                        }
+
+                        Rectangle { height: 1px; background: Colors.surface1; }
+                    }
+
+                    // ── Overlay: shown when this row is selected ──────────────
+                    if bk.id == root.selected-id: Rectangle {
+                        x: 0; y: 0;
+                        width: parent.width; height: parent.height;
+                        background: Colors.surface1;
+
+                        // × close (top-right)
+                        Rectangle {
+                            x: parent.width - 28px; y: 4px;
+                            width: 24px; height: 24px;
+                            border-radius: Layout.radius-sm;
+                            background: ov-close-ta.has-hover ? Colors.surface2 : transparent;
+                            Image {
+                                x: (parent.width  - self.width)  / 2;
+                                y: (parent.height - self.height) / 2;
+                                width: Layout.icon-sm; height: Layout.icon-sm;
+                                source: Icons.close;
+                                colorize: Colors.subtext0;
+                                image-fit: contain;
+                            }
+                            ov-close-ta := TouchArea {
+                                clicked => { root.selected-id = ""; }
+                            }
+                        }
+
+                        // Paste + Run buttons (vertically centered in the row)
+                        VerticalLayout {
+                            alignment: center;
+                            HorizontalLayout {
+                                alignment: center;
+                                spacing: Layout.spacing-lg;
+
+                                // Paste button
+                                Rectangle {
+                                    width: 110px; height: Layout.height-btn-md;
+                                    border-radius: Layout.radius-sm;
+                                    background: ov-paste-ta.has-hover ? Colors.blue : Colors.surface2;
+                                    Text {
+                                        text: @tr("Paste");
+                                        color: ov-paste-ta.has-hover ? Colors.base : Colors.text;
+                                        font-size: Typography.size-base;
+                                        font-weight: 500;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    ov-paste-ta := TouchArea {
+                                        clicked => {
+                                            root.insert-sql(bk.sql);
+                                            root.selected-id = "";
+                                        }
+                                    }
+                                }
+
+                                // Run button
+                                Rectangle {
+                                    width: 110px; height: Layout.height-btn-md;
+                                    border-radius: Layout.radius-sm;
+                                    background: ov-run-ta.has-hover ? Colors.green : Colors.surface2;
+                                    Text {
+                                        text: @tr("Run");
+                                        color: ov-run-ta.has-hover ? Colors.base : Colors.text;
+                                        font-size: Typography.size-base;
+                                        font-weight: 500;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                    ov-run-ta := TouchArea {
+                                        clicked => {
+                                            root.execute-sql(bk.sql);
+                                            root.selected-id = "";
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/snippet_edit_dialog.slint
+++ b/app/src/ui/components/snippet_edit_dialog.slint
@@ -1,0 +1,160 @@
+import { Colors, Typography, Layout, Animation } from "../theme.slint";
+
+/// Full-screen modal for editing an existing snippet.
+/// Shows a comment field and a SQL code block (editable, JetBrains Mono).
+export component SnippetEditDialog inherits Rectangle {
+    in property  <bool>   show:    false;
+    in-out property <string> comment: "";
+    in-out property <string> sql:     "";
+    in property  <length>    code-font-size: Typography.size-xl;
+    callback save();
+    callback cancelled();
+    callback exited();
+
+    x: 0; y: 0;
+    background: Colors.modal-overlay;
+
+    animate opacity {
+        duration: root.show ? Animation.enter : Animation.fast;
+        easing:   root.show ? Animation.enter-ease : Animation.exit-ease;
+    }
+    opacity: root.show ? 1 : 0;
+    changed opacity => { if (self.opacity == 0) { root.exited(); } }
+
+    fs := FocusScope {
+        x: 0; y: 0; width: parent.width; height: parent.height;
+        focus-on-click: true;
+        key-pressed(event) => {
+            if (event.text == Key.Escape) { root.cancelled(); EventResult.accept }
+            else { EventResult.reject }
+        }
+
+        Rectangle {
+            x: (parent.width  - self.width)  / 2;
+            y: (parent.height - self.height) / 2;
+            width:  720px;
+            height: 560px;
+            background:    Colors.surface0;
+            border-radius: Layout.radius-lg;
+            border-width:  1px;
+            border-color:  Colors.surface1;
+            drop-shadow-blur:  24px;
+            drop-shadow-color: Colors.shadow-light;
+            clip: true;
+
+            VerticalLayout {
+                padding: Layout.padding-2xl;
+                spacing: Layout.spacing-lg;
+
+                Text {
+                    text: @tr("Edit Snippet");
+                    color: Colors.text;
+                    font-size: Typography.size-xl;
+                    font-weight: 700;
+                }
+
+                // ── Comment field ─────────────────────────────────────────────
+                Text {
+                    text: @tr("Comment");
+                    color: Colors.subtext0;
+                    font-size: Typography.size-lg;
+                }
+
+                Rectangle {
+                    height: 32px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  comment-input.has-focus ? Colors.blue : Colors.surface1;
+                    background:    Colors.base;
+                    comment-input := TextInput {
+                        x: Layout.padding-md;
+                        width:  parent.width - 2 * Layout.padding-md;
+                        height: parent.height;
+                        text           <=> root.comment;
+                        color:          Colors.text;
+                        font-size:      Typography.size-lg;
+                        vertical-alignment: center;
+                        single-line:    true;
+                        accepted => { root.save(); }
+                    }
+                    if comment-input.text == "": Text {
+                        x: Layout.padding-md;
+                        width:  parent.width - 2 * Layout.padding-md;
+                        height: parent.height;
+                        text: @tr("Comment (optional)");
+                        color: Colors.overlay0;
+                        font-size: Typography.size-lg;
+                        vertical-alignment: center;
+                    }
+                }
+
+                // ── SQL code block ────────────────────────────────────────────
+                Text {
+                    text: @tr("Query");
+                    color: Colors.subtext0;
+                    font-size: Typography.size-lg;
+                }
+
+                Rectangle {
+                    vertical-stretch: 1;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  sql-input.has-focus ? Colors.blue : Colors.surface1;
+                    background:    Colors.mantle;
+                    clip: true;
+                    sql-input := TextInput {
+                        x: Layout.padding-md;
+                        y: Layout.padding-md;
+                        width:  parent.width - 2 * Layout.padding-md;
+                        height: parent.height - 2 * Layout.padding-md;
+                        text        <=> root.sql;
+                        color:          Colors.text;
+                        font-size:      root.code-font-size;
+                        font-family:    "JetBrains Mono";
+                        selection-background-color: Colors.selection;
+                        single-line:    false;
+                        wrap:           word-wrap;
+                    }
+                }
+
+                // ── Buttons ───────────────────────────────────────────────────
+                HorizontalLayout {
+                    spacing: Layout.spacing-md;
+                    alignment: end;
+
+                    Rectangle {
+                        width: 88px; height: Layout.height-btn-lg;
+                        border-radius: Layout.radius-sm;
+                        border-width:  1px;
+                        border-color:  Colors.surface1;
+                        background:    cancel-ta.has-hover ? Colors.surface1 : transparent;
+                        Text {
+                            text: @tr("Cancel");
+                            color: Colors.text;
+                            font-size: Typography.size-lg;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                        cancel-ta := TouchArea { clicked => { root.cancelled(); } }
+                    }
+
+                    Rectangle {
+                        width: 88px; height: Layout.height-btn-lg;
+                        border-radius: Layout.radius-sm;
+                        background:    Colors.blue;
+                        Text {
+                            text: @tr("Save");
+                            color: Colors.base;
+                            font-size: Typography.size-lg;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                        save-ta := TouchArea { clicked => { root.save(); } }
+                    }
+                }
+            }
+        }
+    }
+
+    init => { comment-input.focus(); }
+}

--- a/app/src/ui/components/snippet_list_dialog.slint
+++ b/app/src/ui/components/snippet_list_dialog.slint
@@ -1,0 +1,288 @@
+import { SnippetEntry } from "../globals.slint";
+import { Colors, Typography, Layout, Icons, Animation } from "../theme.slint";
+
+/// Modal dialog listing all snippets. Matches the Connections modal layout.
+/// Single-click row inserts SQL; double-click executes.
+export component SnippetListDialog inherits Rectangle {
+    in property  <bool>            show:      false;
+    in property  <[SnippetEntry]> snippets: [];
+    in property  <length>          code-font-size: Typography.size-xl;
+    callback rename-snippet(string, string, string);   // id, current_comment, current_sql
+    callback delete-snippet(string);           // id
+    callback insert-sql(string);                // single-click
+    callback execute-sql(string);               // double-click
+    callback add-snippet();
+    callback close();
+    callback exited();
+
+    x: 0; y: 0;
+    background: Colors.shadow;
+
+    animate opacity {
+        duration: root.show ? Animation.enter : Animation.fast;
+        easing:   root.show ? Animation.enter-ease : Animation.exit-ease;
+    }
+    opacity: root.show ? 1 : 0;
+    changed opacity => { if (self.opacity == 0) { root.exited(); } }
+
+    fs := FocusScope {
+        x: 0; y: 0; width: parent.width; height: parent.height;
+        focus-on-click: true;
+        key-pressed(event) => {
+            if (event.text == Key.Escape) { root.close(); EventResult.accept }
+            else { EventResult.reject }
+        }
+
+        // ── Centered card ─────────────────────────────────────────────────────
+        Rectangle {
+            x: (parent.width  - self.width)  / 2;
+            y: (parent.height - self.height) / 2;
+            width:  720px;
+            height: 560px;
+            background:    Colors.surface0;
+            border-radius: Layout.radius-lg;
+            border-width:  1px;
+            border-color:  Colors.surface2;
+            drop-shadow-blur:  24px;
+            drop-shadow-color: Colors.shadow-light;
+            clip: true;
+
+            VerticalLayout {
+                // ── Header ────────────────────────────────────────────────────
+                Rectangle {
+                    height: Layout.height-dialog-row;
+                    background: Colors.mantle;
+
+                    HorizontalLayout {
+                        padding-left:  Layout.padding-2xl;
+                        padding-right: Layout.padding-sm;
+                        spacing: 0;
+
+                        Text {
+                            text: @tr("Snippets");
+                            color: Colors.text;
+                            font-size: Typography.size-xl;
+                            font-weight: 700;
+                            vertical-alignment: center;
+                            horizontal-stretch: 1;
+                        }
+
+                        close-rect := Rectangle {
+                            width: 36px;
+                            border-radius: Layout.radius-md;
+                            background: close-ta.has-hover ? Colors.surface1 : transparent;
+                            Image {
+                                x: (parent.width  - self.width)  / 2;
+                                y: (parent.height - self.height) / 2;
+                                width: Layout.icon-lg; height: Layout.icon-lg;
+                                source: Icons.close;
+                                colorize: Colors.subtext0;
+                                image-fit: contain;
+                            }
+                            close-ta := TouchArea { clicked => { root.close(); } }
+                        }
+                    }
+
+                    Rectangle {
+                        y: parent.height - 1px;
+                        height: 1px; width: parent.width;
+                        background: Colors.surface1;
+                    }
+                }
+
+                // ── Scrollable snippet list ───────────────────────────────────
+                list-scroll := Flickable {
+                    vertical-stretch: 1;
+                    interactive: true;
+                    viewport-height: max(list-content.preferred-height, self.height);
+
+                    list-content := VerticalLayout {
+                        if root.snippets.length == 0: Rectangle {
+                            height: 466px;
+                            Text {
+                                width: parent.width; height: parent.height;
+                                text: @tr("No snippets yet");
+                                color: Colors.overlay0;
+                                font-size: Typography.size-lg;
+                                horizontal-alignment: center;
+                                vertical-alignment: center;
+                            }
+                        }
+
+                        for bk in root.snippets: Rectangle {
+                            height: row-vl.preferred-height;
+
+                            row-ta := TouchArea {
+                                width: parent.width; height: parent.height;
+                                clicked        => { root.insert-sql(bk.sql); }
+                                double-clicked => { root.execute-sql(bk.sql); }
+                            }
+
+                            Rectangle {
+                                background: row-ta.has-hover ? Colors.hover-subtle : transparent;
+                                width: parent.width; height: parent.height;
+                            }
+
+                            row-vl := VerticalLayout {
+                                x: 0; y: 0; width: parent.width;
+                                spacing: 0;
+
+                                // ── Header: icon + comment (title) + action buttons ──
+                                HorizontalLayout {
+                                    height: Layout.height-dialog-row;
+                                    padding-left:  Layout.padding-2xl;
+                                    padding-right: Layout.padding-md;
+                                    spacing: Layout.spacing-lg;
+
+                                    VerticalLayout {
+                                        alignment: center;
+                                        Image {
+                                            width: Layout.icon-lg; height: Layout.icon-lg;
+                                            source: Icons.snippet;
+                                            colorize: Colors.blue;
+                                            image-fit: contain;
+                                        }
+                                    }
+
+                                    Text {
+                                        horizontal-stretch: 1;
+                                        text: bk.comment != "" ? bk.comment : bk.name;
+                                        color: bk.comment != "" ? Colors.text : Colors.subtext0;
+                                        font-size: Typography.size-xl;
+                                        font-weight: 700;
+                                        overflow: elide;
+                                        vertical-alignment: center;
+                                    }
+
+                                    // Edit button
+                                    VerticalLayout {
+                                        alignment: center;
+                                        width: 60px;
+                                        edit-rect := Rectangle {
+                                            height: Layout.height-btn-md;
+                                            border-radius: Layout.radius-md;
+                                            background: edit-ta.has-hover ? Colors.surface2 : Colors.surface1;
+                                            HorizontalLayout {
+                                                alignment: center;
+                                                spacing: Layout.spacing-sm;
+                                                Image {
+                                                    width: Layout.icon-sm;
+                                                    source: Icons.edit;
+                                                    colorize: Colors.text;
+                                                    image-fit: contain;
+                                                }
+                                                Text {
+                                                    text: @tr("Edit");
+                                                    color: Colors.text;
+                                                    font-size: Typography.size-md;
+                                                    vertical-alignment: center;
+                                                }
+                                            }
+                                            edit-ta := TouchArea {
+                                                clicked => { root.rename-snippet(bk.id, bk.comment, bk.sql); }
+                                            }
+                                        }
+                                    }
+
+                                    // Delete button
+                                    VerticalLayout {
+                                        alignment: center;
+                                        width: 72px;
+                                        del-rect := Rectangle {
+                                            height: Layout.height-btn-md;
+                                            border-radius: Layout.radius-md;
+                                            background: del-ta.has-hover ? Colors.red : Colors.surface1;
+                                            HorizontalLayout {
+                                                alignment: center;
+                                                spacing: Layout.spacing-sm;
+                                                Image {
+                                                    width: Layout.icon-sm;
+                                                    source: Icons.close;
+                                                    colorize: del-ta.has-hover ? Colors.base : Colors.red;
+                                                    image-fit: contain;
+                                                }
+                                                Text {
+                                                    text: @tr("Delete");
+                                                    color: del-ta.has-hover ? Colors.base : Colors.red;
+                                                    font-size: Typography.size-md;
+                                                    vertical-alignment: center;
+                                                }
+                                            }
+                                            del-ta := TouchArea {
+                                                clicked => { root.delete-snippet(bk.id); }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // ── SQL body (word-wrapped monospace) ────────────
+                                HorizontalLayout {
+                                    padding-left:  Layout.padding-2xl;
+                                    padding-right: Layout.padding-md;
+                                    padding-bottom: Layout.padding-sm;
+                                    spacing: Layout.spacing-lg;
+
+                                    Rectangle { width: Layout.icon-lg; }
+
+                                    Text {
+                                        text: bk.sql;
+                                        color: Colors.subtext1;
+                                        font-size: root.code-font-size;
+                                        font-family: "JetBrains Mono";
+                                        wrap: word-wrap;
+                                        overflow: clip;
+                                    }
+                                }
+
+                                // ── Separator ────────────────────────────────────
+                                Rectangle {
+                                    height: 1px;
+                                    background: Colors.surface1;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ── Separator ─────────────────────────────────────────────────
+                Rectangle {
+                    height: 1px;
+                    background: Colors.surface1;
+                }
+
+                // ── Footer: Add snippet ───────────────────────────────────────
+                Rectangle {
+                    height: Layout.height-footer;
+
+                    footer-ta := TouchArea {
+                        width: parent.width; height: parent.height;
+                        clicked => { root.add-snippet(); }
+                    }
+
+                    Rectangle {
+                        background: footer-ta.has-hover ? Colors.hover-subtle : transparent;
+                        width: parent.width; height: parent.height;
+                    }
+
+                    HorizontalLayout {
+                        padding-left: Layout.padding-2xl;
+                        spacing: Layout.spacing-md;
+                        Image {
+                            width: Layout.icon-md;
+                            source: Icons.plus;
+                            colorize: Colors.blue;
+                            image-fit: contain;
+                        }
+                        Text {
+                            text: @tr("Add Snippet (Ctrl+D)");
+                            color: Colors.blue;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    init => { fs.focus(); }
+}

--- a/app/src/ui/components/snippet_save_dialog.slint
+++ b/app/src/ui/components/snippet_save_dialog.slint
@@ -1,0 +1,128 @@
+import { Colors, Typography, Layout, Animation } from "../theme.slint";
+
+/// Modal dialog for saving a new snippet.
+/// Name is auto-generated from SQL; user provides an optional description.
+export component SnippetSaveDialog inherits Rectangle {
+    in property  <bool>   show:    false;
+    in-out property <string> comment: "";
+    callback save();
+    callback cancelled();
+    callback exited();
+
+    x: 0; y: 0;
+    background: Colors.modal-overlay;
+
+    animate opacity {
+        duration: root.show ? Animation.enter : Animation.fast;
+        easing:   root.show ? Animation.enter-ease : Animation.exit-ease;
+    }
+    opacity: root.show ? 1 : 0;
+    changed opacity => { if (self.opacity == 0) { root.exited(); } }
+
+    fs := FocusScope {
+        x: 0; y: 0; width: parent.width; height: parent.height;
+        focus-on-click: true;
+        key-pressed(event) => {
+            if (event.text == Key.Escape) { root.cancelled(); EventResult.accept }
+            else { EventResult.reject }
+        }
+
+        Rectangle {
+            x: (parent.width  - self.width)  / 2;
+            y: (parent.height - self.height) / 2;
+            width:  480px;
+            height: 148px;
+            background:    Colors.surface0;
+            border-radius: Layout.radius-lg;
+            border-width:  1px;
+            border-color:  Colors.surface1;
+            drop-shadow-blur:  12px;
+            drop-shadow-color: Colors.shadow;
+
+            VerticalLayout {
+                padding: Layout.padding-md;
+                spacing: Layout.spacing-md;
+
+                Text {
+                    text: @tr("Save Snippet");
+                    color: Colors.text;
+                    font-size: Typography.size-lg;
+                    font-weight: 600;
+                }
+
+                Text {
+                    text: @tr("What is the purpose of this query?");
+                    color: Colors.subtext0;
+                    font-size: Typography.size-base;
+                }
+
+                // ── Comment input ─────────────────────────────────────────────
+                Rectangle {
+                    height: 26px;
+                    border-radius: Layout.radius-sm;
+                    border-width:  1px;
+                    border-color:  comment-input.has-focus ? Colors.blue : Colors.surface1;
+                    background:    Colors.base;
+                    comment-input := TextInput {
+                        x: Layout.padding-sm;
+                        width:  parent.width - 2 * Layout.padding-sm;
+                        height: parent.height;
+                        text           <=> root.comment;
+                        color:          Colors.text;
+                        font-size:      Typography.size-base;
+                        vertical-alignment: center;
+                        single-line:    true;
+                        accepted => { root.save(); }
+                    }
+                    if comment-input.text == "": Text {
+                        x: Layout.padding-sm;
+                        width:  parent.width - 2 * Layout.padding-sm;
+                        height: parent.height;
+                        text: @tr("Comment (optional)");
+                        color: Colors.overlay0;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+                }
+
+                // ── Buttons ───────────────────────────────────────────────────
+                HorizontalLayout {
+                    spacing: Layout.spacing-md;
+                    alignment: end;
+
+                    Rectangle {
+                        width: 72px; height: Layout.height-btn-md;
+                        border-radius: Layout.radius-sm;
+                        border-width:  1px;
+                        border-color:  Colors.surface1;
+                        background:    cancel-ta.has-hover ? Colors.surface1 : transparent;
+                        Text {
+                            text: @tr("Cancel");
+                            color: Colors.text;
+                            font-size: Typography.size-base;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                        cancel-ta := TouchArea { clicked => { root.cancelled(); } }
+                    }
+
+                    Rectangle {
+                        width: 72px; height: Layout.height-btn-md;
+                        border-radius: Layout.radius-sm;
+                        background:    Colors.blue;
+                        Text {
+                            text: @tr("Save");
+                            color: Colors.base;
+                            font-size: Typography.size-base;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                        save-ta := TouchArea { clicked => { root.save(); } }
+                    }
+                }
+            }
+        }
+    }
+
+    init => { comment-input.focus(); }
+}

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -53,3 +53,10 @@ export struct ColumnData {
     data-type: string,
     nullable: bool,
 }
+
+export struct SnippetEntry {
+    id: string,
+    name: string,
+    comment: string,
+    sql: string,
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -13,7 +13,7 @@ use slint::ComponentHandle;
 use slint::Model as _;
 use tokio::sync::mpsc;
 use wf_completion::CompletionItem;
-use wf_config::crypto;
+use wf_config::{crypto, snippet::SnippetRepository};
 use wf_db::models::{DbConnection, DbMetadata, DbType, QueryResult, TableInfo};
 use wf_history::find_history::FindHistoryService;
 use wf_history::session::SessionService;
@@ -396,6 +396,7 @@ pub struct UI {
 }
 
 impl UI {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         state: SharedState,
         tx_cmd: mpsc::Sender<Command>,
@@ -404,6 +405,7 @@ impl UI {
         initial_connections: Vec<ConnectionConfig>,
         find_history_svc: FindHistoryService,
         session_svc: SessionService,
+        snippet_repo: Arc<SnippetRepository>,
     ) -> Result<Self> {
         let window = crate::AppWindow::new()?;
 
@@ -547,13 +549,33 @@ impl UI {
         );
         Self::register_language_callback(&window, tx_cmd.clone());
         Self::register_find_replace_callbacks(&window, find_history_svc);
+        Self::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
         Self::register_status_callbacks(&window, state.clone());
+
+        // Load initial snippets (global only — no connection yet).
+        {
+            let initial_bk = handle.block_on(snippet_repo.list(None)).unwrap_or_default();
+            let slint_bk: Vec<crate::SnippetEntry> =
+                initial_bk.into_iter().map(snippet_to_slint).collect();
+            ui_global.set_snippets(Rc::new(slint::VecModel::from(slint_bk)).into());
+        }
+
+        // Load persisted Snippet Bar position.
+        {
+            let (bx, by) = handle
+                .block_on(snippet_repo.get_bar_position())
+                .unwrap_or((0.0, 100.0));
+            ui_global.set_snippet_bar_x(bx);
+            ui_global.set_snippet_bar_y(by);
+        }
+
         Self::spawn_event_handler(
             &window,
             rx_event,
             state,
             Arc::clone(&sidebar_state),
             Arc::clone(&original_data),
+            Arc::clone(&snippet_repo),
         );
 
         Ok(Self { window })
@@ -572,6 +594,7 @@ impl UI {
         state: SharedState,
         sidebar_state: Arc<Mutex<SidebarUiState>>,
         original_data: SharedOriginalData,
+        snippet_repo: Arc<SnippetRepository>,
     ) {
         let window_weak = window.as_weak();
         tokio::spawn(async move {
@@ -582,15 +605,24 @@ impl UI {
                         connections,
                         safe_dml,
                         read_only,
-                    } => Self::handle_connected(
-                        id,
-                        connections,
-                        safe_dml,
-                        read_only,
-                        window_weak.clone(),
-                        state.clone(),
-                        Arc::clone(&sidebar_state),
-                    ),
+                    } => {
+                        let conn_id = id.clone();
+                        Self::handle_connected(
+                            id,
+                            connections,
+                            safe_dml,
+                            read_only,
+                            window_weak.clone(),
+                            state.clone(),
+                            Arc::clone(&sidebar_state),
+                        );
+                        // Refresh snippets to include per-connection entries.
+                        let bk_repo = Arc::clone(&snippet_repo);
+                        let bk_ww = window_weak.clone();
+                        tokio::spawn(async move {
+                            do_refresh_snippets(&bk_ww, &bk_repo, Some(&conn_id)).await;
+                        });
+                    }
                     Event::TestConnectionOk => Self::handle_test_ok(window_weak.clone()),
                     Event::TestConnectionFailed(msg) => {
                         Self::handle_test_failed(msg, window_weak.clone())
@@ -606,7 +638,15 @@ impl UI {
                     ),
                     Event::QueryCancelled => Self::handle_query_cancelled(window_weak.clone()),
                     Event::QueryError(msg) => Self::handle_query_error(msg, window_weak.clone()),
-                    Event::Disconnected(id) => Self::handle_disconnected(id, window_weak.clone()),
+                    Event::Disconnected(id) => {
+                        Self::handle_disconnected(id, window_weak.clone());
+                        // Drop per-connection snippets; show global only.
+                        let bk_repo = Arc::clone(&snippet_repo);
+                        let bk_ww = window_weak.clone();
+                        tokio::spawn(async move {
+                            do_refresh_snippets(&bk_ww, &bk_repo, None).await;
+                        });
+                    }
                     Event::ConnectionRemoved(id) => Self::handle_connection_removed(
                         id,
                         window_weak.clone(),
@@ -3232,6 +3272,202 @@ impl UI {
         // Status bar text is updated by spawn_event_handler via invoke_from_event_loop.
         // No additional setup needed here.
     }
+
+    // ── Snippet callbacks ────────────────────────────────────────────────────
+
+    fn register_snippet_callbacks(window: &crate::AppWindow, snippet_repo: Arc<SnippetRepository>) {
+        let ui = window.global::<crate::UiState>();
+
+        // open-snippet-save: extract SQL from selection or cursor line, pre-fill dialog.
+        {
+            let ww = window.as_weak();
+            ui.on_open_snippet_save(move |anchor_pos, cursor_pos| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let editor_text = ui.get_editor_text().to_string();
+                let a = (anchor_pos as usize).min(editor_text.len());
+                let c = (cursor_pos as usize).min(editor_text.len());
+                let (start, end) = (a.min(c), a.max(c));
+                let sql = if start < end {
+                    editor_text[start..end].to_string()
+                } else {
+                    // Extract the cursor's line from the full editor text.
+                    let byte_pos = c;
+                    let line_start = editor_text[..byte_pos]
+                        .rfind('\n')
+                        .map(|i| i + 1)
+                        .unwrap_or(0);
+                    let line_end = editor_text[byte_pos..]
+                        .find('\n')
+                        .map(|i| byte_pos + i)
+                        .unwrap_or(editor_text.len());
+                    editor_text[line_start..line_end].trim().to_string()
+                };
+                if sql.is_empty() {
+                    return;
+                }
+                ui.set_snippet_save_sql(sql.into());
+                ui.set_snippet_save_comment("".into());
+                ui.set_show_snippet_save(true);
+            });
+        }
+
+        // save-snippet: persist the new entry with a sequential "Query N" name, refresh.
+        {
+            let repo = Arc::clone(&snippet_repo);
+            let ww = window.as_weak();
+            ui.on_save_snippet(move |_name, comment, sql| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let conn_id_str = ui.get_active_connection_id().to_string();
+                let conn_id = if conn_id_str.is_empty() {
+                    None
+                } else {
+                    Some(conn_id_str)
+                };
+                let comment = comment.to_string();
+                let sql = sql.to_string();
+                let repo_c = Arc::clone(&repo);
+                let ww_c = ww.clone();
+                tokio::spawn(async move {
+                    let n = repo_c.next_query_number().await.unwrap_or(1);
+                    let name = format!("Query {n}");
+                    let entry = wf_config::snippet::SnippetEntry {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name,
+                        comment,
+                        connection_id: None,
+                        sql,
+                        created_at: chrono::Utc::now().to_rfc3339(),
+                        sort_order: 0,
+                    };
+                    if let Err(e) = repo_c.add(&entry).await {
+                        tracing::warn!(error = %e, "failed to save snippet");
+                        return;
+                    }
+                    do_refresh_snippets(&ww_c, &repo_c, conn_id.as_deref()).await;
+                });
+            });
+        }
+
+        // save-snippet-edit: persist updated comment + sql, close edit dialog, refresh.
+        {
+            let repo = Arc::clone(&snippet_repo);
+            let ww = window.as_weak();
+            ui.on_save_snippet_edit(move |id, comment, sql| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let conn_id_str = ui.get_active_connection_id().to_string();
+                let conn_id = if conn_id_str.is_empty() {
+                    None
+                } else {
+                    Some(conn_id_str)
+                };
+                let id = id.to_string();
+                let comment = comment.to_string();
+                let sql = sql.to_string();
+                let repo_c = Arc::clone(&repo);
+                let ww_c = ww.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = repo_c.update(&id, &comment, &sql).await {
+                        tracing::warn!(error = %e, "failed to update snippet");
+                        return;
+                    }
+                    do_refresh_snippets(&ww_c, &repo_c, conn_id.as_deref()).await;
+                });
+            });
+        }
+
+        // delete-snippet-item: remove from DB, refresh list.
+        {
+            let repo = Arc::clone(&snippet_repo);
+            let ww = window.as_weak();
+            ui.on_delete_snippet_item(move |id| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let conn_id_str = ui.get_active_connection_id().to_string();
+                let conn_id = if conn_id_str.is_empty() {
+                    None
+                } else {
+                    Some(conn_id_str)
+                };
+                let id = id.to_string();
+                let repo_c = Arc::clone(&repo);
+                let ww_c = ww.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = repo_c.delete(&id).await {
+                        tracing::warn!(error = %e, "failed to delete snippet");
+                        return;
+                    }
+                    do_refresh_snippets(&ww_c, &repo_c, conn_id.as_deref()).await;
+                });
+            });
+        }
+
+        // load-snippet-sql: insert SQL at editor cursor position.
+        {
+            let ww = window.as_weak();
+            ui.on_load_snippet_sql(move |sql, cursor_pos| {
+                with_ui(&ww, |ui| {
+                    let current = ui.get_editor_text().to_string();
+                    let pos = (cursor_pos as usize).min(current.len());
+                    let new_text = format!("{}{}{}", &current[..pos], sql, &current[pos..]);
+                    let new_cursor = (pos + sql.len()) as i32;
+                    ui.set_editor_text(new_text.into());
+                    ui.set_editor_cursor_target(new_cursor);
+                });
+            });
+        }
+
+        // execute-snippet-sql: run snippet SQL directly without touching the editor.
+        {
+            let ww = window.as_weak();
+            ui.on_execute_snippet_sql(move |sql| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                ui.invoke_run_query(sql);
+            });
+        }
+
+        // save-snippet-bar-position: persist dragged position.
+        {
+            let repo = Arc::clone(&snippet_repo);
+            ui.on_save_snippet_bar_position(move |x, y| {
+                let repo_c = Arc::clone(&repo);
+                tokio::spawn(async move {
+                    if let Err(e) = repo_c.set_bar_position(x, y).await {
+                        tracing::warn!(error = %e, "failed to save snippet bar position");
+                    }
+                });
+            });
+        }
+    }
+}
+
+// ── Snippet helpers ──────────────────────────────────────────────────────────
+
+fn snippet_to_slint(b: wf_config::snippet::SnippetEntry) -> crate::SnippetEntry {
+    crate::SnippetEntry {
+        id: b.id.into(),
+        name: b.name.into(),
+        comment: b.comment.into(),
+        sql: b.sql.into(),
+    }
+}
+
+async fn do_refresh_snippets(
+    ww: &slint::Weak<crate::AppWindow>,
+    repo: &SnippetRepository,
+    connection_id: Option<&str>,
+) {
+    let items = repo.list(connection_id).await.unwrap_or_default();
+    let slint_items: Vec<crate::SnippetEntry> = items.into_iter().map(snippet_to_slint).collect();
+    let ww_c = ww.clone();
+    let _ = slint::invoke_from_event_loop(move || {
+        with_ui(&ww_c, move |ui| {
+            ui.set_snippets(Rc::new(slint::VecModel::from(slint_items)).into());
+        });
+    });
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -132,6 +132,7 @@ export global Animation {
 
 export global Icons {
     out property <image> alert-error:      @image-url("../../assets/icons/alert-error.svg");
+    out property <image> snippet:          @image-url("../../assets/icons/snippet.svg");
     out property <image> check:             @image-url("../../assets/icons/check.svg");
     out property <image> brand-mysql:      @image-url("../../assets/icons/brand-mysql.svg");
     out property <image> brand-postgresql: @image-url("../../assets/icons/brand-postgresql.svg");

--- a/crates/wf-config/src/lib.rs
+++ b/crates/wf-config/src/lib.rs
@@ -2,5 +2,7 @@ pub mod crypto;
 pub mod manager;
 pub mod models;
 pub mod repository;
+pub mod snippet;
 
 pub use repository::ConnectionRepository;
+pub use snippet::SnippetRepository;

--- a/crates/wf-config/src/snippet.rs
+++ b/crates/wf-config/src/snippet.rs
@@ -1,0 +1,359 @@
+use anyhow::Context as _;
+use sqlx::{Row as _, SqlitePool};
+
+const CREATE_SNIPPETS: &str = "
+    CREATE TABLE IF NOT EXISTS snippets (
+        id            TEXT    PRIMARY KEY,
+        name          TEXT    NOT NULL,
+        comment       TEXT    NOT NULL DEFAULT '',
+        connection_id TEXT,
+        sql           TEXT    NOT NULL,
+        created_at    TEXT    NOT NULL,
+        sort_order    INTEGER NOT NULL DEFAULT 0
+    )
+";
+
+const CREATE_BAR_POSITION: &str = "
+    CREATE TABLE IF NOT EXISTS snippet_bar_position (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        x  REAL    NOT NULL DEFAULT 0.0,
+        y  REAL    NOT NULL DEFAULT 100.0
+    )
+";
+
+/// A named SQL snippet persisted across app restarts.
+#[derive(Debug, Clone)]
+pub struct SnippetEntry {
+    pub id: String,
+    pub name: String,
+    pub comment: String,
+    pub connection_id: Option<String>,
+    pub sql: String,
+    pub created_at: String,
+    pub sort_order: i64,
+}
+
+/// Persists snippet entries and bar position to SQLite.
+///
+/// Cheap to clone — all clones share the same underlying connection pool.
+#[derive(Clone)]
+pub struct SnippetRepository {
+    pool: SqlitePool,
+}
+
+impl SnippetRepository {
+    /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
+    pub async fn new(pool: SqlitePool) -> anyhow::Result<Self> {
+        sqlx::query(CREATE_SNIPPETS)
+            .execute(&pool)
+            .await
+            .context("failed to create snippets table")?;
+        sqlx::query(CREATE_BAR_POSITION)
+            .execute(&pool)
+            .await
+            .context("failed to create snippet_bar_position table")?;
+        Ok(Self { pool })
+    }
+
+    /// Persist a new snippet.
+    pub async fn add(&self, entry: &SnippetEntry) -> anyhow::Result<()> {
+        let order = self.next_sort_order().await?;
+        sqlx::query(
+            "INSERT INTO snippets (id, name, comment, connection_id, sql, created_at, sort_order)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&entry.id)
+        .bind(&entry.name)
+        .bind(&entry.comment)
+        .bind(&entry.connection_id)
+        .bind(&entry.sql)
+        .bind(&entry.created_at)
+        .bind(order)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return snippets visible for the given `connection_id`.
+    ///
+    /// - `None` → global snippets only (`connection_id IS NULL`).
+    /// - `Some(id)` → global snippets plus snippets scoped to that connection.
+    pub async fn list(&self, connection_id: Option<&str>) -> anyhow::Result<Vec<SnippetEntry>> {
+        let rows = match connection_id {
+            None => {
+                sqlx::query(
+                    "SELECT id, name, comment, connection_id, sql, created_at, sort_order
+                     FROM snippets WHERE connection_id IS NULL
+                     ORDER BY sort_order ASC, created_at ASC",
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
+            Some(id) => {
+                sqlx::query(
+                    "SELECT id, name, comment, connection_id, sql, created_at, sort_order
+                     FROM snippets WHERE connection_id IS NULL OR connection_id = ?
+                     ORDER BY sort_order ASC, created_at ASC",
+                )
+                .bind(id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+        rows.iter().map(row_to_entry).collect()
+    }
+
+    /// Update the name of an existing snippet.
+    pub async fn rename(&self, id: &str, new_name: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE snippets SET name = ? WHERE id = ?")
+            .bind(new_name)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Update comment and SQL of an existing snippet.
+    pub async fn update(&self, id: &str, comment: &str, sql: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE snippets SET comment = ?, sql = ? WHERE id = ?")
+            .bind(comment)
+            .bind(sql)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Update the comment of an existing snippet.
+    pub async fn update_comment(&self, id: &str, comment: &str) -> anyhow::Result<()> {
+        sqlx::query("UPDATE snippets SET comment = ? WHERE id = ?")
+            .bind(comment)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Delete a snippet by id.
+    pub async fn delete(&self, id: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM snippets WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Read the last-saved Snippet Bar position. Returns `(0.0, 100.0)` when unset.
+    pub async fn get_bar_position(&self) -> anyhow::Result<(f32, f32)> {
+        let row = sqlx::query("SELECT x, y FROM snippet_bar_position WHERE id = 1")
+            .fetch_optional(&self.pool)
+            .await?;
+        match row {
+            Some(r) => Ok((r.try_get("x")?, r.try_get("y")?)),
+            None => Ok((0.0, 100.0)),
+        }
+    }
+
+    /// Persist the Snippet Bar position (upsert single-row sentinel).
+    pub async fn set_bar_position(&self, x: f32, y: f32) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO snippet_bar_position (id, x, y) VALUES (1, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET x = excluded.x, y = excluded.y",
+        )
+        .bind(x)
+        .bind(y)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Returns the next sequential number for auto-named snippets ("Query N").
+    /// Finds the highest N already used and returns N+1, so numbers never repeat
+    /// even after deletion.
+    pub async fn next_query_number(&self) -> anyhow::Result<u64> {
+        let names: Vec<String> =
+            sqlx::query_scalar("SELECT name FROM snippets WHERE name LIKE 'Query %'")
+                .fetch_all(&self.pool)
+                .await?;
+        let max = names
+            .iter()
+            .filter_map(|n| n.strip_prefix("Query ").and_then(|s| s.parse::<u64>().ok()))
+            .max()
+            .unwrap_or(0);
+        Ok(max + 1)
+    }
+
+    async fn next_sort_order(&self) -> anyhow::Result<i64> {
+        let max: Option<i64> = sqlx::query_scalar("SELECT MAX(sort_order) FROM snippets")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(max.unwrap_or(-1) + 1)
+    }
+}
+
+// ── Row → model ───────────────────────────────────────────────────────────────
+
+fn row_to_entry(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<SnippetEntry> {
+    Ok(SnippetEntry {
+        id: row.try_get("id")?,
+        name: row.try_get("name")?,
+        comment: row
+            .try_get::<Option<String>, _>("comment")?
+            .unwrap_or_default(),
+        connection_id: row.try_get("connection_id")?,
+        sql: row.try_get("sql")?,
+        created_at: row.try_get("created_at")?,
+        sort_order: row.try_get("sort_order").unwrap_or(0),
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_memory() -> SnippetRepository {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        SnippetRepository::new(pool).await.unwrap()
+    }
+
+    fn make_entry(id: &str, name: &str, sql: &str) -> SnippetEntry {
+        SnippetEntry {
+            id: id.to_string(),
+            name: name.to_string(),
+            comment: String::new(),
+            connection_id: None,
+            sql: sql.to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            sort_order: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_should_add_and_list() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "My Query", "SELECT 1"))
+            .await
+            .unwrap();
+        let items = repo.list(None).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "b1");
+        assert_eq!(items[0].name, "My Query");
+        assert_eq!(items[0].sql, "SELECT 1");
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_list_should_return_empty_when_no_snippets() {
+        let repo = open_memory().await;
+        assert!(repo.list(None).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_list_none_should_return_only_global_snippets() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "Global", "SELECT 1"))
+            .await
+            .unwrap();
+        let mut per_conn = make_entry("b2", "PerConn", "SELECT 2");
+        per_conn.connection_id = Some("conn1".to_string());
+        repo.add(&per_conn).await.unwrap();
+
+        let items = repo.list(None).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "b1");
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_list_some_should_return_global_and_per_connection() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "Global", "SELECT 1"))
+            .await
+            .unwrap();
+        let mut per_conn1 = make_entry("b2", "Conn1Query", "SELECT 2");
+        per_conn1.connection_id = Some("conn1".to_string());
+        repo.add(&per_conn1).await.unwrap();
+        let mut per_conn2 = make_entry("b3", "Conn2Query", "SELECT 3");
+        per_conn2.connection_id = Some("conn2".to_string());
+        repo.add(&per_conn2).await.unwrap();
+
+        let items = repo.list(Some("conn1")).await.unwrap();
+        assert_eq!(items.len(), 2);
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert!(ids.contains(&"b1"));
+        assert!(ids.contains(&"b2"));
+        assert!(!ids.contains(&"b3"));
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_should_rename() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "Old Name", "SELECT 1"))
+            .await
+            .unwrap();
+        repo.rename("b1", "New Name").await.unwrap();
+        let items = repo.list(None).await.unwrap();
+        assert_eq!(items[0].name, "New Name");
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_should_update_comment() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "My Query", "SELECT 1"))
+            .await
+            .unwrap();
+        repo.update_comment("b1", "Monthly report").await.unwrap();
+        let items = repo.list(None).await.unwrap();
+        assert_eq!(items[0].comment, "Monthly report");
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_should_delete() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "My Query", "SELECT 1"))
+            .await
+            .unwrap();
+        repo.delete("b1").await.unwrap();
+        assert!(repo.list(None).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_add_should_increment_sort_order() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "First", "SELECT 1"))
+            .await
+            .unwrap();
+        repo.add(&make_entry("b2", "Second", "SELECT 2"))
+            .await
+            .unwrap();
+        let items = repo.list(None).await.unwrap();
+        assert!(items[0].sort_order < items[1].sort_order);
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_bar_position_should_default_to_zero() {
+        let repo = open_memory().await;
+        let (x, y) = repo.get_bar_position().await.unwrap();
+        assert_eq!(x, 0.0);
+        assert_eq!(y, 100.0);
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_bar_position_should_roundtrip() {
+        let repo = open_memory().await;
+        repo.set_bar_position(320.5, 200.0).await.unwrap();
+        let (x, y) = repo.get_bar_position().await.unwrap();
+        assert!((x - 320.5).abs() < 0.001);
+        assert!((y - 200.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn snippet_repository_bar_position_should_update_on_second_set() {
+        let repo = open_memory().await;
+        repo.set_bar_position(100.0, 200.0).await.unwrap();
+        repo.set_bar_position(400.0, 300.0).await.unwrap();
+        let (x, y) = repo.get_bar_position().await.unwrap();
+        assert!((x - 400.0).abs() < 0.001);
+        assert!((y - 300.0).abs() < 0.001);
+    }
+}

--- a/docs/roadmap/v0-8-0/ROADMAP.md
+++ b/docs/roadmap/v0-8-0/ROADMAP.md
@@ -19,7 +19,7 @@ sidebar sections) that later milestones will extend.
 - [ ] Safe DML mode warns before executing `UPDATE`/`DELETE` without a `WHERE` clause
 - [ ] Read-only mode blocks writes and shows a lock icon on the connection
 - [ ] `Ctrl+F` opens an inline find bar; `Ctrl+H` opens find + replace
-- [ ] Bookmarks are saved to `bookmarks.toml` and accessible from a sidebar section
+- [ ] Snippets are saved to snippets table and accessible from a sidebar section
 - [ ] Connection color dots appear in the sidebar and the status bar active-connection display
 - [ ] Result table supports INSERT SQL export via File → Export → Insert SQL
 - [ ] `Ctrl+P` opens a floating metadata global search palette
@@ -45,7 +45,7 @@ See `docs/roadmap/tasks/v0-8-0.md` for details.
 | T082 | Safe DML mode: WHERE-less UPDATE/DELETE detection and confirmation dialog |
 | T083 | Read-only connection mode: write guard and UI indicator |
 | T084 | Editor find / find-replace floating bar (Ctrl+F / Ctrl+H) |
-| T085 | Query bookmarks: bookmarks.toml persistence and sidebar section |
+| T085 | Query snippets: snippets.toml persistence and sidebar section |
 | T086 | Connection color coding: color dot in sidebar and status bar |
 | T087 | INSERT SQL export from result table |
 | T088 | Metadata global search palette (Ctrl+P) |

--- a/docs/specs/keybindings.md
+++ b/docs/specs/keybindings.md
@@ -33,6 +33,8 @@ These shortcuts work from any pane (no modal must be open).
 | `↑` / `↓` | Move cursor up / down one line (timer-based, no key-repeat lag) |
 | `Shift+↑` / `Shift+↓` | Extend selection up / down one line |
 | `Ctrl+F` | Open find bar |
+| `Ctrl+D` | Open snippet save dialog (uses selection, or cursor line if no selection) |
+| `Ctrl+B` | Toggle Snippet Bar |
 | `Esc` (editor focused, find bar open) | Close find bar |
 
 ### Standard text-editing shortcuts (via OS / TextInput)
@@ -49,6 +51,20 @@ These shortcuts work from any pane (no modal must be open).
 | `Ctrl+←` / `Ctrl+→` | Move by word |
 | `Home` / `End` | Move to line start / end |
 | `Ctrl+Home` / `Ctrl+End` | Move to document start / end |
+
+---
+
+## Snippet Bar
+
+A draggable floating panel toggled with `Ctrl+B`. Stays open while working (non-modal).
+Drag the title bar to reposition; last position is persisted across sessions.
+
+| Key / Action | Behaviour |
+|-------------|-----------|
+| `Ctrl+B` | Show / hide Snippet Bar |
+| Single-click on a snippet | Insert the snippet's SQL at the editor cursor |
+| Double-click on a snippet | Set editor text to snippet SQL and execute immediately |
+| `Esc` (Snippet Bar focused) | Close Snippet Bar |
 
 ---
 

--- a/docs/specs/specification.md
+++ b/docs/specs/specification.md
@@ -636,21 +636,47 @@ DB implementation:
 
 `Ctrl+F`: find bar. `Ctrl+H`: find + replace bar. Floats over editor text (does not push content down). Features: case-sensitive toggle, regex toggle, match count (`3 / 12`), next/prev navigation, replace-one and replace-all. `Esc` or ✕ to close.
 
-### 23-5. Query Bookmarks
+### 23-5. Query Snippets
 
-Saved to `bookmarks.toml` (same directory as `config.toml`):
+Named SQL snippets saved to `wellfeather.db` (shared SQLite, `ConfigManager::app_dir()`).
 
-```toml
-[[bookmark]]
-id = "uuid"
-name = "Monthly Summary"
-folder = "Reports"
-connection_id = "uuid"   # omit for global
-sql = "SELECT ..."
-created_at = "2026-04-30T..."
+**Schema:**
+
+```sql
+CREATE TABLE snippets (
+    id            TEXT    PRIMARY KEY,
+    name          TEXT    NOT NULL,
+    comment       TEXT    NOT NULL DEFAULT '',
+    connection_id TEXT,               -- NULL = global
+    sql           TEXT    NOT NULL,
+    created_at    TEXT    NOT NULL,
+    sort_order    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE snippet_bar_position (
+    id  INTEGER PRIMARY KEY CHECK (id = 1),  -- single-row sentinel
+    x   REAL    NOT NULL DEFAULT 0.0,
+    y   REAL    NOT NULL DEFAULT 0.0
+);
 ```
 
-Sidebar "Bookmarks" section (above connection tree). Double-click to load into editor. `Ctrl+D` or right-click "Save as bookmark" to save current SQL. Right-click: rename / delete / move to folder.
+**Saving (`Ctrl+D` / menu Snippets → Add Snippet):**
+- If text is range-selected in the editor → selected text becomes the SQL.
+- If no selection → the cursor's current line is used.
+- A save dialog opens with a pre-filled **Name** (first 40 chars of the SQL) and an optional **Comment** field.
+
+**Snippet List Modal (menu Snippets → Show Snippets):**
+- Lists all snippets with name and comment preview.
+- Inline rename and delete actions per row.
+
+**Snippet Bar (`Ctrl+B` to toggle):**
+- Lightweight floating panel — not a modal; stays open while working.
+- Draggable anywhere on screen; last position persisted in `snippet_bar_position`.
+- **Single-click**: inserts the snippet's SQL into the editor at the cursor position.
+- **Double-click**: sets the editor text to the snippet SQL and executes immediately (`Ctrl+Enter` equivalent).
+- Global snippets (no `connection_id`) always shown. Per-connection snippets shown only when that connection is active.
+
+**Sidebar:** No snippet section — access is exclusively via the menu bar and Snippet Bar.
 
 ### 23-6. Connection Color Coding
 
@@ -683,7 +709,7 @@ All tabs share the active connection. Tab SQL text, name, and order persisted in
 
 ### 24-2. Code Snippets
 
-Saved to `snippets.toml`. Sidebar "Snippets" section mirrors the Bookmarks pattern. `Ctrl+Shift+S` opens a fuzzy-search palette for quick insert at cursor position.
+Saved to `snippets.toml`. Sidebar "Snippets" section mirrors the Snippets pattern. `Ctrl+Shift+S` opens a fuzzy-search palette for quick insert at cursor position.
 
 ### 24-3. Parameterized Queries
 


### PR DESCRIPTION
## Summary

Implements the snippet system (T085) — users can save frequently-used SQL fragments, manage them via a list/edit modal, and quickly insert or execute them from a draggable floating bar. The feature replaces the earlier bookmark concept end-to-end: all labels, file names, database tables, and code symbols use the name "snippet".

## Changes

- **`crates/wf-config/src/snippet.rs`** (new): `SnippetRepository` backed by SQLite — add, list, rename, delete, and persist the bar's drag position
- **`app/src/ui/components/snippet_bar.slint`** (new): draggable floating panel; clicking a row shows a per-row overlay with Paste (insert at cursor) and Run (execute without touching the editor) buttons
- **`app/src/ui/components/snippet_save_dialog.slint`** (new): modal to save a snippet with an optional comment
- **`app/src/ui/components/snippet_list_dialog.slint`** (new): full-size modal listing all snippets with Edit and Delete actions
- **`app/src/ui/components/snippet_edit_dialog.slint`** (new): modal to edit an existing snippet's comment and SQL
- **`app/src/ui/app.slint`**: UiState snippet properties/callbacks; `Ctrl+B` toggles the bar; `Ctrl+D` opens the save dialog; draggable bar position clamped to window bounds
- **`app/src/ui/mod.rs`**: `register_snippet_callbacks` — cursor-position insert (`load-snippet-sql`), direct execute without editor overwrite (`execute-snippet-sql`), CRUD wiring, bar position persistence
- **`app/src/ui/components/editor.slint`**: `Ctrl+D` shortcut to open snippet save dialog from editor
- **`app/src/ui/components/menu_bar.slint`**: Snippets menu with Add Snippet and Show Snippets items
- **i18n**: English and Japanese strings for all snippet UI labels including Paste / Run overlay buttons
- **`docs/specs/keybindings.md`**: document `Ctrl+B` and `Ctrl+D` shortcuts

## Related Issues

Closes #200

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes