### PR TITLE
feat(platform): add platform abstraction layer for dirs, DPI, and dark mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6765,6 +6765,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "chrono",
+ "directories",
  "regex",
  "rfd",
  "rust-i18n",
@@ -6773,6 +6774,7 @@ dependencies = [
  "slint-build",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
@@ -6784,6 +6786,7 @@ dependencies = [
  "wf-db",
  "wf-history",
  "wf-query",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -25,6 +25,11 @@ serde              = { workspace = true, features = ["derive"] }
 toml               = "1"
 rust-i18n          = "4.0.0"
 regex              = "1.12.3"
+directories        = "6.0.0"
+thiserror          = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62.2", features = ["Win32_UI_HiDpi"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -19,19 +19,24 @@ slint::include_modules!();
 rust_i18n::i18n!("locales", fallback = "en");
 
 mod app;
+mod platform;
 mod state;
 mod ui;
 
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use app::{
     controller::AppController,
     session::{SessionManager, config_to_db_conn},
 };
+use platform::{CurrentPlatform, Platform};
 use state::AppState;
 use ui::UI;
 use wf_completion::cache::MetadataCache;
-use wf_config::{ConnectionRepository, SnippetRepository, crypto, manager::ConfigManager};
+use wf_config::{
+    ConnectionRepository, SnippetRepository, crypto, manager::ConfigManager, models::Theme,
+};
 use wf_db::service::DbService;
 use wf_history::{
     find_history::FindHistoryService, service::HistoryService, session::SessionService,
@@ -39,9 +44,14 @@ use wf_history::{
 
 /// Entry point. Runs on the main OS thread; the Slint event loop must stay here.
 fn main() -> anyhow::Result<()> {
+    // Initialise tracing first so that enable_dpi_awareness() can log warnings.
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
+
+    // Enable per-monitor DPI awareness before any window is created (Windows only;
+    // no-op on macOS and Linux where scaling is handled by the OS / desktop environment).
+    platform::enable_dpi_awareness();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -51,8 +61,30 @@ fn main() -> anyhow::Result<()> {
     // an explicit runtime handle.
     let _guard = runtime.enter();
 
+    // Resolve OS-specific directories once at startup and ensure they exist.
+    // The SQLite database is intentionally kept in config_dir (same as ConfigManager::app_dir())
+    // for backward compatibility with existing installations.
+    let config_dir = CurrentPlatform::get_config_dir()
+        .context("cannot resolve OS application config directory")?;
+    let data_dir =
+        CurrentPlatform::get_data_dir().context("cannot resolve OS application data directory")?;
+    let cache_dir = CurrentPlatform::get_cache_dir()
+        .context("cannot resolve OS application cache directory")?;
+    std::fs::create_dir_all(&config_dir).context("cannot create application config directory")?;
+    std::fs::create_dir_all(&data_dir).context("cannot create application data directory")?;
+    std::fs::create_dir_all(&cache_dir).context("cannot create application cache directory")?;
+    tracing::debug!(
+        config = %config_dir.display(),
+        data   = %data_dir.display(),
+        cache  = %cache_dir.display(),
+        "application directories resolved"
+    );
+
+    // Detect whether this is a first launch (no saved config yet) for dark-mode auto-detection.
+    let config_file_exists = config_dir.join("config.toml").exists();
+
     // Load (or generate) the AES-256-GCM key used to encrypt stored passwords.
-    let enc_key = crypto::load_or_create_key(&ConfigManager::app_dir())?;
+    let enc_key = crypto::load_or_create_key(&config_dir)?;
 
     let state = Arc::new(AppState::new());
 
@@ -64,7 +96,16 @@ fn main() -> anyhow::Result<()> {
         state
             .ui
             .set_page_size(u32::from(config.editor.page_size) as usize);
-        state.ui.set_theme(config.appearance.theme);
+        // On first launch (no saved config): auto-detect the system dark/light mode.
+        // On subsequent launches: respect the theme the user explicitly chose and saved.
+        let theme = if config_file_exists {
+            config.appearance.theme
+        } else if CurrentPlatform::is_dark_mode_enabled() {
+            Theme::Dark
+        } else {
+            Theme::Light
+        };
+        state.ui.set_theme(theme);
     }
 
     // Open the single shared SQLite database for all persistence needs.
@@ -72,7 +113,7 @@ fn main() -> anyhow::Result<()> {
         sqlx::sqlite::SqlitePoolOptions::new()
             .connect_with(
                 sqlx::sqlite::SqliteConnectOptions::new()
-                    .filename(ConfigManager::app_dir().join("wellfeather.db"))
+                    .filename(config_dir.join("wellfeather.db"))
                     .create_if_missing(true)
                     .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal),
             )

--- a/app/src/platform/linux.rs
+++ b/app/src/platform/linux.rs
@@ -1,0 +1,132 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use directories::ProjectDirs;
+
+use super::{APP_NAME, Platform, PlatformError};
+
+pub struct LinuxPlatform;
+
+fn project_dirs() -> Result<ProjectDirs, PlatformError> {
+    ProjectDirs::from("", "", APP_NAME).ok_or(PlatformError::DirectoryNotFound)
+}
+
+/// No-op on Linux: DPI scaling is handled by the desktop environment.
+pub fn enable_dpi_awareness() {
+    tracing::debug!("Linux DPI scaling is handled by the desktop environment");
+}
+
+impl Platform for LinuxPlatform {
+    fn get_data_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.data_dir().to_path_buf())
+    }
+
+    fn get_config_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.config_dir().to_path_buf())
+    }
+
+    fn get_cache_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.cache_dir().to_path_buf())
+    }
+
+    fn is_dark_mode_enabled() -> bool {
+        // ── GNOME: color-scheme preference (preferred, GTK 4.x / GNOME 42+) ─────
+        if let Ok(out) = Command::new("gsettings")
+            .args(["get", "org.gnome.desktop.interface", "color-scheme"])
+            .output()
+        {
+            if out.status.success() {
+                let scheme = String::from_utf8_lossy(&out.stdout);
+                if scheme.contains("prefer-dark") || scheme.contains("dark") {
+                    tracing::debug!("GNOME dark mode detected via color-scheme");
+                    return true;
+                }
+            }
+        }
+
+        // ── GNOME: gtk-theme fallback (GTK 3.x) ──────────────────────────────────
+        if let Ok(out) = Command::new("gsettings")
+            .args(["get", "org.gnome.desktop.interface", "gtk-theme"])
+            .output()
+        {
+            if out.status.success() {
+                let theme = String::from_utf8_lossy(&out.stdout).to_lowercase();
+                if theme.contains("dark") {
+                    tracing::debug!("GNOME dark mode detected via gtk-theme");
+                    return true;
+                }
+            }
+        }
+
+        // ── KDE Plasma 6 (kreadconfig6) and Plasma 5 (kreadconfig5) ─────────────
+        for kreadconfig in ["kreadconfig6", "kreadconfig5"] {
+            if let Ok(out) = Command::new(kreadconfig)
+                .args([
+                    "--group",
+                    "General",
+                    "--key",
+                    "ColorScheme",
+                    "--file",
+                    "kdeglobals",
+                ])
+                .output()
+            {
+                if out.status.success() {
+                    let scheme = String::from_utf8_lossy(&out.stdout).to_lowercase();
+                    if scheme.contains("dark") || scheme.contains("breezedark") {
+                        tracing::debug!("KDE Plasma dark mode detected via {kreadconfig}");
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // ── GTK_THEME environment variable (universal fallback) ───────────────────
+        if let Ok(gtk_theme) = std::env::var("GTK_THEME") {
+            if gtk_theme.to_lowercase().contains("dark") {
+                tracing::debug!("dark mode detected via GTK_THEME environment variable");
+                return true;
+            }
+        }
+
+        tracing::debug!("no dark theme detected on Linux, defaulting to light");
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_platform_get_data_dir_should_contain_app_name() {
+        let path = LinuxPlatform::get_data_dir().expect("failed to get data dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "data dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn linux_platform_get_config_dir_should_contain_app_name() {
+        let path = LinuxPlatform::get_config_dir().expect("failed to get config dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "config dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn linux_platform_get_cache_dir_should_contain_app_name() {
+        let path = LinuxPlatform::get_cache_dir().expect("failed to get cache dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "cache dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn linux_platform_is_dark_mode_enabled_should_return_bool() {
+        let _ = LinuxPlatform::is_dark_mode_enabled();
+    }
+}

--- a/app/src/platform/macos.rs
+++ b/app/src/platform/macos.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use directories::ProjectDirs;
+
+use super::{APP_NAME, Platform, PlatformError};
+
+pub struct MacOsPlatform;
+
+fn project_dirs() -> Result<ProjectDirs, PlatformError> {
+    ProjectDirs::from("", "", APP_NAME).ok_or(PlatformError::DirectoryNotFound)
+}
+
+/// No-op on macOS: the OS and Slint handle HiDPI scaling automatically.
+pub fn enable_dpi_awareness() {
+    tracing::debug!("macOS handles DPI scaling automatically");
+}
+
+impl Platform for MacOsPlatform {
+    fn get_data_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.data_dir().to_path_buf())
+    }
+
+    fn get_config_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.config_dir().to_path_buf())
+    }
+
+    fn get_cache_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.cache_dir().to_path_buf())
+    }
+
+    fn is_dark_mode_enabled() -> bool {
+        // `defaults read -g AppleInterfaceStyle` prints "Dark" in dark mode
+        // and exits with a non-zero status in light mode (key is absent).
+        let output = Command::new("defaults")
+            .args(["read", "-g", "AppleInterfaceStyle"])
+            .output();
+
+        match output {
+            Ok(out) if out.status.success() => {
+                let text = String::from_utf8_lossy(&out.stdout);
+                let is_dark = text.trim().eq_ignore_ascii_case("dark");
+                if is_dark {
+                    tracing::debug!("macOS dark mode detected");
+                }
+                is_dark
+            }
+            Ok(_) => {
+                // Key absent → light mode
+                tracing::debug!("macOS AppleInterfaceStyle not set, using light mode");
+                false
+            }
+            Err(e) => {
+                tracing::debug!(error = ?e, "failed to run 'defaults' command, using light mode");
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macos_platform_get_data_dir_should_contain_app_name() {
+        let path = MacOsPlatform::get_data_dir().expect("failed to get data dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "data dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn macos_platform_get_config_dir_should_contain_app_name() {
+        let path = MacOsPlatform::get_config_dir().expect("failed to get config dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "config dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn macos_platform_get_cache_dir_should_contain_app_name() {
+        let path = MacOsPlatform::get_cache_dir().expect("failed to get cache dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "cache dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn macos_platform_is_dark_mode_enabled_should_return_bool() {
+        let _ = MacOsPlatform::is_dark_mode_enabled();
+    }
+}

--- a/app/src/platform/mod.rs
+++ b/app/src/platform/mod.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "linux")]
+pub use linux::LinuxPlatform as CurrentPlatform;
+#[cfg(target_os = "macos")]
+pub use macos::MacOsPlatform as CurrentPlatform;
+#[cfg(target_os = "windows")]
+pub use windows::WindowsPlatform as CurrentPlatform;
+
+#[cfg(target_os = "linux")]
+pub use linux::enable_dpi_awareness;
+#[cfg(target_os = "macos")]
+pub use macos::enable_dpi_awareness;
+#[cfg(target_os = "windows")]
+pub use windows::enable_dpi_awareness;
+
+pub(crate) const APP_NAME: &str = "wellfeather";
+
+#[derive(Debug, thiserror::Error)]
+pub enum PlatformError {
+    #[error("cannot determine OS application directory")]
+    DirectoryNotFound,
+}
+
+/// Platform-specific directory resolution and system integration.
+///
+/// Each OS target has a concrete implementation (`WindowsPlatform`, `MacOsPlatform`,
+/// `LinuxPlatform`) aliased to `CurrentPlatform` at compile time.
+pub trait Platform {
+    /// Returns the OS data directory for the application.
+    fn get_data_dir() -> Result<PathBuf, PlatformError>;
+
+    /// Returns the OS config directory for the application.
+    fn get_config_dir() -> Result<PathBuf, PlatformError>;
+
+    /// Returns the OS cache directory for the application.
+    fn get_cache_dir() -> Result<PathBuf, PlatformError>;
+
+    /// Returns `true` when the OS system-wide dark mode is active.
+    ///
+    /// Falls back to `false` (light mode) when detection is unavailable or fails.
+    fn is_dark_mode_enabled() -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_get_config_dir_should_contain_app_name() {
+        let path = CurrentPlatform::get_config_dir().expect("failed to get config directory");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "config dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn platform_get_data_dir_should_contain_app_name() {
+        let path = CurrentPlatform::get_data_dir().expect("failed to get data directory");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "data dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn platform_get_cache_dir_should_contain_app_name() {
+        let path = CurrentPlatform::get_cache_dir().expect("failed to get cache directory");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "cache dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn platform_is_dark_mode_enabled_should_return_bool() {
+        // Smoke test: must not panic; actual value depends on system setting.
+        let _ = CurrentPlatform::is_dark_mode_enabled();
+    }
+}

--- a/app/src/platform/windows.rs
+++ b/app/src/platform/windows.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use directories::ProjectDirs;
+
+use super::{APP_NAME, Platform, PlatformError};
+
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetProcessDpiAwarenessContext,
+};
+
+pub struct WindowsPlatform;
+
+fn project_dirs() -> Result<ProjectDirs, PlatformError> {
+    ProjectDirs::from("", "", APP_NAME).ok_or(PlatformError::DirectoryNotFound)
+}
+
+/// Enables per-monitor DPI awareness V2 on Windows.
+///
+/// Must be called before any window is created (i.e., before `slint::run_event_loop()`).
+/// On Windows versions older than 1703 (Creators Update) this call may fail; a warning is
+/// logged and the application continues with system-DPI scaling instead.
+#[cfg(target_os = "windows")]
+pub fn enable_dpi_awareness() {
+    // SAFETY: SetProcessDpiAwarenessContext is safe to call during application initialisation
+    // before any window has been created.
+    unsafe {
+        match SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) {
+            Ok(()) => tracing::debug!("per-monitor DPI awareness V2 enabled"),
+            Err(e) => tracing::warn!(
+                error = ?e,
+                "failed to enable per-monitor DPI awareness V2; \
+                 display may not scale correctly on high-DPI monitors \
+                 (expected on Windows versions older than 1703)"
+            ),
+        }
+    }
+}
+
+impl Platform for WindowsPlatform {
+    fn get_data_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.data_dir().to_path_buf())
+    }
+
+    fn get_config_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.config_dir().to_path_buf())
+    }
+
+    fn get_cache_dir() -> Result<PathBuf, PlatformError> {
+        Ok(project_dirs()?.cache_dir().to_path_buf())
+    }
+
+    fn is_dark_mode_enabled() -> bool {
+        let output = Command::new("reg")
+            .args([
+                "query",
+                r"HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+                "/v",
+                "AppsUseLightTheme",
+            ])
+            .output();
+
+        match output {
+            Ok(out) if out.status.success() => {
+                let text = String::from_utf8_lossy(&out.stdout);
+                for line in text.lines() {
+                    if line.contains("AppsUseLightTheme")
+                        && line.contains("REG_DWORD")
+                        && let Some(hex) = line.split_whitespace().last()
+                    {
+                        let val = if let Some(h) =
+                            hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X"))
+                        {
+                            u32::from_str_radix(h, 16).unwrap_or(1)
+                        } else {
+                            hex.parse::<u32>().unwrap_or(1)
+                        };
+                        return val == 0;
+                    }
+                }
+                tracing::debug!(
+                    "failed to parse Windows AppsUseLightTheme registry value, defaulting to light"
+                );
+                false
+            }
+            _ => {
+                tracing::debug!("failed to query Windows theme registry, defaulting to light");
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_platform_get_data_dir_should_contain_app_name() {
+        let path = WindowsPlatform::get_data_dir().expect("failed to get data dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "data dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn windows_platform_get_config_dir_should_contain_app_name() {
+        let path = WindowsPlatform::get_config_dir().expect("failed to get config dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "config dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn windows_platform_get_cache_dir_should_contain_app_name() {
+        let path = WindowsPlatform::get_cache_dir().expect("failed to get cache dir");
+        assert!(
+            path.to_string_lossy().contains(APP_NAME),
+            "cache dir {path:?} does not contain app name"
+        );
+    }
+
+    #[test]
+    fn windows_platform_is_dark_mode_enabled_should_return_bool() {
+        let _ = WindowsPlatform::is_dark_mode_enabled();
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a compile-time platform abstraction layer (`app/src/platform/`) with per-OS implementations for directory resolution, DPI awareness, and dark mode detection. This replaces the previous ad-hoc approach in `main.rs` and wires up three platform traits: `WindowsPlatform`, `MacOsPlatform`, and `LinuxPlatform`, each aliased to `CurrentPlatform` at compile time.

## Changes

- `app/src/platform/mod.rs` — `Platform` trait with static methods (`get_data_dir`, `get_config_dir`, `get_cache_dir`, `is_dark_mode_enabled`), `PlatformError`, and `CurrentPlatform` type alias via `#[cfg(target_os)]` dispatch
- `app/src/platform/windows.rs` — `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` via `windows` crate; dark mode via `reg query AppsUseLightTheme` with robust hex parsing (`0x0`, `0x00`, `0x0000`, etc.)
- `app/src/platform/macos.rs` — Dark mode via `defaults read -g AppleInterfaceStyle`; DPI is a no-op (macOS handles it)
- `app/src/platform/linux.rs` — Dark mode via GNOME gsettings (`color-scheme` → `gtk-theme`) then KDE (`kreadconfig6` → `kreadconfig5`) then `GTK_THEME` env fallback; DPI is a no-op
- `app/src/main.rs` — Wired up: tracing init first, then `enable_dpi_awareness()`; `get_config_dir/data_dir/cache_dir` replace hardcoded paths; first-launch dark mode auto-detection via `config_file_exists` check
- `app/Cargo.toml` — Added `directories = "6.0.0"`, `thiserror` (workspace), and Windows-only `windows = "0.62.2"` with `Win32_UI_HiDpi` feature
- 12 unit tests across all three platform modules plus `mod.rs`

## Related Issues

Closes #80

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes