### PR TITLE
refactor(app): remove blanket dead_code suppression and dead items

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -1,22 +1,11 @@
-use std::path::PathBuf;
-
 use wf_config::models::{PageSize, Theme};
 use wf_db::models::DbConnection;
-
-/// Format for result export.
-#[derive(Debug)]
-pub enum ExportFormat {
-    Csv,
-    Json,
-}
 
 /// Granular config change sent from the UI.
 #[derive(Debug)]
 pub enum ConfigUpdate {
     Theme(Theme),
     PageSize(PageSize),
-    FontFamily(String),
-    FontSize(u32),
     Language(String),
     /// Update only safe_dml / read_only flags for an existing connection entry.
     ConnectionFlags {
@@ -41,11 +30,9 @@ pub enum Command {
     Disconnect(String),       // connection_id
     RemoveConnection(String), // connection_id — disconnect + delete from config
     RunQuery(String),         // sql
-    RunSelection(String),     // sql (selected range)
     RunAll(String),           // sql (entire editor)
     CancelQuery,
     FetchCompletion(String, usize), // sql, cursor_pos
-    ExportResult(ExportFormat, PathBuf),
     UpdateConfig(ConfigUpdate),
     /// Fetch the DDL CREATE statement for `name` (table/view/index) on `conn_id`.
     FetchDdl {

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -110,11 +110,10 @@ impl AppController {
                 Command::RemoveConnection(id) => this.handle_remove_connection(id).await,
                 Command::RunQuery(sql) => this.handle_run_query(sql).await,
                 Command::RunAll(sql) => this.handle_run_all(sql).await,
-                Command::RunSelection(sql) => this.handle_run_query(sql).await,
                 Command::CancelQuery => this.handle_cancel_query().await,
                 Command::UpdateConfig(update) => this.handle_update_config(update).await,
                 Command::FetchCompletion(sql, cursor_pos) => {
-                    this.handle_fetch_completion(sql, cursor_pos).await;
+                    this.handle_fetch_completion(sql, cursor_pos).await
                 }
                 Command::FetchDdl {
                     tab_id,
@@ -131,7 +130,6 @@ impl AppController {
                     this.handle_fetch_table_data(tab_id, conn_id, table_name, page_size)
                         .await
                 }
-                Command::ExportResult(_, _) => {} // handled client-side in UI layer
             }
         }
     }
@@ -509,7 +507,6 @@ impl AppController {
                     warn!(error = %e, "failed to persist reduce_motion to config");
                 }
             }
-            _ => {}
         }
     }
 

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -5,11 +5,7 @@ use wf_db::models::{DbMetadata, QueryResult};
 /// Fine-grained state transitions forwarded to the UI via `StateChanged`.
 #[derive(Debug)]
 pub enum StateEvent {
-    QueryStarted,
-    QueryFinished(QueryResult),
-    ConnectionChanged(String),
     ThemeChanged(Theme),
-    LoadingChanged(bool),
 }
 
 /// Controller → UI channel messages.
@@ -38,8 +34,6 @@ pub enum Event {
     CompletionReady(Vec<CompletionItem>),
     MetadataLoaded(String, DbMetadata), // conn_id, metadata
     MetadataFetchFailed(String),
-    /// Insert text into the SQL editor (append after existing content).
-    InsertText(String),
     ConfigUpdated,
     /// Fired after `ConfigUpdate::ConnectionFlags` is persisted.
     /// Carries the connection id and the new `read_only` value so the sidebar

--- a/app/src/app/mod.rs
+++ b/app/src/app/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub mod command;
 pub mod command_registry;
 pub mod controller;

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -43,7 +43,8 @@ impl SessionManager {
 
     /// Create a `SessionManager` backed by an arbitrary [`ConfigManager`].
     ///
-    /// Primarily used in tests to point at a temporary directory.
+    /// Used in tests to point at a temporary directory.
+    #[cfg(test)]
     pub fn with_config_manager(cm: ConfigManager) -> Self {
         Self { config_manager: cm }
     }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -737,7 +737,6 @@ impl UI {
                     Event::MetadataFetchFailed(msg) => {
                         Self::handle_metadata_fetch_failed(msg, window_weak.clone())
                     }
-                    Event::InsertText(text) => Self::handle_insert_text(text, window_weak.clone()),
                     Event::CompletionReady(items) => {
                         Self::handle_completion_ready(items, window_weak.clone())
                     }
@@ -1126,16 +1125,6 @@ impl UI {
                         .to_string()
                         .into(),
                 );
-            });
-        });
-    }
-
-    fn handle_insert_text(text: String, ww: slint::Weak<crate::AppWindow>) {
-        // clone required: invoke_from_event_loop closure must be 'static
-        let _ = slint::invoke_from_event_loop(move || {
-            with_ui(&ww, move |ui| {
-                let current = ui.get_editor_text().to_string();
-                ui.set_editor_text(append_editor_text(&current, &text).into());
             });
         });
     }
@@ -3817,19 +3806,6 @@ fn sql_has_from(sql: &str) -> bool {
         || upper.contains("\nFROM ")
         || upper.contains("\tFROM ")
         || upper.starts_with("FROM ")
-}
-
-/// Append `text` to `current` editor content with a newline separator.
-/// If `current` is empty the text is used as-is.
-/// If `current` already ends with `\n` the text is appended directly.
-fn append_editor_text(current: &str, text: &str) -> String {
-    if current.is_empty() {
-        text.to_string()
-    } else if current.ends_with('\n') {
-        format!("{}{}", current, text)
-    } else {
-        format!("{}\n{}", current, text)
-    }
 }
 
 /// Build a `DbConnection` from the current values in the connection form global,

--- a/app/src/ui/tests.rs
+++ b/app/src/ui/tests.rs
@@ -386,29 +386,6 @@ fn result_to_tsv_should_produce_header_only_when_no_rows() {
     assert_eq!(tsv, "id\tname");
 }
 
-// ── append_editor_text tests ──────────────────────────────────────────────────
-
-#[test]
-fn append_editor_text_should_set_text_when_editor_is_empty() {
-    assert_eq!(append_editor_text("", "SELECT * FROM t"), "SELECT * FROM t");
-}
-
-#[test]
-fn append_editor_text_should_prepend_newline_when_content_exists() {
-    assert_eq!(
-        append_editor_text("SELECT 1", "SELECT * FROM t"),
-        "SELECT 1\nSELECT * FROM t"
-    );
-}
-
-#[test]
-fn append_editor_text_should_not_double_newline_when_content_ends_with_newline() {
-    assert_eq!(
-        append_editor_text("SELECT 1\n", "SELECT * FROM t"),
-        "SELECT 1\nSELECT * FROM t"
-    );
-}
-
 // ── compute_matches tests ─────────────────────────────────────────────────────
 
 #[test]

--- a/crates/wf-db/src/models.rs
+++ b/crates/wf-db/src/models.rs
@@ -14,6 +14,7 @@ pub enum DbType {
 }
 
 /// Internal code-level DB variant used for enum dispatch in `DbPool`.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DbKind {
     Postgres,

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -2,7 +2,9 @@ use sqlx::{MySqlPool, PgPool, SqlitePool};
 
 use crate::drivers;
 use crate::error::DbError;
-use crate::models::{DbConnection, DbKind, DbMetadata, DbType, QueryResult};
+#[cfg(test)]
+use crate::models::DbKind;
+use crate::models::{DbConnection, DbMetadata, DbType, QueryResult};
 
 // ---------------------------------------------------------------------------
 // DbPool
@@ -81,6 +83,7 @@ impl DbPool {
     }
 
     /// Returns the [`DbKind`] variant that identifies which DB engine this pool targets.
+    #[cfg(test)]
     pub fn kind(&self) -> DbKind {
         match self {
             DbPool::Pg(_) => DbKind::Postgres,


### PR DESCRIPTION
## Summary

Removes the blanket `#![allow(dead_code)]` from `app/src/app/mod.rs` and deletes the dead items it was concealing. Also gates test-only items in `wf-db` with `#[cfg(test)]`. The result is zero warnings under `cargo clippy --workspace -- -D warnings` with no new targeted suppressions.

## Changes

- Remove `#![allow(dead_code)]` from `app/src/app/mod.rs`
- Delete `Event::InsertText` — never emitted by any controller or service; also removes `handle_insert_text()`, `append_editor_text()` helper, and its 3 tests
- Delete unused `StateEvent` variants: `QueryStarted`, `QueryFinished`, `ConnectionChanged`, `LoadingChanged` — only `ThemeChanged` was ever constructed
- Delete `ExportFormat` enum (`Csv`/`Json`) and `Command::ExportResult` variant — export is handled entirely in UI-layer callbacks; the controller arm was an empty no-op
- Delete `Command::RunSelection` — never sent from the UI; planned feature can be re-added when wired up
- Delete `ConfigUpdate::FontFamily` / `ConfigUpdate::FontSize` — never sent from the UI; controller fell through to `_ => {}`
- Gate `DbKind` enum and `DbPool::kind()` with `#[cfg(test)]` — only used in pool tests
- Gate `SessionManager::with_config_manager` with `#[cfg(test)]` — only used in controller and session tests

## Related Issues

Resolves #262

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes