### PR TITLE
feat(query): INSERT SQL export from result table

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -45,6 +45,10 @@ msgid "Export JSON"
 msgstr "Export JSON"
 
 msgctxt "MenuBar"
+msgid "Export Insert SQL"
+msgstr "Export Insert SQL"
+
+msgctxt "MenuBar"
 msgid "Quit"
 msgstr "Quit"
 
@@ -223,6 +227,10 @@ msgstr "Export CSV"
 msgctxt "ResultTableToolbar"
 msgid "Export JSON"
 msgstr "Export JSON"
+
+msgctxt "ResultTableToolbar"
+msgid "Export Insert SQL"
+msgstr "Export Insert SQL"
 
 msgctxt "ResultTableToolbar"
 msgid "{0} rows"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -45,6 +45,10 @@ msgid "Export JSON"
 msgstr "JSON エクスポート"
 
 msgctxt "MenuBar"
+msgid "Export Insert SQL"
+msgstr "INSERT SQL エクスポート"
+
+msgctxt "MenuBar"
 msgid "Quit"
 msgstr "終了"
 
@@ -223,6 +227,10 @@ msgstr "CSV エクスポート"
 msgctxt "ResultTableToolbar"
 msgid "Export JSON"
 msgstr "JSON エクスポート"
+
+msgctxt "ResultTableToolbar"
+msgid "Export Insert SQL"
+msgstr "INSERT SQL エクスポート"
 
 msgctxt "ResultTableToolbar"
 msgid "{0} rows"

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -82,6 +82,8 @@ export global UiState {
     callback export-csv();
     /// Fired by the Export JSON button; Rust opens a save dialog and writes the file.
     callback export-json();
+    /// Fired by the Export Insert SQL button; Rust auto-detects the table name and writes the file.
+    callback export-insert-sql();
     /// Returns cumulative x-offset (logical px as float) of column j.
     pure callback col-x-offset(int) -> float;
 
@@ -585,8 +587,9 @@ export component AppWindow inherits Window {
             language:     UiState.language;
             has-active-connection: UiState.active-connection-id != "";
             reduce-motion: UiState.reduce-motion;
-            export-csv   => { UiState.export-csv(); }
-            export-json  => { UiState.export-json(); }
+            export-csv        => { UiState.export-csv(); }
+            export-json       => { UiState.export-json(); }
+            export-insert-sql => { UiState.export-insert-sql(); }
             quit         => { UiState.quit(); }
             toggle-theme          => { UiState.toggle-theme(); }
             toggle-reduce-motion  => { UiState.toggle-reduce-motion(); }
@@ -844,6 +847,7 @@ export component AppWindow inherits Window {
                     copy-all-tsv         => { UiState.copy-result-tsv(); }
                     export-csv           => { UiState.export-csv(); }
                     export-json          => { UiState.export-json(); }
+                    export-insert-sql    => { UiState.export-insert-sql(); }
                     col-x-offset(j)      => { UiState.col-x-offset(j); }
                     sort-col:            UiState.result-sort-col;
                     sort-asc:            UiState.result-sort-asc;
@@ -940,8 +944,9 @@ export component AppWindow inherits Window {
             copy-cell(v)  => { UiState.copy-result-cell(v); }
             copy-row(i)   => { UiState.copy-result-row(i); }
             copy-all-tsv  => { UiState.copy-result-tsv(); }
-            export-csv    => { UiState.export-csv(); }
-            export-json   => { UiState.export-json(); }
+            export-csv        => { UiState.export-csv(); }
+            export-json       => { UiState.export-json(); }
+            export-insert-sql => { UiState.export-insert-sql(); }
         }
 
         // ── Completion popup overlay ──────────────────────────────────────────

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -11,6 +11,7 @@ export component MenuBar inherits Rectangle {
 
     callback export-csv();
     callback export-json();
+    callback export-insert-sql();
     callback quit();
     callback toggle-theme();
     callback toggle-reduce-motion();
@@ -62,13 +63,13 @@ export component MenuBar inherits Rectangle {
             file-popup := PopupWindow {
                 x: 0;
                 y: root.height;
-                width:  180px;
-                height: 3 * Layout.height-menu-item + 1px;
+                width:  200px;
+                height: 4 * Layout.height-menu-item + 1px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
-                    width:  180px;
-                    height: 3 * Layout.height-menu-item + 1px;
+                    width:  200px;
+                    height: 4 * Layout.height-menu-item + 1px;
                     background:    Colors.surface0;
                     border-radius: Layout.radius-md;
                     border-width:  1px;
@@ -79,10 +80,11 @@ export component MenuBar inherits Rectangle {
 
                     VerticalLayout {
                         spacing: 0;
-                        MenuItem { text: @tr("Export CSV");  clicked => { root.export-csv();  } }
-                        MenuItem { text: @tr("Export JSON"); clicked => { root.export-json(); } }
+                        MenuItem { text: @tr("Export CSV");        clicked => { root.export-csv();        } }
+                        MenuItem { text: @tr("Export JSON");       clicked => { root.export-json();       } }
+                        MenuItem { text: @tr("Export Insert SQL"); clicked => { root.export-insert-sql(); } }
                         Rectangle { height: 1px; background: Colors.surface1; }
-                        MenuItem { text: @tr("Quit");        clicked => { root.quit();        } }
+                        MenuItem { text: @tr("Quit");              clicked => { root.quit();              } }
                     }
                 }
             }

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -33,6 +33,7 @@ export component ResultTable inherits Rectangle {
     callback copy-all-tsv();
     callback export-csv();
     callback export-json();
+    callback export-insert-sql();
     pure callback col-x-offset(int) -> float;
     callback sort-col-clicked(int);
     callback change-page-size(int);
@@ -64,8 +65,9 @@ export component ResultTable inherits Rectangle {
             total-rows: root.total-rows;
             page-size:  root.page-size;
             change-page-size(n) => { root.change-page-size(n); }
-            export-csv  => { root.export-csv(); }
-            export-json => { root.export-json(); }
+            export-csv        => { root.export-csv(); }
+            export-json       => { root.export-json(); }
+            export-insert-sql => { root.export-insert-sql(); }
         }
 
         header-inst := ResultTableHeader {

--- a/app/src/ui/components/result_table_toolbar.slint
+++ b/app/src/ui/components/result_table_toolbar.slint
@@ -15,6 +15,7 @@ export component ResultTableToolbar inherits Rectangle {
     callback change-page-size(int);
     callback export-csv();
     callback export-json();
+    callback export-insert-sql();
 
     Rectangle {
         x: 0; y: parent.height - 1px;
@@ -73,13 +74,13 @@ export component ResultTableToolbar inherits Rectangle {
     export-popup := PopupWindow {
         x: root.width - 266px;
         y: root.height + 2px;
-        width: 120px;
-        height: 60px;
+        width: 160px;
+        height: 3 * Layout.height-menu-item;
         close-policy: PopupClosePolicy.close-on-click;
 
         Rectangle {
-            width: 120px;
-            height: 60px;
+            width: 160px;
+            height: 3 * Layout.height-menu-item;
             background: Colors.surface0;
             border-radius: Layout.radius-md;
             border-width: 1px;
@@ -90,8 +91,9 @@ export component ResultTableToolbar inherits Rectangle {
 
             VerticalLayout {
                 spacing: 0;
-                MenuItem { text: @tr("Export CSV");  clicked => { root.export-csv(); } }
-                MenuItem { text: @tr("Export JSON"); clicked => { root.export-json(); } }
+                MenuItem { text: @tr("Export CSV");        clicked => { root.export-csv();        } }
+                MenuItem { text: @tr("Export JSON");       clicked => { root.export-json();       } }
+                MenuItem { text: @tr("Export Insert SQL"); clicked => { root.export-insert-sql(); } }
             }
         }
     }

--- a/app/src/ui/components/table_view.slint
+++ b/app/src/ui/components/table_view.slint
@@ -29,6 +29,7 @@ export component TableView inherits Rectangle {
     callback copy-all-tsv();
     callback export-csv();
     callback export-json();
+    callback export-insert-sql();
     out property <bool> tv-focused: tv-focus.has-focus;
     public function grab-focus() { tv-focus.focus(); }
 
@@ -138,8 +139,9 @@ export component TableView inherits Rectangle {
             copy-cell(v) => { root.copy-cell(v); }
             copy-row(i)  => { root.copy-row(i); }
             copy-all-tsv => { root.copy-all-tsv(); }
-            export-csv   => { root.export-csv(); }
-            export-json  => { root.export-json(); }
+            export-csv        => { root.export-csv(); }
+            export-json       => { root.export-json(); }
+            export-insert-sql => { root.export-insert-sql(); }
         }
 
         // Structure sub-tab

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -455,7 +455,7 @@ impl UI {
         Self::register_completion_callbacks(&window, tx_cmd.clone());
         Self::register_completion_accept_callback(&window);
         Self::register_formatter_callback(&window);
-        Self::register_export_callbacks(&window, Arc::clone(&original_data));
+        Self::register_export_callbacks(&window, Arc::clone(&original_data), state.clone());
         Self::register_theme_callback(&window, state.clone(), tx_cmd.clone());
         Self::register_reduce_motion_callback(&window, tx_cmd.clone());
         Self::register_menu_callbacks(&window, tx_cmd.clone());
@@ -2372,8 +2372,13 @@ impl UI {
 
     const CSV_DEFAULT_FILENAME: &str = "query_result.csv";
     const JSON_DEFAULT_FILENAME: &str = "query_result.json";
+    const INSERT_SQL_DEFAULT_FILENAME: &str = "query_result.sql";
 
-    fn register_export_callbacks(window: &crate::AppWindow, original_data: SharedOriginalData) {
+    fn register_export_callbacks(
+        window: &crate::AppWindow,
+        original_data: SharedOriginalData,
+        state: SharedState,
+    ) {
         let ui = window.global::<crate::UiState>();
 
         // ── CSV export ────────────────────────────────────────────────────────
@@ -2445,6 +2450,51 @@ impl UI {
                     let msg = match result {
                         Ok(()) => format!("Saved JSON: {}", path.display()),
                         Err(e) => format!("JSON export failed: {e}"),
+                    };
+                    set_status(window_weak, msg);
+                });
+            });
+        }
+
+        // ── INSERT SQL export ─────────────────────────────────────────────────
+        {
+            let window_weak = window.as_weak(); // clone required: on_export_insert_sql closure
+            let original_data = Arc::clone(&original_data); // clone required: on_export_insert_sql closure
+            ui.on_export_insert_sql(move || {
+                let snapshot = {
+                    let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
+                    orig.as_ref().map(|d| {
+                        let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
+                        (cols, d.rows.clone())
+                    })
+                };
+                let Some((columns, rows)) = snapshot else {
+                    return;
+                };
+                // Auto-detect table name from last SQL; fall back to a safe default.
+                let table_name = state
+                    .query
+                    .last_sql()
+                    .as_deref()
+                    .and_then(wf_query::analyzer::extract_single_table_name)
+                    .unwrap_or_else(|| "exported_table".to_string());
+                let window_weak = window_weak.clone(); // clone required: tokio::spawn needs 'static
+                tokio::spawn(async move {
+                    let Some(handle) = rfd::AsyncFileDialog::new()
+                        .set_title("Save Insert SQL")
+                        .set_file_name(Self::INSERT_SQL_DEFAULT_FILENAME)
+                        .add_filter("SQL files", &["sql"])
+                        .save_file()
+                        .await
+                    else {
+                        return; // user cancelled
+                    };
+                    let path = handle.path().to_path_buf();
+                    let result =
+                        wf_query::export::export_insert_sql(&columns, &rows, &table_name, &path);
+                    let msg = match result {
+                        Ok(()) => format!("Saved Insert SQL: {}", path.display()),
+                        Err(e) => format!("Insert SQL export failed: {e}"),
                     };
                     set_status(window_weak, msg);
                 });

--- a/crates/wf-query/src/analyzer.rs
+++ b/crates/wf-query/src/analyzer.rs
@@ -75,6 +75,46 @@ pub fn is_write_statement(sql: &str) -> bool {
     })
 }
 
+/// Extract the table name from a simple `SELECT … FROM <table>` query.
+///
+/// Returns `None` when the query is not a SELECT, references multiple tables
+/// (JOIN or comma-separated FROM), uses a subquery in the FROM clause, or the
+/// table name cannot be parsed.
+pub fn extract_single_table_name(sql: &str) -> Option<String> {
+    let upper = sql.trim_start().to_uppercase();
+    if !upper.starts_with("SELECT") {
+        return None;
+    }
+    if upper.contains(" JOIN ") || upper.contains(" JOIN\t") || upper.contains(" JOIN\n") {
+        return None;
+    }
+    // Find " FROM " case-insensitively
+    let from_kw = " FROM ";
+    let from_pos = upper.find(from_kw)? + from_kw.len();
+    let rest = sql[from_pos..].trim_start();
+    // Reject subqueries and comma-separated tables
+    if rest.starts_with('(') {
+        return None;
+    }
+    if upper[from_pos..].trim_start().contains(',') {
+        return None;
+    }
+    // Extract the identifier (quoted or unquoted)
+    let name = if let Some(inner) = rest.strip_prefix('"') {
+        let end = inner.find('"')?;
+        inner[..end].to_string()
+    } else if let Some(inner) = rest.strip_prefix('`') {
+        let end = inner.find('`')?;
+        inner[..end].to_string()
+    } else {
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == ';' || c == ')')
+            .unwrap_or(rest.len());
+        rest[..end].to_string()
+    };
+    if name.is_empty() { None } else { Some(name) }
+}
+
 /// Returns the substring of `sql` for the byte range `start..end`.
 ///
 /// The range is clamped to valid string boundaries.  If `start > end`
@@ -285,7 +325,80 @@ mod tests {
         assert!(!is_write_statement("SELECT inserts FROM t"));
     }
 
-    // ── extract_selection ───────────────────────────────────────────────────
+    // ── extract_single_table_name ───────────────────────────��────────────────
+
+    #[test]
+    fn extract_single_table_name_should_return_name_for_simple_select() {
+        assert_eq!(
+            extract_single_table_name("SELECT * FROM users"),
+            Some("users".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_handle_where_clause() {
+        assert_eq!(
+            extract_single_table_name("SELECT id, name FROM orders WHERE id = 1"),
+            Some("orders".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_be_case_insensitive() {
+        assert_eq!(
+            extract_single_table_name("select * from Users"),
+            Some("Users".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_handle_quoted_identifier() {
+        assert_eq!(
+            extract_single_table_name(r#"SELECT * FROM "my table""#),
+            Some("my table".to_string())
+        );
+        assert_eq!(
+            extract_single_table_name("SELECT * FROM `orders`"),
+            Some("orders".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_return_none_for_join() {
+        assert_eq!(
+            extract_single_table_name(
+                "SELECT * FROM users JOIN orders ON users.id = orders.user_id"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_return_none_for_subquery() {
+        assert_eq!(
+            extract_single_table_name("SELECT * FROM (SELECT 1) t"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_single_table_name_should_return_none_for_non_select() {
+        assert_eq!(
+            extract_single_table_name("INSERT INTO users VALUES (1)"),
+            None
+        );
+        assert_eq!(extract_single_table_name("UPDATE users SET x = 1"), None);
+    }
+
+    #[test]
+    fn extract_single_table_name_should_handle_trailing_semicolon() {
+        assert_eq!(
+            extract_single_table_name("SELECT * FROM products;"),
+            Some("products".to_string())
+        );
+    }
+
+    // ── extract_selection ─────────────────────────────────────────────────��─
 
     #[test]
     fn extract_selection_should_return_exact_byte_range() {

--- a/crates/wf-query/src/export.rs
+++ b/crates/wf-query/src/export.rs
@@ -76,6 +76,56 @@ pub fn export_json(
     Ok(())
 }
 
+/// Serialise `columns` + `rows` to a batch INSERT SQL string.
+///
+/// Output format: one `INSERT INTO "<table>" (<cols>) VALUES (<vals>);` per row.
+/// - `None` cells become the SQL `NULL` literal.
+/// - String values are single-quote escaped (`'` → `''`).
+/// - Column and table names are double-quoted with `"` escaped as `""`.
+pub fn result_to_insert_sql(
+    columns: &[String],
+    rows: &[Vec<Option<String>>],
+    table_name: &str,
+) -> String {
+    if rows.is_empty() || columns.is_empty() {
+        return String::new();
+    }
+    let quoted_table = format!("\"{}\"", table_name.replace('"', "\"\""));
+    let col_list: String = columns
+        .iter()
+        .map(|c| format!("\"{}\"", c.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut buf = String::new();
+    for row in rows {
+        let values: String = row
+            .iter()
+            .map(|cell| match cell {
+                None => "NULL".to_string(),
+                Some(s) => format!("'{}'", s.replace('\'', "''")),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        buf.push_str(&format!(
+            "INSERT INTO {quoted_table} ({col_list}) VALUES ({values});\n"
+        ));
+    }
+    buf
+}
+
+/// Write an INSERT SQL file at `path`.  See [`result_to_insert_sql`] for format details.
+pub fn export_insert_sql(
+    columns: &[String],
+    rows: &[Vec<Option<String>>],
+    table_name: &str,
+    path: &Path,
+) -> anyhow::Result<()> {
+    let content = result_to_insert_sql(columns, rows, table_name);
+    std::fs::write(path, content.as_bytes())?;
+    Ok(())
+}
+
 /// Write a UTF-8 BOM CSV file at `path`.  NULL cells become empty strings.
 pub fn export_csv(
     columns: &[String],
@@ -90,6 +140,77 @@ pub fn export_csv(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── result_to_insert_sql ──────────────────────────────────────────────────
+
+    #[test]
+    fn result_to_insert_sql_should_return_empty_for_no_rows() {
+        let cols = vec!["id".to_string()];
+        let rows: Vec<Vec<Option<String>>> = vec![];
+        assert!(result_to_insert_sql(&cols, &rows, "t").is_empty());
+    }
+
+    #[test]
+    fn result_to_insert_sql_should_generate_one_insert_per_row() {
+        let cols = vec!["id".to_string(), "name".to_string()];
+        let rows = vec![
+            vec![Some("1".to_string()), Some("Alice".to_string())],
+            vec![Some("2".to_string()), Some("Bob".to_string())],
+        ];
+        let sql = result_to_insert_sql(&cols, &rows, "users");
+        let lines: Vec<&str> = sql.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("INSERT INTO \"users\""));
+        assert!(lines[0].contains("\"id\""));
+        assert!(lines[0].contains("'Alice'"));
+        assert!(lines[1].contains("'Bob'"));
+    }
+
+    #[test]
+    fn result_to_insert_sql_should_write_null_literal_for_none_cells() {
+        let cols = vec!["a".to_string(), "b".to_string()];
+        let rows = vec![vec![Some("hello".to_string()), None]];
+        let sql = result_to_insert_sql(&cols, &rows, "t");
+        assert!(sql.contains("NULL"), "expected NULL literal: {sql}");
+        assert!(!sql.contains("''"), "NULL must not be empty string: {sql}");
+    }
+
+    #[test]
+    fn result_to_insert_sql_should_escape_single_quotes_in_values() {
+        let cols = vec!["v".to_string()];
+        let rows = vec![vec![Some("it's a test".to_string())]];
+        let sql = result_to_insert_sql(&cols, &rows, "t");
+        assert!(
+            sql.contains("'it''s a test'"),
+            "expected escaped quote: {sql}"
+        );
+    }
+
+    #[test]
+    fn result_to_insert_sql_should_quote_table_and_column_names() {
+        let cols = vec!["my col".to_string()];
+        let rows = vec![vec![Some("v".to_string())]];
+        let sql = result_to_insert_sql(&cols, &rows, "my table");
+        assert!(sql.contains("\"my table\""), "expected quoted table: {sql}");
+        assert!(sql.contains("\"my col\""), "expected quoted column: {sql}");
+    }
+
+    #[test]
+    fn result_to_insert_sql_should_escape_double_quotes_in_identifiers() {
+        let cols = vec!["a\"b".to_string()];
+        let rows = vec![vec![Some("v".to_string())]];
+        let sql = result_to_insert_sql(&cols, &rows, "t\"t");
+        assert!(
+            sql.contains("\"t\"\"t\""),
+            "expected escaped table name: {sql}"
+        );
+        assert!(
+            sql.contains("\"a\"\"b\""),
+            "expected escaped column name: {sql}"
+        );
+    }
+
+    // ── result_to_json_bytes ──────────────────────────────────────────────────
 
     #[test]
     fn result_to_json_bytes_should_map_null_to_json_null() {


### PR DESCRIPTION
## Summary

Adds an "Export Insert SQL" option to the File menu, result table toolbar, and table view export menu. Each row in the current query result is exported as a named-column INSERT statement to a `.sql` file. For single-table SELECT queries the table name is auto-detected; JOIN queries and non-SELECT statements fall back to `exported_table`.

## Changes

- `crates/wf-query/src/analyzer.rs`: add `extract_single_table_name` — parses simple `SELECT … FROM <table>` queries, rejects JOINs, subqueries, and non-SELECT statements; 9 unit tests added
- `crates/wf-query/src/export.rs`: add `result_to_insert_sql` and `export_insert_sql` — generate named-column batch INSERT statements with NULL literals and proper quote escaping; 6 unit tests added
- `app/src/ui/mod.rs`: add `on_export_insert_sql` handler — snapshots result data, opens native save dialog via `rfd::AsyncFileDialog`, writes file via `export_insert_sql`
- `app/src/ui/app.slint`: add `callback export-insert-sql()` to UiState; wire through MenuBar and ResultTable
- `app/src/ui/components/menu_bar.slint`: add "Export Insert SQL" item to File menu
- `app/src/ui/components/result_table_toolbar.slint`: add "Export Insert SQL" item to Export dropdown
- `app/src/ui/components/result_table.slint`, `table_view.slint`: pass-through callback wiring
- `app/lang/en/LC_MESSAGES/wellfeather.po`, `app/lang/ja/LC_MESSAGES/wellfeather.po`: add i18n strings

## Related Issues

Closes #202

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes