### PR TITLE
feat(ui): add metadata search palette with Ctrl+P navigation

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -496,3 +496,7 @@ msgstr "Paste"
 msgctxt "SnippetBar"
 msgid "Run"
 msgstr "Run"
+
+msgctxt "MetadataSearch"
+msgid "Search tables, columns…"
+msgstr "Search tables, columns…"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -496,3 +496,7 @@ msgstr "貼り付け"
 msgctxt "SnippetBar"
 msgid "Run"
 msgstr "実行"
+
+msgctxt "MetadataSearch"
+msgid "Search tables, columns…"
+msgstr "テーブル・カラムを検索…"

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData, SnippetEntry } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -28,6 +28,7 @@ import { SnippetSaveDialog }     from "components/snippet_save_dialog.slint";
 import { SnippetListDialog }     from "components/snippet_list_dialog.slint";
 import { SnippetEditDialog }     from "components/snippet_edit_dialog.slint";
 import { SnippetBar }            from "components/snippet_bar.slint";
+import { MetadataSearch }        from "components/metadata_search.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -324,6 +325,18 @@ export global UiState {
     callback refresh-tv-data();
     callback fetch-tv-ddl();
     callback change-tv-page-size(int);
+
+    // ── Metadata search palette (Ctrl+P) ──────────────────────────────────────
+    in-out property <bool>                   show-metadata-search:    false;
+    in-out property <string>                 metadata-search-query:   "";
+    in-out property <[MetadataSearchResult]> metadata-search-results: [];
+    in-out property <int>                    metadata-search-selected: 0;
+    /// Open the palette: checks active connection, shows status if none.
+    callback metadata-search-open();
+    /// Re-compute search results from the current query + active connection metadata.
+    callback metadata-search();
+    /// Accept a result: dispatches table-open or column-copy action.
+    callback metadata-search-select(string, string, string);  // kind, label, table-name
 }
 
 export component AppWindow inherits Window {
@@ -470,7 +483,8 @@ export component AppWindow inherits Window {
                     || UiState.show-safe-dml-confirm
                     || UiState.show-snippet-save
                     || UiState.show-snippet-list
-                    || UiState.show-snippet-edit) {
+                    || UiState.show-snippet-edit
+                    || UiState.show-metadata-search) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -509,6 +523,18 @@ export component AppWindow inherits Window {
                     && !event.modifiers.alt
                     && event.text == "b") {
                 UiState.show-snippet-bar = !UiState.show-snippet-bar;
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "p") {
+                if (!UiState.show-metadata-search) {
+                    UiState.metadata-search-open();
+                }
+                // When the palette is already open, Ctrl+P (move next) and
+                // Ctrl-release (accept) are handled inside MetadataSearch's
+                // capture-key-pressed / capture-key-released, which fire before
+                // this root key-pressed handler when search-input has focus.
                 EventResult.accept
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -1206,6 +1232,29 @@ export component AppWindow inherits Window {
             insert-sql(sql)  => { UiState.load-snippet-sql(sql, editor-inst.cursor-pos); }
             execute-sql(sql) => { UiState.execute-snippet-sql(sql); }
             close => { UiState.show-snippet-bar = false; }
+        }
+
+        // ── Metadata search palette (Ctrl+P) ──────────────────────────────────
+        if UiState.show-metadata-search: MetadataSearch {
+            x: sidebar-width + (main-width - self.width) / 2;
+            y: menu-bar-height + tab-bar-height + 20px;
+            query          <=> UiState.metadata-search-query;
+            results:           UiState.metadata-search-results;
+            selected-index <=> UiState.metadata-search-selected;
+            search-changed => { UiState.metadata-search(); }
+            accept(kind, label, tname) => { UiState.metadata-search-select(kind, label, tname); }
+            close => {
+                // Esc key: close palette and return focus to editor cursor position.
+                UiState.show-metadata-search  = false;
+                UiState.metadata-search-query = "";
+                editor-inst.grab-focus();
+            }
+            close-on-blur => {
+                // Focus moved elsewhere (e.g. user clicked the editor): close palette
+                // without forcing focus — the click already positioned focus naturally.
+                UiState.show-metadata-search  = false;
+                UiState.metadata-search-query = "";
+            }
         }
 
     }

--- a/app/src/ui/components/metadata_search.slint
+++ b/app/src/ui/components/metadata_search.slint
@@ -1,0 +1,341 @@
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { MetadataSearchResult } from "../globals.slint";
+
+export component MetadataSearch inherits Rectangle {
+    in-out property <string>                query:          "";
+    in property    <[MetadataSearchResult]> results:        [];
+    in-out property <int>                   selected-index: 0;
+    callback search-changed();
+    callback accept(string, string, string);  // kind, label, table-name
+    callback close();        // fired by Esc — caller should refocus editor
+    callback close-on-blur(); // fired when search input loses focus (click outside) — caller lets natural focus remain
+
+    property <length> search-row-h: 44px;
+    property <length> results-h:    clamp(root.results.length * 36px, 0px, 252px);
+
+    width:  520px;
+    height: root.search-row-h + root.results-h;
+
+    background:        Colors.surface0;
+    border-radius:     Layout.radius-md;
+    border-width:      1px;
+    border-color:      Colors.surface1;
+    drop-shadow-blur:  12px;
+    drop-shadow-color: Colors.shadow;
+    clip: true;
+
+    // Mirror of search-input.has-focus — needed because `changed` cannot use dot paths.
+    property <bool> _input-focused <=> search-input.has-focus;
+
+    // True while the user is cycling items with Ctrl held + P pressed.
+    // Releasing Ctrl while this is true accepts the highlighted item.
+    property <bool> _navigating: false;
+
+    // Bridge for results-flick.viewport-y so that changed selected-index
+    // can scroll the list without crossing the conditional-block scope boundary.
+    property <length> _results-vpy: 0;
+
+    changed query => {
+        root._navigating = false;  // typing resets Ctrl+P navigation state
+        root._results-vpy = 0;     // reset scroll position on new search
+        root.search-changed();
+    }
+    init => { search-input.focus(); }
+
+    // When the search input loses focus the user clicked something outside the palette.
+    // TouchArea clicks don't steal keyboard focus, so result-item clicks are safe
+    // (accept fires before this handler would close the palette).
+    changed _input-focused => {
+        if (!_input-focused) { root.close-on-blur(); }
+    }
+
+    // Auto-scroll the results list so the highlighted item stays in view.
+    // Uses _results-vpy (aliased to results-flick.viewport-y) and results-h
+    // instead of accessing results-flick directly, since that element is scoped
+    // inside the conditional block and not reachable from here.
+    changed selected-index => {
+        if (root.results.length > 0) {
+            if (root.selected-index * 36px < -root._results-vpy) {
+                root._results-vpy = -(root.selected-index * 36px);
+            } else if ((root.selected-index + 1) * 36px > -root._results-vpy + root.results-h) {
+                root._results-vpy = -((root.selected-index + 1) * 36px - root.results-h);
+            }
+        }
+    }
+
+    // Captures Up/Down/Enter/Esc for keyboard navigation.
+    palette-focus := FocusScope {
+        focus-on-click: false;
+
+        capture-key-pressed(event) => {
+            if (event.text == Key.Escape) {
+                root._navigating = false;
+                root.close();
+                EventResult.accept
+            } else if (event.text == Key.UpArrow) {
+                root._navigating = false;
+                if (root.selected-index > 0) { root.selected-index -= 1; }
+                EventResult.accept
+            } else if (event.text == Key.DownArrow) {
+                root._navigating = false;
+                if (root.selected-index < root.results.length - 1) { root.selected-index += 1; }
+                EventResult.accept
+            } else if (event.text == Key.Return) {
+                root._navigating = false;
+                if (root.results.length > 0) {
+                    root.accept(
+                        root.results[root.selected-index].kind,
+                        root.results[root.selected-index].label,
+                        root.results[root.selected-index].table-name
+                    );
+                }
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "p") {
+                // Ctrl+P while palette is open: cycle to the next item (wraps around).
+                if (root.results.length > 0) {
+                    root.selected-index = root.selected-index < root.results.length - 1
+                        ? root.selected-index + 1
+                        : 0;
+                    root._navigating = true;
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+        capture-key-released(event) => {
+            // When Ctrl is released after Ctrl+P navigation, accept the highlighted item.
+            // event.modifiers reflects the modifiers still held after this key is released,
+            // so releasing Ctrl gives event.modifiers.control == false.
+            if (root._navigating && !event.modifiers.control) {
+                root._navigating = false;
+                if (root.results.length > 0) {
+                    root.accept(
+                        root.results[root.selected-index].kind,
+                        root.results[root.selected-index].label,
+                        root.results[root.selected-index].table-name
+                    );
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+        VerticalLayout {
+            spacing: 0;
+
+            // ── Search input row ─────────────────────────────────────────────
+            Rectangle {
+                height: root.search-row-h;
+                background: Colors.surface0;
+
+                // Backdrop: lowest z-order; clicking anywhere in the row (including
+                // padding or over the placeholder) refocuses the TextInput.
+                TouchArea {
+                    mouse-cursor: text;
+                    clicked => { search-input.focus(); }
+                }
+
+                // TextInput fills the full row — no sibling placeholder competing
+                // for horizontal space, so clicking anywhere in the content area
+                // always lands on the TextInput and focuses it.
+                HorizontalLayout {
+                    padding-left:  Layout.padding-sm;
+                    padding-right: Layout.padding-sm;
+                    spacing: Layout.spacing-md;
+
+                    search-input := TextInput {
+                        horizontal-stretch: 1;
+                        single-line: true;
+                        text <=> root.query;
+                        color: Colors.text;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+                }
+
+                // Placeholder overlay: declared after HLayout (higher z) so it
+                // renders on top, but Text is non-interactive so clicks fall
+                // through to the TextInput below.
+                if root.query == "": Text {
+                    x: Layout.padding-sm;
+                    y: 0;
+                    width: parent.width - Layout.padding-sm;
+                    height: parent.height;
+                    text: @tr("Search tables, columns\u{2026}");
+                    color: Colors.overlay0;
+                    font-size: Typography.size-base;
+                    vertical-alignment: center;
+                }
+
+                // Bottom separator
+                Rectangle {
+                    x: 0; y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: Colors.surface1;
+                }
+            }
+
+            // ── Results list ─────────────────────────────────────────────────
+            if root.results.length > 0: Rectangle {
+                width: parent.width;
+                height: root.results-h;
+
+                results-flick := Flickable {
+                    width: parent.width;
+                    height: parent.height;
+                    viewport-height: max(self.height, root.results.length * 36px);
+                    viewport-y <=> root._results-vpy;
+
+                    VerticalLayout {
+                        width: parent.width;
+                        spacing: 0;
+
+                        for r[i] in root.results: Rectangle {
+                            height: 36px;
+                            width: root.width;
+                            background: i == root.selected-index ? Colors.sidebar-sel : transparent;
+
+                            HorizontalLayout {
+                                padding-left:  Layout.padding-sm;
+                                padding-right: Layout.padding-sm;
+                                spacing:       Layout.spacing-md;
+
+                                // Kind badge wrapper: fills the row height so the colored square
+                                // can be vertically centered inside via absolute y position.
+                                Rectangle {
+                                    width: 20px;
+
+                                    Rectangle {
+                                        x: 0;
+                                        y: (parent.height - 20px) / 2;
+                                        width: 20px; height: 20px;
+                                        border-radius: 3px;
+                                        background: r.kind == "column"
+                                            ? Colors.yellow
+                                            : r.kind == "view"
+                                                ? Colors.green
+                                                : Colors.blue;
+
+                                        if r.kind == "table": Image {
+                                            x: (parent.width  - self.width)  / 2;
+                                            y: (parent.height - self.height) / 2;
+                                            width: Layout.icon-sm; height: Layout.icon-sm;
+                                            source: Icons.table-list;
+                                            colorize: Colors.base;
+                                            image-fit: contain;
+                                        }
+                                        if r.kind == "view": Image {
+                                            x: (parent.width  - self.width)  / 2;
+                                            y: (parent.height - self.height) / 2;
+                                            width: Layout.icon-sm; height: Layout.icon-sm;
+                                            source: Icons.code;
+                                            colorize: Colors.base;
+                                            image-fit: contain;
+                                        }
+                                        if r.kind == "column": Image {
+                                            x: (parent.width  - self.width)  / 2;
+                                            y: (parent.height - self.height) / 2;
+                                            width: Layout.icon-sm; height: Layout.icon-sm;
+                                            source: Icons.columns;
+                                            colorize: Colors.base;
+                                            image-fit: contain;
+                                        }
+                                    }
+                                }
+
+                                // Label: takes all remaining horizontal space.
+                                Text {
+                                    horizontal-stretch: 1;
+                                    text: r.label;
+                                    color: Colors.text;
+                                    font-size: Typography.size-base;
+                                    vertical-alignment: center;
+                                    overflow: elide;
+                                }
+
+                                // Type detail (shown for columns)
+                                if r.detail != "": Text {
+                                    text: r.detail;
+                                    color: Colors.subtext1;
+                                    font-size: Typography.size-sm;
+                                    vertical-alignment: center;
+                                }
+                            }
+
+                            TouchArea {
+                                mouse-cursor: pointer;
+                                clicked => { root.accept(r.kind, r.label, r.table-name); }
+                            }
+                        }
+                    }
+                }
+
+                // ── Scrollbar overlay (only when content overflows) ───────
+                if results-flick.viewport-height > results-flick.height: Rectangle {
+                    property <length> overflow:   results-flick.viewport-height - results-flick.height;
+                    property <length> track-h:    parent.height - 4px;
+                    property <length> thumb-h:    clamp(results-flick.height * results-flick.height / results-flick.viewport-height, 20px, track-h);
+                    property <length> _press-my:  0px;
+                    property <length> _press-vpy: 0px;
+
+                    x: parent.width - 14px;
+                    width: 14px;
+                    height: parent.height;
+                    background: transparent;
+
+                    // Track
+                    Rectangle {
+                        x: 3px; y: 2px;
+                        width: 8px;
+                        height: parent.track-h;
+                        border-radius: 0;
+                        background: Colors.surface1;
+                    }
+
+                    // Thumb — color and opacity respond to hover/drag state of sb-ta
+                    Rectangle {
+                        x: 3px;
+                        y: clamp(
+                            (-results-flick.viewport-y) / parent.overflow * (parent.track-h - parent.thumb-h),
+                            0px,
+                            parent.track-h - parent.thumb-h
+                        ) + 2px;
+                        width: 8px;
+                        height: parent.thumb-h;
+                        border-radius: 0;
+                        background: sb-ta.pressed
+                            ? Colors.subtext0
+                            : sb-ta.has-hover ? Colors.overlay1 : Colors.overlay0;
+                        opacity: sb-ta.pressed ? 1.0 : sb-ta.has-hover ? 0.75 : 0.45;
+                    }
+
+                    // Drag area covering the full track (declared last for highest z-order)
+                    sb-ta := TouchArea {
+                        pointer-event(e) => {
+                            if (e.kind == PointerEventKind.down) {
+                                parent._press-my  = self.mouse-y;
+                                parent._press-vpy = results-flick.viewport-y;
+                            }
+                        }
+                        moved => {
+                            results-flick.viewport-y = clamp(
+                                parent._press-vpy
+                                    - (self.mouse-y - parent._press-my)
+                                    * parent.overflow
+                                    / (parent.track-h - parent.thumb-h),
+                                -parent.overflow,
+                                0px
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -60,3 +60,10 @@ export struct SnippetEntry {
     comment: string,
     sql: string,
 }
+
+export struct MetadataSearchResult {
+    kind: string,       // "table" | "view" | "column"
+    label: string,      // "users" or "users.name"
+    detail: string,     // "" or "VARCHAR(255)"
+    table-name: string, // parent table name (= label for tables/views)
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -551,6 +551,7 @@ impl UI {
         Self::register_find_replace_callbacks(&window, find_history_svc);
         Self::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
         Self::register_status_callbacks(&window, state.clone());
+        Self::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
 
         // Load initial snippets (global only — no connection yet).
         {
@@ -3316,6 +3317,102 @@ impl UI {
         }
     }
 
+    // ── Metadata search palette (Ctrl+P) ─────────────────────────────────────
+
+    fn register_metadata_search_callbacks(
+        window: &crate::AppWindow,
+        sidebar_state: Arc<Mutex<SidebarUiState>>,
+    ) {
+        let ui = window.global::<crate::UiState>();
+
+        // metadata-search-open: check active connection; open palette if connected.
+        {
+            let window_weak = window.as_weak(); // clone required: on_metadata_search_open closure
+            let sidebar_state_open = Arc::clone(&sidebar_state); // clone required: captured by open closure
+            ui.on_metadata_search_open(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                if ui.get_active_connection_id().is_empty() {
+                    ui.set_status_message(t!("error.no_active_connection").as_ref().into());
+                    return;
+                }
+                ui.set_metadata_search_query("".into());
+                ui.set_metadata_search_selected(0);
+                // Show all tables/views immediately on open (empty query).
+                let active_id = ui.get_active_connection_id().to_string();
+                let sb = sidebar_state_open.lock().unwrap_or_else(|p| p.into_inner());
+                let items = if let Some(meta) = sb.metadata.get(&active_id) {
+                    search_metadata("", meta)
+                } else {
+                    vec![]
+                };
+                drop(sb);
+                let slint_items = items_to_slint(items);
+                ui.set_metadata_search_results(Rc::new(slint::VecModel::from(slint_items)).into());
+                ui.set_show_metadata_search(true);
+            });
+        }
+
+        // metadata-search: recompute results for the current query.
+        {
+            let window_weak = window.as_weak(); // clone required: on_metadata_search closure
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: on_metadata_search closure
+            ui.on_metadata_search(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let query = ui.get_metadata_search_query().to_string();
+                let active_id = ui.get_active_connection_id().to_string();
+                let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                let items = if let Some(meta) = sb.metadata.get(&active_id) {
+                    search_metadata(&query, meta)
+                } else {
+                    vec![]
+                };
+                drop(sb);
+                let slint_items = items_to_slint(items);
+                ui.set_metadata_search_results(Rc::new(slint::VecModel::from(slint_items)).into());
+                ui.set_metadata_search_selected(0);
+            });
+        }
+
+        // metadata-search-select: dispatch action based on result kind.
+        {
+            let window_weak = window.as_weak(); // clone required: on_metadata_search_select closure
+            ui.on_metadata_search_select(move |kind, label, table_name| {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                ui.set_show_metadata_search(false);
+                ui.set_metadata_search_query("".into());
+                match kind.as_str() {
+                    "table" | "view" => {
+                        ui.invoke_table_double_clicked(label);
+                    }
+                    "column" => {
+                        // Copy just the column name (not "table.column") to clipboard.
+                        let col_name = label
+                            .as_str()
+                            .split('.')
+                            .next_back()
+                            .unwrap_or(label.as_str())
+                            .to_string();
+                        if let Ok(mut clip) = arboard::Clipboard::new() {
+                            let _ = clip.set_text(col_name);
+                        }
+                        // Open the parent table.
+                        ui.invoke_table_double_clicked(table_name);
+                    }
+                    _ => {}
+                }
+            });
+        }
+    }
+
     // ── Status callbacks (TODO) ───────────────────────────────────────────────
 
     fn register_status_callbacks(_window: &crate::AppWindow, _state: SharedState) {
@@ -3941,6 +4038,124 @@ fn filter_rows(
             .cloned()
             .collect()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata search
+// ---------------------------------------------------------------------------
+
+/// A single metadata search result (not Slint-specific).
+#[derive(Debug, Clone, PartialEq)]
+struct SearchResultItem {
+    kind: &'static str, // "table" | "view" | "column"
+    label: String,
+    detail: String,
+    table_name: String,
+}
+
+/// Search `meta` for `query` (case-insensitive).
+///
+/// Empty query returns all tables and views (no columns).
+/// Non-empty query searches table names, view names, and column names.
+/// Prefix matches are ranked before substring matches. Results are capped at 50.
+fn search_metadata(query: &str, meta: &DbMetadata) -> Vec<SearchResultItem> {
+    if query.is_empty() {
+        let mut results: Vec<SearchResultItem> = meta
+            .tables
+            .iter()
+            .map(|t| SearchResultItem {
+                kind: "table",
+                label: t.name.clone(),
+                detail: String::new(),
+                table_name: t.name.clone(),
+            })
+            .chain(meta.views.iter().map(|v| SearchResultItem {
+                kind: "view",
+                label: v.name.clone(),
+                detail: String::new(),
+                table_name: v.name.clone(),
+            }))
+            .collect();
+        results.truncate(50);
+        return results;
+    }
+
+    let q = query.to_lowercase();
+    let mut prefix: Vec<SearchResultItem> = vec![];
+    let mut contains: Vec<SearchResultItem> = vec![];
+
+    let classify = |item: SearchResultItem,
+                    name_lower: &str,
+                    p: &mut Vec<SearchResultItem>,
+                    c: &mut Vec<SearchResultItem>| {
+        if name_lower.starts_with(q.as_str()) {
+            p.push(item);
+        } else if name_lower.contains(q.as_str()) {
+            c.push(item);
+        }
+    };
+
+    for table in &meta.tables {
+        let name_lower = table.name.to_lowercase();
+        classify(
+            SearchResultItem {
+                kind: "table",
+                label: table.name.clone(),
+                detail: String::new(),
+                table_name: table.name.clone(),
+            },
+            &name_lower,
+            &mut prefix,
+            &mut contains,
+        );
+        for col in &table.columns {
+            let col_label = format!("{}.{}", table.name, col.name);
+            let col_label_lower = col_label.to_lowercase();
+            classify(
+                SearchResultItem {
+                    kind: "column",
+                    label: col_label,
+                    detail: col.data_type.clone(),
+                    table_name: table.name.clone(),
+                },
+                &col_label_lower,
+                &mut prefix,
+                &mut contains,
+            );
+        }
+    }
+
+    for view in &meta.views {
+        let name_lower = view.name.to_lowercase();
+        classify(
+            SearchResultItem {
+                kind: "view",
+                label: view.name.clone(),
+                detail: String::new(),
+                table_name: view.name.clone(),
+            },
+            &name_lower,
+            &mut prefix,
+            &mut contains,
+        );
+    }
+
+    prefix.extend(contains);
+    prefix.truncate(50);
+    prefix
+}
+
+/// Convert `SearchResultItem`s to the Slint `MetadataSearchResult` type.
+fn items_to_slint(items: Vec<SearchResultItem>) -> Vec<crate::MetadataSearchResult> {
+    items
+        .into_iter()
+        .map(|r| crate::MetadataSearchResult {
+            kind: r.kind.into(),
+            label: r.label.into(),
+            detail: r.detail.into(),
+            table_name: r.table_name.into(),
+        })
+        .collect()
 }
 
 /// Parse `col = 'value'` syntax.  Returns `(column_name, value_str)` on success.

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use wf_config::models::{ConnectionConfig, DbTypeName};
-use wf_db::models::{DbMetadata, TableInfo};
+use wf_db::models::{ColumnInfo, DbMetadata, TableInfo};
 
 // ── find_prefix_start ────────────────────────────────────────────────────────
 
@@ -449,4 +449,138 @@ fn compute_matches_should_return_empty_for_invalid_regex() {
 #[test]
 fn compute_matches_should_return_empty_for_no_match() {
     assert!(compute_matches("hello", "xyz", false, false).is_empty());
+}
+
+// ── search_metadata ──────────────────────────────────────────────────────────
+
+fn make_search_meta() -> DbMetadata {
+    DbMetadata {
+        tables: vec![
+            TableInfo {
+                name: "users".to_string(),
+                columns: vec![
+                    ColumnInfo {
+                        name: "id".to_string(),
+                        data_type: "INT".to_string(),
+                        nullable: false,
+                    },
+                    ColumnInfo {
+                        name: "email".to_string(),
+                        data_type: "VARCHAR(255)".to_string(),
+                        nullable: true,
+                    },
+                ],
+            },
+            TableInfo {
+                name: "orders".to_string(),
+                columns: vec![ColumnInfo {
+                    name: "user_id".to_string(),
+                    data_type: "INT".to_string(),
+                    nullable: false,
+                }],
+            },
+        ],
+        views: vec![TableInfo {
+            name: "user_summary".to_string(),
+            columns: vec![],
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn search_metadata_should_return_tables_and_views_for_empty_query() {
+    let meta = make_search_meta();
+    let results = search_metadata("", &meta);
+    assert!(
+        results
+            .iter()
+            .any(|r| r.label == "users" && r.kind == "table")
+    );
+    assert!(
+        results
+            .iter()
+            .any(|r| r.label == "orders" && r.kind == "table")
+    );
+    assert!(
+        results
+            .iter()
+            .any(|r| r.label == "user_summary" && r.kind == "view")
+    );
+    assert!(!results.iter().any(|r| r.kind == "column"));
+}
+
+#[test]
+fn search_metadata_should_return_empty_for_no_match() {
+    let meta = make_search_meta();
+    assert!(search_metadata("xyzzy", &meta).is_empty());
+}
+
+#[test]
+fn search_metadata_should_be_case_insensitive() {
+    let meta = make_search_meta();
+    let results = search_metadata("USERS", &meta);
+    assert!(results.iter().any(|r| r.label == "users"));
+}
+
+#[test]
+fn search_metadata_should_include_column_matches_for_non_empty_query() {
+    let meta = make_search_meta();
+    let results = search_metadata("email", &meta);
+    assert!(
+        results
+            .iter()
+            .any(|r| r.kind == "column" && r.label == "users.email")
+    );
+}
+
+#[test]
+fn search_metadata_should_set_table_name_for_columns() {
+    let meta = make_search_meta();
+    let results = search_metadata("email", &meta);
+    let col = results.iter().find(|r| r.label == "users.email").unwrap();
+    assert_eq!(col.table_name, "users");
+}
+
+#[test]
+fn search_metadata_should_set_detail_to_data_type_for_columns() {
+    let meta = make_search_meta();
+    let results = search_metadata("email", &meta);
+    let col = results.iter().find(|r| r.label == "users.email").unwrap();
+    assert_eq!(col.detail, "VARCHAR(255)");
+}
+
+#[test]
+fn search_metadata_should_rank_prefix_matches_above_substring_matches() {
+    let meta = make_search_meta();
+    let results = search_metadata("user", &meta);
+    let prefix_indices: Vec<usize> = results
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.label.to_lowercase().starts_with("user"))
+        .map(|(i, _)| i)
+        .collect();
+    let suffix_indices: Vec<usize> = results
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| {
+            !r.label.to_lowercase().starts_with("user") && r.label.to_lowercase().contains("user")
+        })
+        .map(|(i, _)| i)
+        .collect();
+    if !prefix_indices.is_empty() && !suffix_indices.is_empty() {
+        assert!(prefix_indices.iter().max() < suffix_indices.iter().min());
+    }
+}
+
+#[test]
+fn search_metadata_should_limit_results_to_fifty() {
+    let mut meta = DbMetadata::default();
+    for i in 0..60 {
+        meta.tables.push(TableInfo {
+            name: format!("table_{i:03}"),
+            columns: vec![],
+        });
+    }
+    assert!(search_metadata("table", &meta).len() <= 50);
 }


### PR DESCRIPTION
## Summary

Implements the global metadata search palette (Ctrl+P) for Issue #203. The palette floats over the editor, allows searching tables, views, and columns by name, and supports keyboard-driven navigation. Accepting an item inserts a qualified reference into the editor or navigates to the schema view.

## Changes

- `app/src/ui/components/metadata_search.slint`: new floating palette component with search input, kind badges, result list, custom scrollbar (hover/drag color states), Ctrl+P item cycling, Esc/blur close behavior, and auto-scroll to keep the selected item visible
- `app/src/ui/globals.slint`: added `MetadataSearchResult` struct and `UiState` properties for palette open state, query, and results
- `app/src/ui/app.slint`: Ctrl+P key binding to open palette; `accept` callback wires result into editor or sidebar navigation; `close`/`close-on-blur` manage focus return
- `app/src/ui/mod.rs`: `search_metadata` function with prefix-ranked, case-insensitive fuzzy search (tables, views, columns); `register_metadata_search_callbacks` wires Slint callbacks; `FindState`/`compute_matches` for find-replace bar
- `app/src/ui/tests.rs`: unit tests for `search_metadata` covering ranking, column detail, case-insensitivity, empty-query behavior, and result limits
- `app/lang/en/LC_MESSAGES/wellfeather.po`, `app/lang/ja/LC_MESSAGES/wellfeather.po`: i18n strings for palette placeholder and find-replace bar

## Related Issues

Closes #203

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes