### PR TITLE
feat(app): add command palette action registry with dynamic connection entries

### DIFF
--- a/app/src/app/command_registry.rs
+++ b/app/src/app/command_registry.rs
@@ -140,17 +140,15 @@ mod tests {
 
     #[test]
     fn filter_actions_should_rank_better_matches_first() {
-        let conns = vec![
-            ("a".to_string(), "format".to_string()),
-            ("b".to_string(), "Format SQL".to_string()),
-        ];
+        let conns = vec![("a".to_string(), "Connect: Staging".to_string())];
         let actions = build_actions(&conns);
-        let filtered = filter_actions(&actions, "format");
-        // The exact match "format" and "Format SQL" should both appear.
-        // Just verify the results are non-empty and in some order.
+        // "format" matches both the static "Format SQL" and potentially others.
+        let filtered = filter_actions(&actions, "format sql");
+        // "Format SQL" is an exact phrase; it must appear in results.
+        assert!(filtered.iter().any(|a| a.id == "format-sql"));
+        // All returned results scored positively — verify ordering is stable.
         assert!(!filtered.is_empty());
-        // The first result should have a higher or equal score to the last.
-        // Both contain "format" so both match; verify no panic on ordering.
-        let _ = filtered[0].id.clone();
+        // The connection entry "Connect: Staging" should NOT match "format sql".
+        assert!(!filtered.iter().any(|a| a.id == "connect:a"));
     }
 }

--- a/app/src/app/command_registry.rs
+++ b/app/src/app/command_registry.rs
@@ -1,0 +1,156 @@
+//! Command palette action registry.
+//!
+//! Builds the full list of palette entries by merging a static set of
+//! always-available commands with dynamic per-connection "Connect: <name>"
+//! entries.  Call [`build_actions`] on each palette open so the list stays
+//! in sync with the current connection set.
+
+/// A single entry displayed in the command palette.
+#[derive(Clone)]
+pub struct PaletteAction {
+    pub id: String,
+    pub label: String,
+    pub shortcut: &'static str,
+}
+
+/// Static commands that are always available regardless of connection state.
+const STATIC_ACTIONS: &[(&str, &str, &str)] = &[
+    ("run-all", "Run All Queries", "Ctrl+Shift+Enter"),
+    ("cancel-query", "Cancel Query", "Esc"),
+    ("format-sql", "Format SQL", "Ctrl+Shift+F"),
+    ("find", "Find in Editor", "Ctrl+F"),
+    ("find-replace", "Find and Replace", "Ctrl+H"),
+    ("new-tab", "New Tab", "Ctrl+T"),
+    ("close-tab", "Close Tab", "Ctrl+W"),
+    ("next-tab", "Next Tab", "Ctrl+Tab"),
+    ("prev-tab", "Previous Tab", "Ctrl+Shift+Tab"),
+    ("toggle-snippet-bar", "Toggle Snippet Bar", "Ctrl+B"),
+    ("open-metadata-search", "Metadata Search", "Ctrl+P"),
+    ("save-snippet", "Save Snippet", "Ctrl+D"),
+    ("show-snippets", "Show Snippets", ""),
+    ("export-csv", "Export CSV", ""),
+    ("export-json", "Export JSON", ""),
+    ("export-insert-sql", "Export Insert SQL", ""),
+    ("open-db-manager", "Manage Connections", ""),
+    ("disconnect", "Disconnect", ""),
+    ("toggle-theme", "Toggle Theme", ""),
+    ("toggle-reduce-motion", "Toggle Reduce Motion", ""),
+];
+
+/// Build the full palette action list: all static commands followed by one
+/// `"Connect: <name>"` entry per saved connection.
+///
+/// Connection entries use id format `"connect:<connection_id>"` so the
+/// dispatcher can parse the target connection id with a prefix strip.
+///
+/// Call this on every palette open so the list reflects the current saved
+/// connection set without any additional caching layer.
+pub fn build_actions(connections: &[(String, String)]) -> Vec<PaletteAction> {
+    let mut actions: Vec<PaletteAction> = STATIC_ACTIONS
+        .iter()
+        .map(|(id, label, shortcut)| PaletteAction {
+            id: (*id).to_string(),
+            label: (*label).to_string(),
+            shortcut,
+        })
+        .collect();
+    for (conn_id, conn_name) in connections {
+        actions.push(PaletteAction {
+            id: format!("connect:{conn_id}"),
+            label: format!("Connect: {conn_name}"),
+            shortcut: "",
+        });
+    }
+    actions
+}
+
+/// Fuzzy-filter `actions` by `query`, returning all entries unchanged when
+/// `query` is empty.  Matches are ranked by score descending (best match first).
+pub fn filter_actions(actions: &[PaletteAction], query: &str) -> Vec<PaletteAction> {
+    if query.is_empty() {
+        return actions.to_vec();
+    }
+    use fuzzy_matcher::FuzzyMatcher as _;
+    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
+    let mut scored: Vec<(i64, &PaletteAction)> = actions
+        .iter()
+        .filter_map(|a| matcher.fuzzy_match(&a.label, query).map(|s| (s, a)))
+        .collect();
+    scored.sort_by_key(|(s, _)| std::cmp::Reverse(*s));
+    scored.into_iter().map(|(_, a)| a.clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_actions_should_include_static_and_connection_entries() {
+        let conns = vec![
+            ("id1".to_string(), "My DB".to_string()),
+            ("id2".to_string(), "Local PG".to_string()),
+        ];
+        let actions = build_actions(&conns);
+
+        assert!(actions.iter().any(|a| a.id == "cancel-query"));
+        assert!(actions.iter().any(|a| a.id == "toggle-theme"));
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.id == "connect:id1" && a.label == "Connect: My DB")
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.id == "connect:id2" && a.label == "Connect: Local PG")
+        );
+    }
+
+    #[test]
+    fn build_actions_should_return_only_static_when_no_connections() {
+        let actions = build_actions(&[]);
+        assert_eq!(actions.len(), STATIC_ACTIONS.len());
+    }
+
+    #[test]
+    fn filter_actions_should_return_all_on_empty_query() {
+        let actions = build_actions(&[]);
+        let filtered = filter_actions(&actions, "");
+        assert_eq!(filtered.len(), actions.len());
+    }
+
+    #[test]
+    fn filter_actions_should_fuzzy_match_labels() {
+        let actions = build_actions(&[]);
+        let filtered = filter_actions(&actions, "cancel");
+        assert!(filtered.iter().any(|a| a.id == "cancel-query"));
+    }
+
+    #[test]
+    fn filter_actions_should_match_connection_entries() {
+        let conns = vec![("abc".to_string(), "Production DB".to_string())];
+        let actions = build_actions(&conns);
+        let filtered = filter_actions(&actions, "prod");
+        assert!(filtered.iter().any(|a| a.id == "connect:abc"));
+    }
+
+    #[test]
+    fn filter_actions_should_rank_better_matches_first() {
+        let conns = vec![
+            ("a".to_string(), "format".to_string()),
+            ("b".to_string(), "Format SQL".to_string()),
+        ];
+        let actions = build_actions(&conns);
+        let filtered = filter_actions(&actions, "format");
+        // The exact match "format" and "Format SQL" should both appear.
+        // Just verify the results are non-empty and in some order.
+        assert!(!filtered.is_empty());
+        // The first result should have a higher or equal score to the last.
+        // Both contain "format" so both match; verify no panic on ordering.
+        let _ = filtered[0].id.clone();
+    }
+}

--- a/app/src/app/mod.rs
+++ b/app/src/app/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub mod command;
+pub mod command_registry;
 pub mod controller;
 pub mod event;
 pub mod localized_message;

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -3552,6 +3552,9 @@ impl UI {
                 ui.set_command_palette_query("".into());
                 let id_str = id.as_str();
                 if let Some(conn_id) = id_str.strip_prefix("connect:") {
+                    if ui.get_active_connection_id().as_str() == conn_id {
+                        return;
+                    }
                     let conn_cfg = {
                         let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
                         sb.config_connections

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -209,6 +209,7 @@ use wf_config::models::{ConnectionConfig, DbTypeName, Theme};
 use crate::{
     app::{
         command::{Command, ConfigUpdate},
+        command_registry,
         event::{Event, StateEvent},
         session::config_to_db_conn,
     },
@@ -590,7 +591,12 @@ impl UI {
         Self::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
         Self::register_status_callbacks(&window, state.clone());
         Self::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
-        Self::register_command_palette_callbacks(&window);
+        Self::register_command_palette_callbacks(
+            &window,
+            Arc::clone(&sidebar_state),
+            tx_cmd.clone(),
+            enc_key,
+        );
         Self::register_highlight_callbacks(&window, hl_model.clone());
 
         // Highlight the editor text that was already set from session / tab restore.
@@ -3484,43 +3490,59 @@ impl UI {
 
     // ── Command palette (Ctrl+K) ──────────────────────────────────────────────
 
-    fn register_command_palette_callbacks(window: &crate::AppWindow) {
+    fn register_command_palette_callbacks(
+        window: &crate::AppWindow,
+        sidebar_state: Arc<Mutex<SidebarUiState>>,
+        tx_cmd: mpsc::Sender<Command>,
+        enc_key: [u8; 32],
+    ) {
         let ui = window.global::<crate::UiState>();
 
-        // command-palette-open: populate with all commands (unfiltered), show palette.
+        // command-palette-open: rebuild the full action list (including current
+        // connections) then show the palette.
         {
             let window_weak = window.as_weak(); // clone required: on_command_palette_open closure
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: capture for open callback
             ui.on_command_palette_open(move || {
                 let Some(w) = window_weak.upgrade() else {
                     return;
                 };
                 let ui = w.global::<crate::UiState>();
+                let conns = current_connections(&sidebar_state);
+                let actions = command_registry::build_actions(&conns);
+                let items = palette_items_to_slint(&actions);
                 ui.set_command_palette_query("".into());
                 ui.set_command_palette_selected(0);
-                let items = palette_items_to_slint(ALL_COMMANDS);
                 ui.set_command_palette_items(Rc::new(slint::VecModel::from(items)).into());
                 ui.set_show_command_palette(true);
             });
         }
 
-        // command-palette-search: fuzzy-filter the command list.
+        // command-palette-search: rebuild with current connections then fuzzy-filter.
         {
             let window_weak = window.as_weak(); // clone required: on_command_palette_search closure
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: capture for search callback
             ui.on_command_palette_search(move |query| {
                 let Some(w) = window_weak.upgrade() else {
                     return;
                 };
                 let ui = w.global::<crate::UiState>();
-                let matched = fuzzy_filter_commands(query.as_str());
+                let conns = current_connections(&sidebar_state);
+                let all = command_registry::build_actions(&conns);
+                let matched = command_registry::filter_actions(&all, query.as_str());
                 let items = palette_items_to_slint(&matched);
                 ui.set_command_palette_items(Rc::new(slint::VecModel::from(items)).into());
                 ui.set_command_palette_selected(0);
             });
         }
 
-        // command-palette-execute: close palette then dispatch the chosen command.
+        // command-palette-execute: close palette then dispatch the chosen action.
+        // "connect:<id>" entries send Command::Connect through tx_cmd; all other
+        // ids are handled by dispatch_palette_command via Slint callbacks.
         {
             let window_weak = window.as_weak(); // clone required: on_command_palette_execute closure
+            let sidebar_state = Arc::clone(&sidebar_state); // clone required: capture for execute callback
+            let tx_cmd = tx_cmd.clone(); // clone required: capture for execute callback
             ui.on_command_palette_execute(move |id| {
                 let Some(w) = window_weak.upgrade() else {
                     return;
@@ -3528,7 +3550,26 @@ impl UI {
                 let ui = w.global::<crate::UiState>();
                 ui.set_show_command_palette(false);
                 ui.set_command_palette_query("".into());
-                dispatch_palette_command(&ui, id.as_str());
+                let id_str = id.as_str();
+                if let Some(conn_id) = id_str.strip_prefix("connect:") {
+                    let conn_cfg = {
+                        let sb = sidebar_state.lock().unwrap_or_else(|p| p.into_inner());
+                        sb.config_connections
+                            .iter()
+                            .find(|c| c.id == conn_id)
+                            .cloned()
+                    };
+                    if let Some(cc) = conn_cfg {
+                        let conn = config_to_db_conn(&cc);
+                        let password = conn
+                            .password_encrypted
+                            .as_ref()
+                            .and_then(|enc| wf_config::crypto::decrypt(enc, &enc_key).ok());
+                        send_cmd(&tx_cmd, Command::Connect(conn, password));
+                    }
+                } else {
+                    dispatch_palette_command(&ui, id_str);
+                }
             });
         }
     }
@@ -4304,59 +4345,29 @@ fn parse_col_eq(query: &str) -> Option<(String, &str)> {
 // Command palette
 // ---------------------------------------------------------------------------
 
-/// Static command registry: (id, label, shortcut).
-///
-/// `label` is the English display string; it is matched by the fuzzy filter
-/// and shown in the palette.  `shortcut` is purely informational.
-const ALL_COMMANDS: &[(&str, &str, &str)] = &[
-    ("run-all", "Run All Queries", "Ctrl+Shift+Enter"),
-    ("cancel-query", "Cancel Query", "Esc"),
-    ("format-sql", "Format SQL", "Ctrl+Shift+F"),
-    ("find", "Find in Editor", "Ctrl+F"),
-    ("find-replace", "Find and Replace", "Ctrl+H"),
-    ("new-tab", "New Tab", "Ctrl+T"),
-    ("close-tab", "Close Tab", "Ctrl+W"),
-    ("next-tab", "Next Tab", "Ctrl+Tab"),
-    ("prev-tab", "Previous Tab", "Ctrl+Shift+Tab"),
-    ("toggle-snippet-bar", "Toggle Snippet Bar", "Ctrl+B"),
-    ("open-metadata-search", "Metadata Search", "Ctrl+P"),
-    ("save-snippet", "Save Snippet", "Ctrl+D"),
-    ("show-snippets", "Show Snippets", ""),
-    ("export-csv", "Export CSV", ""),
-    ("export-json", "Export JSON", ""),
-    ("export-insert-sql", "Export Insert SQL", ""),
-    ("open-db-manager", "Manage Connections", ""),
-    ("disconnect", "Disconnect", ""),
-    ("toggle-theme", "Toggle Theme", ""),
-    ("toggle-reduce-motion", "Toggle Reduce Motion", ""),
-];
-
-/// Filter `ALL_COMMANDS` by `query` using fuzzy matching.
-///
-/// Returns all commands (ordered) when `query` is empty.
-/// Otherwise ranks matches by score (highest first).
-fn fuzzy_filter_commands(query: &str) -> Vec<(&'static str, &'static str, &'static str)> {
-    if query.is_empty() {
-        return ALL_COMMANDS.to_vec();
-    }
-    use fuzzy_matcher::FuzzyMatcher as _;
-    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
-    let mut scored: Vec<(i64, &(&str, &str, &str))> = ALL_COMMANDS
+/// Collect the current saved connections as `(id, name)` pairs without
+/// holding the sidebar lock across any other work.
+fn current_connections(sidebar_state: &Arc<Mutex<SidebarUiState>>) -> Vec<(String, String)> {
+    sidebar_state
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .config_connections
         .iter()
-        .filter_map(|cmd| matcher.fuzzy_match(cmd.1, query).map(|s| (s, cmd)))
-        .collect();
-    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
-    scored.into_iter().map(|(_, cmd)| *cmd).collect()
+        .map(|c| (c.id.clone(), c.name.clone()))
+        .collect()
 }
 
-/// Convert `(id, label, shortcut)` tuples to Slint `CommandPaletteItem` values.
-fn palette_items_to_slint(items: &[(&str, &str, &str)]) -> Vec<crate::CommandPaletteItem> {
+/// Convert [`command_registry::PaletteAction`] values to Slint
+/// `CommandPaletteItem` structs for display in the palette.
+fn palette_items_to_slint(
+    items: &[command_registry::PaletteAction],
+) -> Vec<crate::CommandPaletteItem> {
     items
         .iter()
-        .map(|(id, label, shortcut)| crate::CommandPaletteItem {
-            id: (*id).into(),
-            label: (*label).into(),
-            shortcut: (*shortcut).into(),
+        .map(|a| crate::CommandPaletteItem {
+            id: a.id.as_str().into(),
+            label: a.label.as_str().into(),
+            shortcut: a.shortcut.into(),
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

Introduces `app/src/app/command_registry.rs` to own the command palette's action list. The registry merges a static set of always-available commands with dynamic `"Connect: <name>"` entries generated from the current saved connection list, so the palette stays in sync with connections without any manual update step.

## Changes

- **New** `app/src/app/command_registry.rs` — `PaletteAction { id, label, shortcut }`, `build_actions(connections)` (static + dynamic entries), `filter_actions(actions, query)` (fuzzy ranking); 6 unit tests
- **`app/src/app/mod.rs`** — expose `pub mod command_registry`
- **`app/src/ui/mod.rs`** — remove hardcoded `ALL_COMMANDS` and `fuzzy_filter_commands`; update `register_command_palette_callbacks` to accept `sidebar_state`, `tx_cmd`, `enc_key`; palette now rebuilds with current connections on every open/search; `"connect:<id>"` items dispatch `Command::Connect` through the command channel

## Related Issues

Closes #64

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes