### PR TITLE
refactor(wf-db): deduplicate driver execute and fetch_metadata boilerplate

### DIFF
--- a/crates/wf-db/src/drivers/mod.rs
+++ b/crates/wf-db/src/drivers/mod.rs
@@ -2,6 +2,10 @@ pub mod my;
 pub mod pg;
 pub mod sqlite;
 
+use std::collections::HashMap;
+
+use crate::models::{ColumnInfo, DbMetadata, TableInfo};
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -34,12 +38,159 @@ pub(super) fn is_row_returning(sql: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// impl_execute! macro
+// ---------------------------------------------------------------------------
+
+/// Expand a standard `execute` function for the given pool type.
+///
+/// Relies on `cell_to_string(row, i) -> Option<String>` being defined in the
+/// calling module — each driver supplies its own driver-specific version.
+macro_rules! impl_execute {
+    ($pool_ty:ty) => {
+        /// Execute `sql` against `pool` and return a [`crate::models::QueryResult`].
+        ///
+        /// - **SELECT / row-returning statements**: columns and rows are populated.
+        /// - **DML / DDL statements**: rows are empty; `row_count` = `rows_affected()`.
+        /// - **NULL values** map to `None`.
+        /// - `execution_time_ms` is measured with [`std::time::Instant`].
+        pub async fn execute(
+            pool: &$pool_ty,
+            sql: &str,
+        ) -> Result<crate::models::QueryResult, crate::error::DbError> {
+            use sqlx::{Column as _, Row as _};
+            let started = ::std::time::Instant::now();
+
+            if super::is_row_returning(sql) {
+                let rows = sqlx::query(sql)
+                    .fetch_all(pool)
+                    .await
+                    .map_err(crate::error::DbError::from)?;
+
+                let columns: Vec<String> = rows
+                    .first()
+                    .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
+                    .unwrap_or_default();
+
+                let data: Vec<Vec<Option<String>>> = rows
+                    .iter()
+                    .map(|row| (0..row.len()).map(|i| cell_to_string(row, i)).collect())
+                    .collect();
+
+                let row_count = data.len();
+                Ok(crate::models::QueryResult {
+                    columns,
+                    rows: data,
+                    row_count,
+                    execution_time_ms: started.elapsed().as_millis(),
+                })
+            } else {
+                let result = sqlx::query(sql)
+                    .execute(pool)
+                    .await
+                    .map_err(crate::error::DbError::from)?;
+
+                Ok(crate::models::QueryResult {
+                    columns: vec![],
+                    rows: vec![],
+                    row_count: result.rows_affected() as usize,
+                    execution_time_ms: started.elapsed().as_millis(),
+                })
+            }
+        }
+    };
+}
+pub(crate) use impl_execute;
+
+// ---------------------------------------------------------------------------
+// MetadataAccumulator
+// ---------------------------------------------------------------------------
+
+/// Builder that accumulates schema metadata during `fetch_metadata`.
+///
+/// **PG / MySQL**: call [`add_column`] for each column row first, then
+/// [`add_table`] / [`add_view`] per object row (each drains the column map
+/// for that name).  Call [`set_stored_procs`] and [`set_indexes`] for the
+/// remaining result sets, then [`build`].
+///
+/// **SQLite**: call [`push_table`] / [`push_view`] directly (columns come
+/// from `PRAGMA table_info`, one round-trip per object).  Call [`set_indexes`]
+/// then [`build`].
+pub(super) struct MetadataAccumulator {
+    col_map: HashMap<String, Vec<ColumnInfo>>,
+    tables: Vec<TableInfo>,
+    views: Vec<TableInfo>,
+    stored_procs: Vec<String>,
+    indexes: Vec<String>,
+}
+
+impl MetadataAccumulator {
+    pub fn new() -> Self {
+        Self {
+            col_map: HashMap::new(),
+            tables: Vec::new(),
+            views: Vec::new(),
+            stored_procs: Vec::new(),
+            indexes: Vec::new(),
+        }
+    }
+
+    /// Record a column belonging to `table`.  Call before [`add_table`] /
+    /// [`add_view`] for the same table so the map is populated when those
+    /// methods drain it.
+    pub fn add_column(&mut self, table: String, col: ColumnInfo) {
+        self.col_map.entry(table).or_default().push(col);
+    }
+
+    /// Append a table entry, draining its columns from the internal map.
+    pub fn add_table(&mut self, name: String) {
+        let columns = self.col_map.remove(&name).unwrap_or_default();
+        self.tables.push(TableInfo { name, columns });
+    }
+
+    /// Append a view entry, draining its columns from the internal map.
+    pub fn add_view(&mut self, name: String) {
+        let columns = self.col_map.remove(&name).unwrap_or_default();
+        self.views.push(TableInfo { name, columns });
+    }
+
+    /// Append a fully-constructed table (for SQLite, which fetches columns via PRAGMA).
+    pub fn push_table(&mut self, info: TableInfo) {
+        self.tables.push(info);
+    }
+
+    /// Append a fully-constructed view (for SQLite).
+    pub fn push_view(&mut self, info: TableInfo) {
+        self.views.push(info);
+    }
+
+    pub fn set_stored_procs(&mut self, procs: Vec<String>) {
+        self.stored_procs = procs;
+    }
+
+    pub fn set_indexes(&mut self, indexes: Vec<String>) {
+        self.indexes = indexes;
+    }
+
+    /// Consume the accumulator and return the final [`DbMetadata`].
+    pub fn build(self) -> DbMetadata {
+        DbMetadata {
+            tables: self.tables,
+            views: self.views,
+            stored_procs: self.stored_procs,
+            indexes: self.indexes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── is_row_returning ─────────────────────────────────────────────────────
 
     #[test]
     fn is_row_returning_should_return_true_for_select() {
@@ -56,5 +207,105 @@ mod tests {
         assert!(!is_row_returning("CREATE TABLE t (id INTEGER)"));
         assert!(!is_row_returning("DROP TABLE t"));
         assert!(!is_row_returning("ALTER TABLE t ADD COLUMN x TEXT"));
+    }
+
+    // ── MetadataAccumulator ───────────────────────────────────────────────────
+
+    #[test]
+    fn metadata_accumulator_build_should_return_empty_metadata_by_default() {
+        let acc = MetadataAccumulator::new();
+        let meta = acc.build();
+        assert!(meta.tables.is_empty());
+        assert!(meta.views.is_empty());
+        assert!(meta.stored_procs.is_empty());
+        assert!(meta.indexes.is_empty());
+    }
+
+    #[test]
+    fn metadata_accumulator_should_assemble_tables_with_columns() {
+        let mut acc = MetadataAccumulator::new();
+        acc.add_column(
+            "users".to_string(),
+            ColumnInfo {
+                name: "id".to_string(),
+                data_type: "INTEGER".to_string(),
+                nullable: false,
+            },
+        );
+        acc.add_column(
+            "users".to_string(),
+            ColumnInfo {
+                name: "name".to_string(),
+                data_type: "TEXT".to_string(),
+                nullable: true,
+            },
+        );
+        acc.add_table("users".to_string());
+
+        let meta = acc.build();
+        assert_eq!(meta.tables.len(), 1);
+        assert_eq!(meta.tables[0].name, "users");
+        assert_eq!(meta.tables[0].columns.len(), 2);
+        assert_eq!(meta.tables[0].columns[0].name, "id");
+        assert_eq!(meta.tables[0].columns[1].name, "name");
+    }
+
+    #[test]
+    fn metadata_accumulator_should_assemble_views_with_columns() {
+        let mut acc = MetadataAccumulator::new();
+        acc.add_column(
+            "v".to_string(),
+            ColumnInfo {
+                name: "x".to_string(),
+                data_type: "INT".to_string(),
+                nullable: true,
+            },
+        );
+        acc.add_view("v".to_string());
+
+        let meta = acc.build();
+        assert_eq!(meta.views.len(), 1);
+        assert_eq!(meta.views[0].name, "v");
+        assert_eq!(meta.views[0].columns.len(), 1);
+        assert_eq!(meta.views[0].columns[0].name, "x");
+    }
+
+    #[test]
+    fn metadata_accumulator_push_table_should_bypass_column_map() {
+        let mut acc = MetadataAccumulator::new();
+        acc.push_table(TableInfo {
+            name: "t".to_string(),
+            columns: vec![ColumnInfo {
+                name: "id".to_string(),
+                data_type: "INTEGER".to_string(),
+                nullable: false,
+            }],
+        });
+
+        let meta = acc.build();
+        assert_eq!(meta.tables.len(), 1);
+        assert_eq!(meta.tables[0].name, "t");
+        assert_eq!(meta.tables[0].columns.len(), 1);
+    }
+
+    #[test]
+    fn metadata_accumulator_should_store_procs_and_indexes() {
+        let mut acc = MetadataAccumulator::new();
+        acc.set_stored_procs(vec!["proc_a".to_string(), "proc_b".to_string()]);
+        acc.set_indexes(vec!["idx_1".to_string()]);
+
+        let meta = acc.build();
+        assert_eq!(meta.stored_procs, vec!["proc_a", "proc_b"]);
+        assert_eq!(meta.indexes, vec!["idx_1"]);
+    }
+
+    #[test]
+    fn metadata_accumulator_add_table_should_use_empty_columns_when_none_recorded() {
+        let mut acc = MetadataAccumulator::new();
+        acc.add_table("orphan".to_string()); // no columns added first
+
+        let meta = acc.build();
+        assert_eq!(meta.tables.len(), 1);
+        assert!(meta.tables[0].columns.is_empty());
     }
 }

--- a/crates/wf-db/src/drivers/my.rs
+++ b/crates/wf-db/src/drivers/my.rs
@@ -1,11 +1,7 @@
-use std::time::Instant;
-
 use sqlx::{Column, MySqlPool, Row, TypeInfo};
 
-use std::collections::HashMap;
-
 use crate::error::DbError;
-use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
+use crate::models::{ColumnInfo, DbMetadata};
 
 /// Connect to a MySQL database at `url`.
 ///
@@ -16,58 +12,15 @@ pub async fn connect(url: &str) -> Result<MySqlPool, DbError> {
         .map_err(|e| DbError::ConnectionFailed(e.to_string()))
 }
 
-/// Execute `sql` against `pool` and return a [`QueryResult`].
-///
-/// - **SELECT / row-returning statements**: columns and rows are populated.
-/// - **DML / DDL statements**: rows are empty; `row_count` = `rows_affected()`.
-/// - **NULL values** map to `None`.
-/// - `execution_time_ms` is measured with [`Instant`].
-pub async fn execute(pool: &MySqlPool, sql: &str) -> Result<QueryResult, DbError> {
-    let started = Instant::now();
-
-    if super::is_row_returning(sql) {
-        let rows = sqlx::query(sql)
-            .fetch_all(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        let columns: Vec<String> = rows
-            .first()
-            .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
-            .unwrap_or_default();
-
-        let data: Vec<Vec<Option<String>>> = rows
-            .iter()
-            .map(|row| (0..row.len()).map(|i| cell_to_string(row, i)).collect())
-            .collect();
-
-        let row_count = data.len();
-        Ok(QueryResult {
-            columns,
-            rows: data,
-            row_count,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    } else {
-        let result = sqlx::query(sql)
-            .execute(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        Ok(QueryResult {
-            columns: vec![],
-            rows: vec![],
-            row_count: result.rows_affected() as usize,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    }
-}
+super::impl_execute!(MySqlPool);
 
 /// Fetch schema metadata from the connected MySQL database.
 ///
 /// Queries `information_schema` restricted to the current schema (`DATABASE()`).
 /// PG/MySQL tests are `#[ignore]` — run with `cargo test -- --ignored`.
 pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
+    let mut acc = super::MetadataAccumulator::new();
+
     // ── all columns (single round-trip) ───────────────────────────────────────
     let col_rows = sqlx::query(
         "SELECT table_name, column_name, data_type, is_nullable \
@@ -79,14 +32,15 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let mut col_map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
     for row in &col_rows {
-        let table = get_meta_str(row, 0);
-        col_map.entry(table).or_default().push(ColumnInfo {
-            name: get_meta_str(row, 1),
-            data_type: get_meta_str(row, 2),
-            nullable: get_meta_str(row, 3) == "YES",
-        });
+        acc.add_column(
+            get_meta_str(row, 0),
+            ColumnInfo {
+                name: get_meta_str(row, 1),
+                data_type: get_meta_str(row, 2),
+                nullable: get_meta_str(row, 3) == "YES",
+            },
+        );
     }
 
     // ── tables ────────────────────────────────────────────────────────────────
@@ -99,14 +53,9 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let tables: Vec<TableInfo> = table_rows
-        .iter()
-        .map(|r| {
-            let name = get_meta_str(r, 0);
-            let columns = col_map.remove(&name).unwrap_or_default();
-            TableInfo { name, columns }
-        })
-        .collect();
+    for row in &table_rows {
+        acc.add_table(get_meta_str(row, 0));
+    }
 
     // ── views ─────────────────────────────────────────────────────────────────
     let view_rows = sqlx::query(
@@ -118,14 +67,9 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let views: Vec<TableInfo> = view_rows
-        .iter()
-        .map(|r| {
-            let name = get_meta_str(r, 0);
-            let columns = col_map.remove(&name).unwrap_or_default();
-            TableInfo { name, columns }
-        })
-        .collect();
+    for row in &view_rows {
+        acc.add_view(get_meta_str(row, 0));
+    }
 
     // ── stored procedures ─────────────────────────────────────────────────────
     let proc_rows = sqlx::query(
@@ -137,7 +81,7 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let stored_procs: Vec<String> = proc_rows.iter().map(|r| get_meta_str(r, 0)).collect();
+    acc.set_stored_procs(proc_rows.iter().map(|r| get_meta_str(r, 0)).collect());
 
     // ── indexes ───────────────────────────────────────────────────────────────
     let index_rows = sqlx::query(
@@ -149,14 +93,9 @@ pub async fn fetch_metadata(pool: &MySqlPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let indexes: Vec<String> = index_rows.iter().map(|r| get_meta_str(r, 0)).collect();
+    acc.set_indexes(index_rows.iter().map(|r| get_meta_str(r, 0)).collect());
 
-    Ok(DbMetadata {
-        tables,
-        views,
-        stored_procs,
-        indexes,
-    })
+    Ok(acc.build())
 }
 
 /// Fetch the DDL `CREATE` statement for `name` from MySQL.

--- a/crates/wf-db/src/drivers/pg.rs
+++ b/crates/wf-db/src/drivers/pg.rs
@@ -1,11 +1,7 @@
-use std::time::Instant;
-
 use sqlx::{Column, PgPool, Row, TypeInfo};
 
-use std::collections::HashMap;
-
 use crate::error::DbError;
-use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
+use crate::models::{ColumnInfo, DbMetadata};
 
 /// Connect to a PostgreSQL database at `url`.
 ///
@@ -16,59 +12,14 @@ pub async fn connect(url: &str) -> Result<PgPool, DbError> {
         .map_err(|e| DbError::ConnectionFailed(e.to_string()))
 }
 
-/// Execute `sql` against `pool` and return a [`QueryResult`].
-///
-/// - **SELECT / row-returning statements**: columns and rows are populated.
-/// - **DML / DDL statements**: rows are empty; `row_count` = `rows_affected()`.
-/// - **NULL values** map to `None`.
-/// - `execution_time_ms` is measured with [`Instant`].
-pub async fn execute(pool: &PgPool, sql: &str) -> Result<QueryResult, DbError> {
-    let started = Instant::now();
-
-    if super::is_row_returning(sql) {
-        let rows = sqlx::query(sql)
-            .fetch_all(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        let columns: Vec<String> = rows
-            .first()
-            .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
-            .unwrap_or_default();
-
-        let data: Vec<Vec<Option<String>>> = rows
-            .iter()
-            .map(|row| (0..row.len()).map(|i| cell_to_string(row, i)).collect())
-            .collect();
-
-        let row_count = data.len();
-        Ok(QueryResult {
-            columns,
-            rows: data,
-            row_count,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    } else {
-        let result = sqlx::query(sql)
-            .execute(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        Ok(QueryResult {
-            columns: vec![],
-            rows: vec![],
-            row_count: result.rows_affected() as usize,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    }
-}
+super::impl_execute!(PgPool);
 
 /// Fetch schema metadata from the connected PostgreSQL database.
 ///
 /// Queries `information_schema` and `pg_indexes` restricted to the `public`
 /// schema.  PG/MySQL tests are `#[ignore]` — run with `cargo test -- --ignored`.
 pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
-    use sqlx::Row as _;
+    let mut acc = super::MetadataAccumulator::new();
 
     // ── all columns (single round-trip) ───────────────────────────────────────
     let col_rows = sqlx::query(
@@ -81,14 +32,15 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let mut col_map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
     for row in &col_rows {
-        let table: String = row.get("table_name");
-        col_map.entry(table).or_default().push(ColumnInfo {
-            name: row.get("column_name"),
-            data_type: row.get("data_type"),
-            nullable: row.get::<&str, _>("is_nullable") == "YES",
-        });
+        acc.add_column(
+            row.get("table_name"),
+            ColumnInfo {
+                name: row.get("column_name"),
+                data_type: row.get("data_type"),
+                nullable: row.get::<&str, _>("is_nullable") == "YES",
+            },
+        );
     }
 
     // ── tables ────────────────────────────────────────────────────────────────
@@ -101,14 +53,9 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let tables: Vec<TableInfo> = table_rows
-        .iter()
-        .map(|r| {
-            let name: String = r.get("table_name");
-            let columns = col_map.remove(&name).unwrap_or_default();
-            TableInfo { name, columns }
-        })
-        .collect();
+    for row in &table_rows {
+        acc.add_table(row.get("table_name"));
+    }
 
     // ── views ─────────────────────────────────────────────────────────────────
     let view_rows = sqlx::query(
@@ -120,14 +67,9 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let views: Vec<TableInfo> = view_rows
-        .iter()
-        .map(|r| {
-            let name: String = r.get("table_name");
-            let columns = col_map.remove(&name).unwrap_or_default();
-            TableInfo { name, columns }
-        })
-        .collect();
+    for row in &view_rows {
+        acc.add_view(row.get("table_name"));
+    }
 
     // ── stored procedures / functions ─────────────────────────────────────────
     let proc_rows = sqlx::query(
@@ -139,7 +81,7 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let stored_procs: Vec<String> = proc_rows.iter().map(|r| r.get("routine_name")).collect();
+    acc.set_stored_procs(proc_rows.iter().map(|r| r.get("routine_name")).collect());
 
     // ── indexes ───────────────────────────────────────────────────────────────
     let index_rows = sqlx::query(
@@ -151,14 +93,9 @@ pub async fn fetch_metadata(pool: &PgPool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("indexname")).collect();
+    acc.set_indexes(index_rows.iter().map(|r| r.get("indexname")).collect());
 
-    Ok(DbMetadata {
-        tables,
-        views,
-        stored_procs,
-        indexes,
-    })
+    Ok(acc.build())
 }
 
 /// Fetch the DDL `CREATE` statement for `name` from PostgreSQL.

--- a/crates/wf-db/src/drivers/sqlite.rs
+++ b/crates/wf-db/src/drivers/sqlite.rs
@@ -1,9 +1,7 @@
-use std::time::Instant;
-
 use sqlx::{Column, Row, SqlitePool, TypeInfo};
 
 use crate::error::DbError;
-use crate::models::{ColumnInfo, DbMetadata, QueryResult, TableInfo};
+use crate::models::{ColumnInfo, DbMetadata, TableInfo};
 
 /// Connect to a SQLite database at `url`.
 ///
@@ -18,60 +16,14 @@ pub async fn connect(url: &str) -> Result<SqlitePool, DbError> {
         .map_err(|e| DbError::ConnectionFailed(e.to_string()))
 }
 
-/// Execute `sql` against `pool` and return a [`QueryResult`].
-///
-/// - **SELECT / row-returning statements**: columns and rows are populated;
-///   `row_count` equals the number of returned rows.
-/// - **DML / DDL statements**: rows are empty; `row_count` equals
-///   `rows_affected()` reported by SQLite.
-/// - **NULL values** map to `None` in every cell.
-/// - `execution_time_ms` is measured with [`Instant`].
-pub async fn execute(pool: &SqlitePool, sql: &str) -> Result<QueryResult, DbError> {
-    let started = Instant::now();
-
-    if super::is_row_returning(sql) {
-        let rows = sqlx::query(sql)
-            .fetch_all(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        let columns: Vec<String> = rows
-            .first()
-            .map(|r| r.columns().iter().map(|c| c.name().to_string()).collect())
-            .unwrap_or_default();
-
-        let data: Vec<Vec<Option<String>>> = rows
-            .iter()
-            .map(|row| (0..row.len()).map(|i| cell_to_string(row, i)).collect())
-            .collect();
-
-        let row_count = data.len();
-        Ok(QueryResult {
-            columns,
-            rows: data,
-            row_count,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    } else {
-        let result = sqlx::query(sql)
-            .execute(pool)
-            .await
-            .map_err(DbError::from)?;
-
-        Ok(QueryResult {
-            columns: vec![],
-            rows: vec![],
-            row_count: result.rows_affected() as usize,
-            execution_time_ms: started.elapsed().as_millis(),
-        })
-    }
-}
+super::impl_execute!(SqlitePool);
 
 /// Fetch schema metadata from the SQLite database:
 /// tables, views, indexes, and per-table columns.
 /// SQLite has no stored procedures — that field is always empty.
 pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
     use sqlx::Row as _;
+    let mut acc = super::MetadataAccumulator::new();
 
     // ── tables ────────────────────────────────────────────────────────────────
     let table_rows = sqlx::query(
@@ -83,11 +35,10 @@ pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let mut tables = Vec::new();
     for row in &table_rows {
         let name: String = row.get("name");
         let columns = pragma_columns(pool, &name).await?;
-        tables.push(TableInfo { name, columns });
+        acc.push_table(TableInfo { name, columns });
     }
 
     // ── views ─────────────────────────────────────────────────────────────────
@@ -96,11 +47,10 @@ pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
         .await
         .map_err(DbError::from)?;
 
-    let mut views = Vec::new();
     for row in &view_rows {
         let name: String = row.get("name");
         let columns = pragma_columns(pool, &name).await?;
-        views.push(TableInfo { name, columns });
+        acc.push_view(TableInfo { name, columns });
     }
 
     // ── indexes ───────────────────────────────────────────────────────────────
@@ -113,14 +63,9 @@ pub async fn fetch_metadata(pool: &SqlitePool) -> Result<DbMetadata, DbError> {
     .await
     .map_err(DbError::from)?;
 
-    let indexes: Vec<String> = index_rows.iter().map(|r| r.get("name")).collect();
+    acc.set_indexes(index_rows.iter().map(|r| r.get("name")).collect());
 
-    Ok(DbMetadata {
-        tables,
-        views,
-        stored_procs: vec![],
-        indexes,
-    })
+    Ok(acc.build())
 }
 
 /// Fetch the DDL `CREATE` statement for `name` from `sqlite_master`.


### PR DESCRIPTION
## Summary

Extracts the identical `execute` function body shared across all three database drivers (PG, MySQL, SQLite) into a `macro_rules! impl_execute!` macro, and introduces a `MetadataAccumulator` builder struct to eliminate the repeated `HashMap` + `Vec` assembly pattern in each driver's `fetch_metadata`. The macro resolves `cell_to_string` at the call site, so each driver's own type-specific decoder is used without any generics or trait bounds.

## Changes

- `drivers/mod.rs`: added `impl_execute!` macro (expands a full `execute` fn for a given pool type), `MetadataAccumulator` struct with `add_column`, `add_table`, `add_view`, `push_table`, `push_view`, `set_stored_procs`, `set_indexes`, `build` methods, and 6 new unit tests for the accumulator
- `drivers/pg.rs`: replaced 40-line `execute` body with `super::impl_execute!(PgPool)`, rewrote `fetch_metadata` using `MetadataAccumulator`, removed `Instant`/`HashMap` imports and `QueryResult`/`TableInfo` from local imports (~95 lines removed)
- `drivers/my.rs`: same treatment with `MySqlPool` (~85 lines removed)
- `drivers/sqlite.rs`: replaced `execute` body with `super::impl_execute!(SqlitePool)`, simplified `fetch_metadata` with `push_table`/`push_view` (~45 lines removed)

## Related Issues

Resolves #263

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes