### PR TITLE
test: add missing tests for sqlite driver, formatter, config manager, and metadata cache

### DIFF
--- a/crates/wf-completion/src/cache.rs
+++ b/crates/wf-completion/src/cache.rs
@@ -207,4 +207,36 @@ mod tests {
         let result = cache.load("does-not-exist").await;
         assert!(result.is_none());
     }
+
+    #[tokio::test]
+    async fn cache_store_and_load_should_roundtrip_in_memory() {
+        let cache = open_memory().await;
+        let meta = make_meta("accounts");
+
+        cache
+            .store("conn-mem", meta.clone())
+            .await
+            .expect("store should succeed");
+        let loaded = cache
+            .load("conn-mem")
+            .await
+            .expect("load should return Some");
+
+        assert_eq!(loaded.tables.len(), 1);
+        assert_eq!(loaded.tables[0].name, "accounts");
+        assert_eq!(loaded.tables[0].columns.len(), 2);
+        assert_eq!(loaded.indexes[0], "idx_id");
+    }
+
+    #[tokio::test]
+    async fn cache_preload_should_survive_empty_database() {
+        let cache = open_memory().await;
+        cache
+            .preload_from_disk()
+            .await
+            .expect("preload_from_disk should not fail on an empty database");
+        // Nothing was stored — memory map remains empty
+        let result = cache.load("any-conn").await;
+        assert!(result.is_none());
+    }
 }

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -147,4 +147,23 @@ mod tests {
         let loaded = mgr.load().expect("load should succeed");
         assert_eq!(original, loaded);
     }
+
+    #[test]
+    fn config_manager_should_roundtrip_editor_settings() {
+        use crate::models::{EditorConfig, PageSize};
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let mgr = ConfigManager::with_path(dir.path().join("config.toml"));
+
+        let original = Config {
+            editor: EditorConfig {
+                page_size: PageSize::Rows100,
+            },
+            ..Config::default()
+        };
+
+        mgr.save(&original).expect("save should succeed");
+        let loaded = mgr.load().expect("load should succeed");
+        assert_eq!(loaded.editor.page_size, PageSize::Rows100);
+    }
 }

--- a/crates/wf-db/src/drivers/sqlite.rs
+++ b/crates/wf-db/src/drivers/sqlite.rs
@@ -468,6 +468,18 @@ mod tests {
         assert!(ddl.to_uppercase().contains("CREATE VIEW"));
     }
 
+    // ── execute — error ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_should_return_error_on_invalid_sql() {
+        let pool = connect("sqlite::memory:").await.unwrap();
+        let err = execute(&pool, "NOT VALID SQL").await.unwrap_err();
+        assert!(
+            matches!(err, DbError::Sqlx(_)),
+            "expected Sqlx error for invalid SQL, got {err:?}"
+        );
+    }
+
     // ── execute — timing ─────────────────────────────────────────────────────
 
     #[tokio::test]

--- a/crates/wf-query/src/formatter.rs
+++ b/crates/wf-query/src/formatter.rs
@@ -42,4 +42,36 @@ mod tests {
         assert!(output.contains("SELECT"));
         assert!(output.contains("FROM"));
     }
+
+    #[test]
+    fn format_sql_should_indent_columns_after_select() {
+        let input = "select a, b, c from t";
+        let output = format_sql(input);
+        // sqlformat inserts a newline and indentation between SELECT and column list
+        assert!(
+            output.contains('\n'),
+            "expected formatted output to contain newlines:\n{output}"
+        );
+        assert!(output.contains('a') && output.contains('b') && output.contains('c'));
+    }
+
+    #[test]
+    fn format_sql_should_preserve_string_literal_casing() {
+        let input = "SELECT * FROM users WHERE name = 'Alice'";
+        let output = format_sql(input);
+        assert!(
+            output.contains("'Alice'"),
+            "expected string literal 'Alice' to preserve case in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn format_sql_should_handle_multistatement_input() {
+        let input = "select 1; select 2";
+        let output = format_sql(input);
+        assert!(
+            output.contains("SELECT"),
+            "expected SELECT in formatted output:\n{output}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds 7 missing unit tests across four crates to satisfy the coverage requirements documented in `docs/rules/test.md`. All newly added tests cover behaviour paths that existed in the code but had no corresponding test.

## Changes

- `wf-db/src/drivers/sqlite.rs`: add `execute_should_return_error_on_invalid_sql` — verifies that syntactically invalid SQL returns `DbError::Sqlx(_)`
- `wf-query/src/formatter.rs`: add `format_sql_should_indent_columns_after_select`, `format_sql_should_preserve_string_literal_casing`, `format_sql_should_handle_multistatement_input`
- `wf-config/src/manager.rs`: add `config_manager_should_roundtrip_editor_settings` — saves `PageSize::Rows100` and verifies it loads back correctly
- `wf-completion/src/cache.rs`: add `cache_store_and_load_should_roundtrip_in_memory` (pure in-memory cycle) and `cache_preload_should_survive_empty_database` (no error on empty DB)

## Related Issues

Closes #265

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes