### PR TITLE
feat(xtask): add Linux AppImage packaging via cargo x package --platform linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +35,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -52,8 +52,37 @@ jobs:
           name: wellfeather-macos
           path: packaging/output/*.dmg
 
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y imagemagick
+          wget -q -O /tmp/appimagetool \
+            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          echo "/tmp" >> $GITHUB_PATH
+
+      - name: Build AppImage
+        run: ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 cargo x package --platform linux
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wellfeather-linux
+          path: packaging/output/*.AppImage
+
   create-release:
-    needs: [build-windows, build-macos]
+    needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -79,6 +108,7 @@ jobs:
           files: |
             artifacts/wellfeather-windows/*.msix
             artifacts/wellfeather-macos/*.dmg
+            artifacts/wellfeather-linux/*.AppImage
           draft: false
           generate_release_notes: false
           body_path: release_notes.txt

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -3,3 +3,4 @@ temp/
 *.msix
 *.dmg
 *.app
+*.AppImage

--- a/packaging/linux/wellfeather.desktop
+++ b/packaging/linux/wellfeather.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=wellfeather
+Comment=A lightweight, keyboard-centric SQL client
+Exec=wellfeather
+Icon=wellfeather
+Categories=Development;Database;
+Terminal=false
+StartupNotify=true

--- a/packaging/scripts/build-linux.sh
+++ b/packaging/scripts/build-linux.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Build a Linux AppImage for wellfeather.
+#
+# Prerequisites:
+#   - appimagetool in PATH (https://github.com/AppImage/AppImageKit/releases)
+#   - imagemagick (optional — used for icon resizing; falls back to copy)
+#
+# Usage:
+#   ./build-linux.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Linux AppImage Package ==="
+
+# Build release binary
+echo "Building release binary..."
+cargo build --release
+
+# Read version from Cargo.toml
+VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+echo "Version: $VERSION"
+
+TEMP="$REPO_ROOT/packaging/temp/linux"
+APPDIR="$TEMP/AppDir"
+OUTPUT="$REPO_ROOT/packaging/output"
+
+mkdir -p \
+    "$APPDIR/usr/share/applications" \
+    "$APPDIR/usr/share/icons/hicolor" \
+    "$OUTPUT"
+
+# Copy binary
+cp "$REPO_ROOT/target/release/wellfeather" "$APPDIR/wellfeather"
+chmod +x "$APPDIR/wellfeather"
+
+# Desktop entry
+cp "$REPO_ROOT/packaging/linux/wellfeather.desktop" "$APPDIR/wellfeather.desktop"
+cp "$REPO_ROOT/packaging/linux/wellfeather.desktop" \
+    "$APPDIR/usr/share/applications/wellfeather.desktop"
+
+# Icon assets
+ICON_SRC="$REPO_ROOT/app/assets/icon.png"
+if [[ ! -f "$ICON_SRC" ]]; then
+    echo "error: icon not found at $ICON_SRC" >&2
+    echo "Place a 1024×1024 PNG at app/assets/icon.png before packaging." >&2
+    exit 1
+fi
+
+HAS_MAGICK=0
+command -v magick &>/dev/null && HAS_MAGICK=1
+
+for SIZE in 16 32 48 128 256 512; do
+    ICON_DIR="$APPDIR/usr/share/icons/hicolor/${SIZE}x${SIZE}/apps"
+    mkdir -p "$ICON_DIR"
+    DEST="$ICON_DIR/wellfeather.png"
+    if [[ $HAS_MAGICK -eq 1 ]]; then
+        magick "$ICON_SRC" -resize "${SIZE}x${SIZE}" "$DEST"
+    else
+        echo "warning: ImageMagick not found; copying source PNG for ${SIZE}x${SIZE}"
+        cp "$ICON_SRC" "$DEST"
+    fi
+    # appimagetool requires a root-level icon — use the 256px version
+    if [[ $SIZE -eq 256 ]]; then
+        cp "$DEST" "$APPDIR/wellfeather.png"
+    fi
+done
+
+# Run appimagetool
+if ! command -v appimagetool &>/dev/null; then
+    echo "error: appimagetool not found in PATH." >&2
+    echo "Download from https://github.com/AppImage/AppImageKit/releases" >&2
+    exit 1
+fi
+
+APPIMAGE_PATH="$OUTPUT/wellfeather-$VERSION-x86_64.AppImage"
+rm -f "$APPIMAGE_PATH"
+echo "Running appimagetool..."
+ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 appimagetool "$APPDIR" "$APPIMAGE_PATH"
+
+SIZE_MB=$(du -m "$APPIMAGE_PATH" | cut -f1)
+echo ""
+echo "✓ Package ready: $APPIMAGE_PATH (${SIZE_MB} MB)"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,9 +20,9 @@ enum Commands {
     PreCommit,
     /// Install git pre-commit hook
     InstallHooks,
-    /// Build distribution packages (Windows MSIX, macOS DMG)
+    /// Build distribution packages (Windows MSIX, macOS DMG, Linux AppImage)
     Package {
-        /// Target platform: windows, macos, or all (default: current platform)
+        /// Target platform: windows, macos, linux, or all (default: current platform)
         #[arg(long, default_value = "current")]
         platform: String,
         /// Enable code signing

--- a/xtask/src/package/linux.rs
+++ b/xtask/src/package/linux.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{build_release_binary, prepare_dirs, print_output, workspace_version, PackageConfig};
+
+pub fn build_appimage(config: &PackageConfig) -> Result<()> {
+    let _ = config; // sign/notarize deferred for Linux
+
+    println!("{}", "=== Linux AppImage Package ===".bold().blue());
+
+    build_release_binary()?;
+
+    let version = workspace_version()?;
+    let temp = prepare_dirs("linux")?;
+    let appdir = temp.join("AppDir");
+
+    build_appdir(&appdir, &version)?;
+
+    let output_dir = Path::new("packaging").join("output");
+    let appimage_name = format!("wellfeather-{version}-x86_64.AppImage");
+    let appimage_path = output_dir.join(&appimage_name);
+
+    run_appimagetool(&appdir, &appimage_path)?;
+
+    print_output(&appimage_path)
+}
+
+/// Assemble the AppDir layout required by appimagetool.
+fn build_appdir(appdir: &Path, _version: &str) -> Result<()> {
+    // Remove stale content from previous runs before populating
+    if appdir.exists() {
+        std::fs::remove_dir_all(appdir).context("cannot clean AppDir from previous build")?;
+    }
+
+    // Required subdirectories
+    let app_share = appdir.join("usr").join("share");
+    let icon_base = app_share.join("icons").join("hicolor");
+    let apps_share = app_share.join("applications");
+    std::fs::create_dir_all(&apps_share).context("cannot create AppDir/usr/share/applications")?;
+
+    // Copy release binary
+    let bin_src = Path::new("target").join("release").join("wellfeather");
+    anyhow::ensure!(
+        bin_src.exists(),
+        "release binary not found at {}",
+        bin_src.display()
+    );
+    let bin_dest = appdir.join("wellfeather");
+    std::fs::copy(&bin_src, &bin_dest).context("cannot copy wellfeather binary")?;
+    set_executable(&bin_dest)?;
+
+    // Desktop entry — required at AppDir root AND usr/share/applications/
+    let desktop_template = std::fs::read_to_string("packaging/linux/wellfeather.desktop")
+        .context("cannot read packaging/linux/wellfeather.desktop")?;
+    std::fs::write(appdir.join("wellfeather.desktop"), &desktop_template)
+        .context("cannot write AppDir/wellfeather.desktop")?;
+    std::fs::write(apps_share.join("wellfeather.desktop"), &desktop_template)
+        .context("cannot write AppDir/usr/share/applications/wellfeather.desktop")?;
+
+    // Icon assets
+    let icon_src = Path::new("app").join("assets").join("icon.png");
+    anyhow::ensure!(
+        icon_src.exists(),
+        "icon not found at {}.\n\
+         Please place a 1024×1024 PNG at app/assets/icon.png before packaging.",
+        icon_src.display()
+    );
+    generate_xdg_icons(&icon_src, appdir, &icon_base)?;
+
+    Ok(())
+}
+
+/// Generate XDG icon sizes and place the 256px copy at the AppDir root.
+fn generate_xdg_icons(icon_src: &Path, appdir: &Path, icon_base: &Path) -> Result<()> {
+    let sizes: &[u32] = &[16, 32, 48, 128, 256, 512];
+
+    let has_magick = Command::new("magick")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    for &size in sizes {
+        let dir = icon_base.join(format!("{size}x{size}")).join("apps");
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("cannot create icon dir {size}x{size}"))?;
+        let dest = dir.join("wellfeather.png");
+
+        if has_magick {
+            let status = Command::new("magick")
+                .args([
+                    icon_src.to_str().unwrap(),
+                    "-resize",
+                    &format!("{size}x{size}"),
+                    dest.to_str().unwrap(),
+                ])
+                .status()
+                .context("failed to run magick")?;
+            anyhow::ensure!(status.success(), "magick failed for {size}x{size}");
+        } else {
+            println!(
+                "  {} ImageMagick not found; copying source PNG for {size}x{size}",
+                "warning:".yellow().bold()
+            );
+            std::fs::copy(icon_src, &dest)
+                .with_context(|| format!("cannot copy icon for {size}x{size}"))?;
+        }
+
+        // appimagetool requires a root-level icon; use the 256px version
+        if size == 256 {
+            std::fs::copy(&dest, appdir.join("wellfeather.png"))
+                .context("cannot copy root icon to AppDir")?;
+        }
+    }
+    Ok(())
+}
+
+/// Find `appimagetool` by searching PATH entries (`:` separated on Unix).
+fn find_appimagetool() -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("appimagetool");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn run_appimagetool(appdir: &Path, output: &Path) -> Result<()> {
+    let tool = find_appimagetool().context(
+        "appimagetool not found in PATH.\n\
+         Download it from https://github.com/AppImage/AppImageKit/releases and add it to PATH.\n\
+         On CI: see the build-linux job in .github/workflows/release.yml",
+    )?;
+
+    // Remove existing output so appimagetool does not prompt to overwrite
+    if output.exists() {
+        std::fs::remove_file(output).context("cannot remove existing AppImage")?;
+    }
+
+    println!("  Running appimagetool...");
+    let status = Command::new(&tool)
+        .arg(appdir)
+        .arg(output)
+        .env("ARCH", "x86_64")
+        // Run without FUSE when appimagetool itself is an AppImage (common in CI)
+        .env("APPIMAGE_EXTRACT_AND_RUN", "1")
+        .status()
+        .context("failed to run appimagetool")?;
+    anyhow::ensure!(status.success(), "appimagetool failed");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)
+        .with_context(|| format!("cannot chmod +x {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}

--- a/xtask/src/package/mod.rs
+++ b/xtask/src/package/mod.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+pub mod linux;
 pub mod macos;
 pub mod windows;
 
@@ -25,6 +26,8 @@ impl PackageConfig {
                     "windows"
                 } else if cfg!(target_os = "macos") {
                     "macos"
+                } else if cfg!(target_os = "linux") {
+                    "linux"
                 } else {
                     "all"
                 }
@@ -56,11 +59,13 @@ pub fn run_package(config: &PackageConfig) -> Result<()> {
     match platform {
         "windows" => windows::build_msix(config)?,
         "macos" => macos::build_dmg(config)?,
+        "linux" => linux::build_appimage(config)?,
         "all" => {
             windows::build_msix(config)?;
             macos::build_dmg(config)?;
+            linux::build_appimage(config)?;
         }
-        other => anyhow::bail!("Unknown platform: {other}. Use: windows, macos, or all"),
+        other => anyhow::bail!("Unknown platform: {other}. Use: windows, macos, linux, or all"),
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Extends `cargo x package` with `--platform linux`, producing a self-contained AppImage artifact that runs on any modern Linux distro without installation. Follows the same xtask pattern established by #255 for Windows MSIX and macOS DMG, and adds the corresponding `build-linux` CI job to the release workflow.

## Changes

- `xtask/src/package/linux.rs` (new): AppImage build logic — assembles the AppDir layout (binary, `.desktop`, XDG hicolor icons), calls `appimagetool`, and prints the output path with size
- `packaging/linux/wellfeather.desktop` (new): XDG desktop entry required by appimagetool
- `packaging/scripts/build-linux.sh` (new): Standalone bash alternative for users without the Rust toolchain
- `.github/workflows/release.yml`: Add `build-linux` job; fix `build-windows` and `build-macos` permissions from `contents: write` → `contents: read` (least-privilege); add Linux artifact to `create-release`; remove unnecessary `libfuse2` (replaced by `APPIMAGE_EXTRACT_AND_RUN=1`)
- `xtask/src/package/mod.rs`: Add `pub mod linux;`; update `resolved_platform()` for Linux; dispatch `linux::build_appimage()` in `run_package()` and `--platform all`
- `xtask/src/main.rs`: Update `--platform` help text to include `linux`
- `packaging/.gitignore`: Add `*.AppImage`

Security fixes included:
- AppDir is fully cleaned before each build to prevent stale files from previous runs
- CI build jobs carry only `contents: read`; write access limited to the `create-release` job
- `libfuse2` removed from the dependency list (FUSE is not required when `APPIMAGE_EXTRACT_AND_RUN=1` is set)

## Related Issues

Closes #82

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes