### PR TITLE
feat(ui): add command palette with fuzzy search (Ctrl+K)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "gbm"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6766,6 +6775,7 @@ dependencies = [
  "arboard",
  "chrono",
  "directories",
+ "fuzzy-matcher",
  "regex",
  "rfd",
  "rust-i18n",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -25,6 +25,7 @@ serde              = { workspace = true, features = ["derive"] }
 toml               = "1"
 rust-i18n          = "4.0.0"
 regex              = "1.12.3"
+fuzzy-matcher      = "0.3.7"
 directories        = "6.0.0"
 thiserror          = { workspace = true }
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -29,6 +29,7 @@ import { SnippetListDialog }     from "components/snippet_list_dialog.slint";
 import { SnippetEditDialog }     from "components/snippet_edit_dialog.slint";
 import { SnippetBar }            from "components/snippet_bar.slint";
 import { MetadataSearch }        from "components/metadata_search.slint";
+import { CommandPalette }        from "components/command_palette.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -343,6 +344,18 @@ export global UiState {
     callback metadata-search();
     /// Accept a result: dispatches table-open or column-copy action.
     callback metadata-search-select(string, string, string);  // kind, label, table-name
+
+    // ── Command palette (Ctrl+K) ──────────────────────────────────────────────
+    in-out property <bool>                 show-command-palette:    false;
+    in-out property <string>               command-palette-query:   "";
+    in-out property <[CommandPaletteItem]> command-palette-items:   [];
+    in-out property <int>                  command-palette-selected: 0;
+    /// Open the palette with all commands shown.
+    callback command-palette-open();
+    /// Re-filter the command list by the current query string.
+    callback command-palette-search(string);
+    /// Execute the command identified by id.
+    callback command-palette-execute(string);
 }
 
 export component AppWindow inherits Window {
@@ -490,7 +503,8 @@ export component AppWindow inherits Window {
                     || UiState.show-snippet-save
                     || UiState.show-snippet-list
                     || UiState.show-snippet-edit
-                    || UiState.show-metadata-search) {
+                    || UiState.show-metadata-search
+                    || UiState.show-command-palette) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -522,6 +536,15 @@ export component AppWindow inherits Window {
                     && !event.modifiers.alt
                     && UiState.active-tab-kind-sql
                     && event.text == "f") {
+                UiState.find-bar-with-replace = false;
+                UiState.show-find-bar = true;
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && UiState.active-tab-kind-sql
+                    && event.text == "h") {
+                UiState.find-bar-with-replace = true;
                 UiState.show-find-bar = true;
                 EventResult.accept
             } else if (event.modifiers.control
@@ -541,6 +564,14 @@ export component AppWindow inherits Window {
                 // Ctrl-release (accept) are handled inside MetadataSearch's
                 // capture-key-pressed / capture-key-released, which fire before
                 // this root key-pressed handler when search-input has focus.
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && !event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "k") {
+                if (!UiState.show-command-palette) {
+                    UiState.command-palette-open();
+                }
                 EventResult.accept
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -1264,6 +1295,29 @@ export component AppWindow inherits Window {
                 // without forcing focus — the click already positioned focus naturally.
                 UiState.show-metadata-search  = false;
                 UiState.metadata-search-query = "";
+            }
+        }
+
+        // ── Command palette (Ctrl+K) ───────────────────────────────────────────
+        if UiState.show-command-palette: CommandPalette {
+            x: sidebar-width + (main-width - self.width) / 2;
+            y: menu-bar-height + tab-bar-height + 20px;
+            query          <=> UiState.command-palette-query;
+            items:             UiState.command-palette-items;
+            selected-index <=> UiState.command-palette-selected;
+            search-changed(q) => { UiState.command-palette-search(q); }
+            execute(id) => {
+                UiState.command-palette-execute(id);
+                editor-inst.grab-focus();
+            }
+            close => {
+                UiState.show-command-palette  = false;
+                UiState.command-palette-query = "";
+                editor-inst.grab-focus();
+            }
+            close-on-blur => {
+                UiState.show-command-palette  = false;
+                UiState.command-palette-query = "";
             }
         }
 

--- a/app/src/ui/components/command_palette.slint
+++ b/app/src/ui/components/command_palette.slint
@@ -1,0 +1,233 @@
+import { Colors, Typography, Layout } from "../theme.slint";
+import { CommandPaletteItem } from "../globals.slint";
+
+export component CommandPalette inherits Rectangle {
+    in-out property <string>              query:          "";
+    in property    <[CommandPaletteItem]> items:          [];
+    in-out property <int>                 selected-index: 0;
+    callback search-changed(string);
+    callback execute(string);   // command id
+    callback close();           // Esc — caller should refocus editor
+    callback close-on-blur();   // click outside — caller lets focus remain naturally
+
+    property <length> search-row-h: 44px;
+    property <length> results-h:    clamp(root.items.length * 36px, 0px, 288px);
+
+    width:  560px;
+    height: root.search-row-h + root.results-h;
+
+    background:        Colors.surface0;
+    border-radius:     Layout.radius-md;
+    border-width:      1px;
+    border-color:      Colors.surface1;
+    drop-shadow-blur:  12px;
+    drop-shadow-color: Colors.shadow;
+    clip: true;
+
+    // Mirror of search-input.has-focus for blur detection.
+    property <bool> _input-focused <=> search-input.has-focus;
+
+    // Bridge for results-flick.viewport-y so that changed selected-index
+    // can scroll without crossing the conditional-block scope boundary.
+    property <length> _results-vpy: 0;
+
+    changed query => {
+        root._results-vpy = 0;
+        root.search-changed(root.query);
+    }
+    init => { search-input.focus(); }
+
+    changed _input-focused => {
+        if (!_input-focused) { root.close-on-blur(); }
+    }
+
+    // Auto-scroll to keep highlighted item in view.
+    changed selected-index => {
+        if (root.items.length > 0) {
+            if (root.selected-index * 36px < -root._results-vpy) {
+                root._results-vpy = -(root.selected-index * 36px);
+            } else if ((root.selected-index + 1) * 36px > -root._results-vpy + root.results-h) {
+                root._results-vpy = -((root.selected-index + 1) * 36px - root.results-h);
+            }
+        }
+    }
+
+    palette-focus := FocusScope {
+        focus-on-click: false;
+
+        capture-key-pressed(event) => {
+            if (event.text == Key.Escape) {
+                root.close();
+                EventResult.accept
+            } else if (event.text == Key.UpArrow) {
+                if (root.selected-index > 0) { root.selected-index -= 1; }
+                EventResult.accept
+            } else if (event.text == Key.DownArrow) {
+                if (root.selected-index < root.items.length - 1) { root.selected-index += 1; }
+                EventResult.accept
+            } else if (event.text == Key.Return) {
+                if (root.items.length > 0) {
+                    root.execute(root.items[root.selected-index].id);
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+        VerticalLayout {
+            spacing: 0;
+
+            // ── Search input row ─────────────────────────────────────────────
+            Rectangle {
+                height: root.search-row-h;
+                background: Colors.surface0;
+
+                TouchArea {
+                    mouse-cursor: text;
+                    clicked => { search-input.focus(); }
+                }
+
+                HorizontalLayout {
+                    padding-left:  Layout.padding-sm;
+                    padding-right: Layout.padding-sm;
+                    spacing:       Layout.spacing-md;
+
+                    search-input := TextInput {
+                        horizontal-stretch: 1;
+                        single-line: true;
+                        text <=> root.query;
+                        color: Colors.text;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+                }
+
+                if root.query == "": Text {
+                    x: Layout.padding-sm;
+                    y: 0;
+                    width: parent.width - Layout.padding-sm;
+                    height: parent.height;
+                    text: @tr("Search commands\u{2026}");
+                    color: Colors.overlay0;
+                    font-size: Typography.size-base;
+                    vertical-alignment: center;
+                }
+
+                Rectangle {
+                    x: 0; y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: Colors.surface1;
+                }
+            }
+
+            // ── Results list ─────────────────────────────────────────────────
+            if root.items.length > 0: Rectangle {
+                width: parent.width;
+                height: root.results-h;
+
+                results-flick := Flickable {
+                    width: parent.width;
+                    height: parent.height;
+                    viewport-height: max(self.height, root.items.length * 36px);
+                    viewport-y <=> root._results-vpy;
+
+                    VerticalLayout {
+                        width: parent.width;
+                        spacing: 0;
+
+                        for item[i] in root.items: Rectangle {
+                            height: 36px;
+                            width: root.width;
+                            background: i == root.selected-index ? Colors.sidebar-sel : transparent;
+
+                            HorizontalLayout {
+                                padding-left:  Layout.padding-sm;
+                                padding-right: Layout.padding-sm;
+                                spacing:       Layout.spacing-md;
+
+                                Text {
+                                    horizontal-stretch: 1;
+                                    text: item.label;
+                                    color: Colors.text;
+                                    font-size: Typography.size-base;
+                                    vertical-alignment: center;
+                                    overflow: elide;
+                                }
+
+                                if item.shortcut != "": Text {
+                                    text: item.shortcut;
+                                    color: Colors.subtext1;
+                                    font-size: Typography.size-sm;
+                                    vertical-alignment: center;
+                                }
+                            }
+
+                            TouchArea {
+                                mouse-cursor: pointer;
+                                clicked => { root.execute(item.id); }
+                            }
+                        }
+                    }
+                }
+
+                // ── Scrollbar overlay ─────────────────────────────────────────
+                if results-flick.viewport-height > results-flick.height: Rectangle {
+                    property <length> overflow:   results-flick.viewport-height - results-flick.height;
+                    property <length> track-h:    parent.height - 4px;
+                    property <length> thumb-h:    clamp(results-flick.height * results-flick.height / results-flick.viewport-height, 20px, track-h);
+                    property <length> _press-my:  0px;
+                    property <length> _press-vpy: 0px;
+
+                    x: parent.width - 14px;
+                    width: 14px;
+                    height: parent.height;
+                    background: transparent;
+
+                    Rectangle {
+                        x: 3px; y: 2px;
+                        width: 8px;
+                        height: parent.track-h;
+                        border-radius: 0;
+                        background: Colors.surface1;
+                    }
+
+                    Rectangle {
+                        x: 3px;
+                        y: clamp(
+                            (-results-flick.viewport-y) / parent.overflow * (parent.track-h - parent.thumb-h),
+                            0px,
+                            parent.track-h - parent.thumb-h
+                        ) + 2px;
+                        width: 8px;
+                        height: parent.thumb-h;
+                        border-radius: 0;
+                        background: sb-ta.pressed
+                            ? Colors.subtext0
+                            : sb-ta.has-hover ? Colors.overlay1 : Colors.overlay0;
+                        opacity: sb-ta.pressed ? 1.0 : sb-ta.has-hover ? 0.75 : 0.45;
+                    }
+
+                    sb-ta := TouchArea {
+                        pointer-event(e) => {
+                            if (e.kind == PointerEventKind.down) {
+                                parent._press-my  = self.mouse-y;
+                                parent._press-vpy = results-flick.viewport-y;
+                            }
+                        }
+                        moved => {
+                            results-flick.viewport-y = clamp(
+                                parent._press-vpy
+                                    - (self.mouse-y - parent._press-my)
+                                    * parent.overflow
+                                    / (parent.track-h - parent.thumb-h),
+                                -parent.overflow,
+                                0px
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -68,6 +68,12 @@ export struct MetadataSearchResult {
     table-name: string, // parent table name (= label for tables/views)
 }
 
+export struct CommandPaletteItem {
+    id: string,
+    label: string,
+    shortcut: string,
+}
+
 /// One syntax-highlight span rendered as a colored Text element over the editor text.
 /// kind: 0=keyword, 1=string-literal, 2=comment, 3=number, 4=identifier (gap fill)
 export struct HighlightSpan {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -590,6 +590,7 @@ impl UI {
         Self::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
         Self::register_status_callbacks(&window, state.clone());
         Self::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
+        Self::register_command_palette_callbacks(&window);
         Self::register_highlight_callbacks(&window, hl_model.clone());
 
         // Highlight the editor text that was already set from session / tab restore.
@@ -3481,6 +3482,57 @@ impl UI {
         }
     }
 
+    // ── Command palette (Ctrl+K) ──────────────────────────────────────────────
+
+    fn register_command_palette_callbacks(window: &crate::AppWindow) {
+        let ui = window.global::<crate::UiState>();
+
+        // command-palette-open: populate with all commands (unfiltered), show palette.
+        {
+            let window_weak = window.as_weak(); // clone required: on_command_palette_open closure
+            ui.on_command_palette_open(move || {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                ui.set_command_palette_query("".into());
+                ui.set_command_palette_selected(0);
+                let items = palette_items_to_slint(ALL_COMMANDS);
+                ui.set_command_palette_items(Rc::new(slint::VecModel::from(items)).into());
+                ui.set_show_command_palette(true);
+            });
+        }
+
+        // command-palette-search: fuzzy-filter the command list.
+        {
+            let window_weak = window.as_weak(); // clone required: on_command_palette_search closure
+            ui.on_command_palette_search(move |query| {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                let matched = fuzzy_filter_commands(query.as_str());
+                let items = palette_items_to_slint(&matched);
+                ui.set_command_palette_items(Rc::new(slint::VecModel::from(items)).into());
+                ui.set_command_palette_selected(0);
+            });
+        }
+
+        // command-palette-execute: close palette then dispatch the chosen command.
+        {
+            let window_weak = window.as_weak(); // clone required: on_command_palette_execute closure
+            ui.on_command_palette_execute(move |id| {
+                let Some(w) = window_weak.upgrade() else {
+                    return;
+                };
+                let ui = w.global::<crate::UiState>();
+                ui.set_show_command_palette(false);
+                ui.set_command_palette_query("".into());
+                dispatch_palette_command(&ui, id.as_str());
+            });
+        }
+    }
+
     // ── Status callbacks (TODO) ───────────────────────────────────────────────
 
     fn register_status_callbacks(_window: &crate::AppWindow, _state: SharedState) {
@@ -4246,6 +4298,150 @@ fn parse_col_eq(query: &str) -> Option<(String, &str)> {
     let rest = parts.next()?.trim();
     let val = rest.strip_prefix('\'')?.strip_suffix('\'')?;
     Some((col.to_string(), val))
+}
+
+// ---------------------------------------------------------------------------
+// Command palette
+// ---------------------------------------------------------------------------
+
+/// Static command registry: (id, label, shortcut).
+///
+/// `label` is the English display string; it is matched by the fuzzy filter
+/// and shown in the palette.  `shortcut` is purely informational.
+const ALL_COMMANDS: &[(&str, &str, &str)] = &[
+    ("run-all", "Run All Queries", "Ctrl+Shift+Enter"),
+    ("cancel-query", "Cancel Query", "Esc"),
+    ("format-sql", "Format SQL", "Ctrl+Shift+F"),
+    ("find", "Find in Editor", "Ctrl+F"),
+    ("find-replace", "Find and Replace", "Ctrl+H"),
+    ("new-tab", "New Tab", "Ctrl+T"),
+    ("close-tab", "Close Tab", "Ctrl+W"),
+    ("next-tab", "Next Tab", "Ctrl+Tab"),
+    ("prev-tab", "Previous Tab", "Ctrl+Shift+Tab"),
+    ("toggle-snippet-bar", "Toggle Snippet Bar", "Ctrl+B"),
+    ("open-metadata-search", "Metadata Search", "Ctrl+P"),
+    ("save-snippet", "Save Snippet", "Ctrl+D"),
+    ("show-snippets", "Show Snippets", ""),
+    ("export-csv", "Export CSV", ""),
+    ("export-json", "Export JSON", ""),
+    ("export-insert-sql", "Export Insert SQL", ""),
+    ("open-db-manager", "Manage Connections", ""),
+    ("disconnect", "Disconnect", ""),
+    ("toggle-theme", "Toggle Theme", ""),
+    ("toggle-reduce-motion", "Toggle Reduce Motion", ""),
+];
+
+/// Filter `ALL_COMMANDS` by `query` using fuzzy matching.
+///
+/// Returns all commands (ordered) when `query` is empty.
+/// Otherwise ranks matches by score (highest first).
+fn fuzzy_filter_commands(query: &str) -> Vec<(&'static str, &'static str, &'static str)> {
+    if query.is_empty() {
+        return ALL_COMMANDS.to_vec();
+    }
+    use fuzzy_matcher::FuzzyMatcher as _;
+    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
+    let mut scored: Vec<(i64, &(&str, &str, &str))> = ALL_COMMANDS
+        .iter()
+        .filter_map(|cmd| matcher.fuzzy_match(cmd.1, query).map(|s| (s, cmd)))
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.into_iter().map(|(_, cmd)| *cmd).collect()
+}
+
+/// Convert `(id, label, shortcut)` tuples to Slint `CommandPaletteItem` values.
+fn palette_items_to_slint(items: &[(&str, &str, &str)]) -> Vec<crate::CommandPaletteItem> {
+    items
+        .iter()
+        .map(|(id, label, shortcut)| crate::CommandPaletteItem {
+            id: (*id).into(),
+            label: (*label).into(),
+            shortcut: (*shortcut).into(),
+        })
+        .collect()
+}
+
+/// Dispatch a command palette selection to the appropriate `UiState` action.
+///
+/// Called on the Slint event-loop thread so `ui.invoke_*` and property setters
+/// are safe to call directly.
+fn dispatch_palette_command(ui: &crate::UiState, id: &str) {
+    match id {
+        "run-all" => {
+            let sql = ui.get_editor_text().to_string();
+            ui.invoke_run_all(sql.into());
+        }
+        "cancel-query" => {
+            ui.invoke_cancel_query();
+        }
+        "format-sql" => {
+            ui.invoke_format_sql();
+        }
+        "find" => {
+            if ui.get_active_tab_kind_sql() {
+                ui.set_find_bar_with_replace(false);
+                ui.set_show_find_bar(true);
+            }
+        }
+        "find-replace" => {
+            if ui.get_active_tab_kind_sql() {
+                ui.set_find_bar_with_replace(true);
+                ui.set_show_find_bar(true);
+            }
+        }
+        "new-tab" => {
+            ui.invoke_new_tab();
+        }
+        "close-tab" => {
+            ui.invoke_close_tab(ui.get_active_tab_index());
+        }
+        "next-tab" => {
+            let n = ui.get_tabs().row_count() as i32;
+            if n > 0 {
+                ui.invoke_switch_tab((ui.get_active_tab_index() + 1) % n);
+            }
+        }
+        "prev-tab" => {
+            let n = ui.get_tabs().row_count() as i32;
+            if n > 0 {
+                ui.invoke_switch_tab((ui.get_active_tab_index() + n - 1) % n);
+            }
+        }
+        "toggle-snippet-bar" => {
+            ui.set_show_snippet_bar(!ui.get_show_snippet_bar());
+        }
+        "open-metadata-search" => {
+            ui.invoke_metadata_search_open();
+        }
+        "save-snippet" => {
+            ui.invoke_open_snippet_save(0, 0);
+        }
+        "show-snippets" => {
+            ui.set_show_snippet_list(true);
+        }
+        "export-csv" => {
+            ui.invoke_export_csv();
+        }
+        "export-json" => {
+            ui.invoke_export_json();
+        }
+        "export-insert-sql" => {
+            ui.invoke_export_insert_sql();
+        }
+        "open-db-manager" => {
+            ui.invoke_open_db_manager();
+        }
+        "disconnect" => {
+            ui.invoke_disconnect(ui.get_active_connection_id());
+        }
+        "toggle-theme" => {
+            ui.invoke_toggle_theme();
+        }
+        "toggle-reduce-motion" => {
+            ui.invoke_toggle_reduce_motion();
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -4345,7 +4345,7 @@ fn fuzzy_filter_commands(query: &str) -> Vec<(&'static str, &'static str, &'stat
         .iter()
         .filter_map(|cmd| matcher.fuzzy_match(cmd.1, query).map(|s| (s, cmd)))
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
     scored.into_iter().map(|(_, cmd)| *cmd).collect()
 }
 
@@ -4377,17 +4377,13 @@ fn dispatch_palette_command(ui: &crate::UiState, id: &str) {
         "format-sql" => {
             ui.invoke_format_sql();
         }
-        "find" => {
-            if ui.get_active_tab_kind_sql() {
-                ui.set_find_bar_with_replace(false);
-                ui.set_show_find_bar(true);
-            }
+        "find" if ui.get_active_tab_kind_sql() => {
+            ui.set_find_bar_with_replace(false);
+            ui.set_show_find_bar(true);
         }
-        "find-replace" => {
-            if ui.get_active_tab_kind_sql() {
-                ui.set_find_bar_with_replace(true);
-                ui.set_show_find_bar(true);
-            }
+        "find-replace" if ui.get_active_tab_kind_sql() => {
+            ui.set_find_bar_with_replace(true);
+            ui.set_show_find_bar(true);
         }
         "new-tab" => {
             ui.invoke_new_tab();


### PR DESCRIPTION
## Summary

Implements the command palette (Ctrl+K) described in issue #63. A floating search popup appears over the editor, listing all available app commands with real-time fuzzy filtering powered by `fuzzy-matcher` (SkimMatcherV2). Commands are keyboard-navigable and executing any command returns focus to the editor immediately, enabling continuous keyboard-driven workflows. Also wires Ctrl+H as a direct shortcut for Find and Replace.

## Changes

- `app/src/ui/components/command_palette.slint` (new): palette component modeled after `MetadataSearch` — FocusScope key navigation (↑/↓/Enter/Esc), scrollable list with right-aligned shortcut badges, blur-to-close
- `app/src/ui/globals.slint`: add `CommandPaletteItem { id, label, shortcut }` struct
- `app/src/ui/app.slint`: import component; add `UiState` properties and callbacks (`command-palette-open/search/execute`); add Ctrl+K shortcut to root FocusScope; add Ctrl+H shortcut for Find and Replace; guard global shortcuts against palette-open state; instantiate `CommandPalette` with `editor-inst.grab-focus()` after every execute
- `app/src/ui/mod.rs`: `register_command_palette_callbacks` with three handlers (open/search/execute); `ALL_COMMANDS` static registry (20 commands); `fuzzy_filter_commands` using `SkimMatcherV2`; `dispatch_palette_command` dispatching to existing `UiState` callbacks; find/find-replace commands guarded by `active-tab-kind-sql` to prevent state pollution on Table View tabs
- `app/Cargo.toml`: add `fuzzy-matcher = "0.3.7"`

## Related Issues

Closes #63

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes