### PR TITLE
test: introduce proptest and improve assertion quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,7 +2887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -4341,6 +4356,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4384,6 +4418,12 @@ dependencies = [
  "cpp_build",
  "semver",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -4508,6 +4548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,7 +4600,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -4890,6 +4939,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -5867,7 +5928,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -6247,6 +6308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6475,6 +6542,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6804,6 +6880,7 @@ name = "wf-completion"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "proptest",
  "serde",
  "serde_json",
  "sqlx",
@@ -6823,6 +6900,7 @@ dependencies = [
  "anyhow",
  "base64",
  "directories",
+ "proptest",
  "rand 0.10.0",
  "serde",
  "sqlx",
@@ -6868,6 +6946,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "csv",
+ "proptest",
  "serde",
  "serde_json",
  "sqlformat",

--- a/crates/wf-completion/Cargo.toml
+++ b/crates/wf-completion/Cargo.toml
@@ -24,3 +24,4 @@ tracing    = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.27.0"
+proptest = "1.11.0"

--- a/crates/wf-completion/src/engine.rs
+++ b/crates/wf-completion/src/engine.rs
@@ -498,4 +498,24 @@ mod tests {
         let all_items = CompletionEngine::complete(ctx, &meta, "");
         assert_eq!(all_items.len(), 2);
     }
+
+    // ── proptest ──────────────────────────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn complete_should_never_panic_on_arbitrary_prefix(
+            prefix in ".*",
+        ) {
+            let meta = DbMetadata::default();
+            let _ = CompletionEngine::complete(CompletionContext::Keyword, &meta, &prefix);
+            let _ = CompletionEngine::complete(CompletionContext::TableName, &meta, &prefix);
+            let _ = CompletionEngine::complete(
+                CompletionContext::ColumnName { table: None },
+                &meta,
+                &prefix,
+            );
+        }
+    }
 }

--- a/crates/wf-config/Cargo.toml
+++ b/crates/wf-config/Cargo.toml
@@ -27,3 +27,4 @@ base64      = "0.22.1"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+proptest = "1.11.0"

--- a/crates/wf-config/src/crypto.rs
+++ b/crates/wf-config/src/crypto.rs
@@ -127,10 +127,12 @@ mod tests {
         let encrypted = encrypt("my-password", TEST_KEY);
 
         // Split and tamper with one byte in the ciphertext half
-        let (nonce_b64, ct_b64) = encrypted.split_once(':').unwrap();
+        let (nonce_b64, ct_b64) = encrypted
+            .split_once(':')
+            .expect("encrypted output should have nonce:ct format");
         let mut ct_bytes = base64::engine::general_purpose::STANDARD
             .decode(ct_b64)
-            .unwrap();
+            .expect("ct_b64 should be valid Base64");
         ct_bytes[0] ^= 0xFF; // flip all bits in the first byte
         let tampered = format!(
             "{}:{}",
@@ -138,8 +140,12 @@ mod tests {
             base64::engine::general_purpose::STANDARD.encode(&ct_bytes)
         );
 
-        let result = decrypt(&tampered, TEST_KEY);
-        assert!(result.is_err(), "expected Err for tampered ciphertext");
+        let err = decrypt(&tampered, TEST_KEY)
+            .expect_err("expected decrypt to fail on tampered ciphertext");
+        assert!(
+            err.to_string().contains("GCM authentication"),
+            "expected GCM tag mismatch error, got: {err}"
+        );
     }
 
     #[test]
@@ -154,7 +160,7 @@ mod tests {
         assert_eq!(key.len(), 32);
         assert!(key_path.exists(), "key file should be created");
 
-        let stored = fs::read(&key_path).unwrap();
+        let stored = fs::read(&key_path).expect("failed to read key file");
         assert_eq!(stored, key, "stored key should match returned key");
     }
 
@@ -164,9 +170,26 @@ mod tests {
         let key_path = dir.path().join(".wellfeather.key");
 
         let expected: [u8; 32] = *b"known-32-byte-key-for-testing-xx";
-        fs::write(&key_path, expected).unwrap();
+        fs::write(&key_path, expected).expect("failed to write key file");
 
         let loaded = load_or_create_key(dir.path()).expect("should succeed");
         assert_eq!(loaded, expected);
+    }
+
+    // ── proptest ──────────────────────────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn encrypt_decrypt_should_roundtrip_any_plaintext(
+            plaintext in ".*",
+        ) {
+            let key = [0u8; 32];
+            let ciphertext = encrypt(&plaintext, &key);
+            let decrypted = decrypt(&ciphertext, &key)
+                .expect("decrypt should succeed for valid ciphertext");
+            prop_assert_eq!(decrypted, plaintext);
+        }
     }
 }

--- a/crates/wf-db/src/service.rs
+++ b/crates/wf-db/src/service.rs
@@ -168,7 +168,9 @@ mod tests {
         let conn = sqlite_memory_conn("conn-1");
 
         assert!(!svc.is_connected("conn-1"));
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
         assert!(svc.is_connected("conn-1"));
     }
 
@@ -177,7 +179,9 @@ mod tests {
         let svc = DbService::new();
         let conn = sqlite_memory_conn("conn-2");
 
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
         assert!(svc.is_connected("conn-2"));
 
         svc.disconnect("conn-2");
@@ -198,8 +202,12 @@ mod tests {
         let c1 = sqlite_memory_conn("a");
         let c2 = sqlite_memory_conn("b");
 
-        svc.connect(&c1, None).await.unwrap();
-        svc.connect(&c2, None).await.unwrap();
+        svc.connect(&c1, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
+        svc.connect(&c2, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
 
         assert!(svc.is_connected("a"));
         assert!(svc.is_connected("b"));
@@ -216,7 +224,9 @@ mod tests {
         let svc2 = svc.clone();
 
         let conn = sqlite_memory_conn("shared");
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
 
         assert!(svc2.is_connected("shared"));
     }
@@ -227,9 +237,14 @@ mod tests {
     async fn execute_should_return_query_result_for_connected_id() {
         let svc = DbService::new();
         let conn = sqlite_memory_conn("exec-1");
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
 
-        let result = svc.execute("exec-1", "SELECT 42 AS answer").await.unwrap();
+        let result = svc
+            .execute("exec-1", "SELECT 42 AS answer")
+            .await
+            .expect("query should succeed on connected SQLite");
 
         assert_eq!(result.row_count, 1);
         assert_eq!(result.rows[0][0], Some("42".to_string()));
@@ -241,7 +256,10 @@ mod tests {
 
         let err = svc.execute("unknown", "SELECT 1").await.unwrap_err();
 
-        assert!(matches!(err, DbError::ConnectionFailed(_)));
+        assert!(
+            matches!(err, DbError::ConnectionFailed(_)),
+            "expected ConnectionFailed for unknown id, got {err:?}"
+        );
     }
 
     // ── execute_with_cancel ───────────────────────────────────────────────────
@@ -250,7 +268,9 @@ mod tests {
     async fn execute_with_cancel_should_return_result_when_not_cancelled() {
         let svc = DbService::new();
         let conn = sqlite_memory_conn("cancel-1");
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
 
         let token = CancellationToken::new();
         let result = svc
@@ -265,7 +285,9 @@ mod tests {
     async fn execute_with_cancel_should_return_cancelled_when_token_fires() {
         let svc = DbService::new();
         let conn = sqlite_memory_conn("cancel-2");
-        svc.connect(&conn, None).await.unwrap();
+        svc.connect(&conn, None)
+            .await
+            .expect("failed to connect to in-memory SQLite");
 
         let token = CancellationToken::new();
         token.cancel(); // fire immediately before the query starts
@@ -275,7 +297,10 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(err, DbError::Cancelled));
+        assert!(
+            matches!(err, DbError::Cancelled),
+            "expected Cancelled when token fires, got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -288,6 +313,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(err, DbError::ConnectionFailed(_)));
+        assert!(
+            matches!(err, DbError::ConnectionFailed(_)),
+            "expected ConnectionFailed for unknown id, got {err:?}"
+        );
     }
 }

--- a/crates/wf-query/Cargo.toml
+++ b/crates/wf-query/Cargo.toml
@@ -18,3 +18,6 @@ thiserror = { workspace = true }
 sqlformat = "0.5.0"
 csv        = "1.4.0"
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
+
+[dev-dependencies]
+proptest = "1.11.0"

--- a/crates/wf-query/src/analyzer.rs
+++ b/crates/wf-query/src/analyzer.rs
@@ -425,4 +425,19 @@ mod tests {
     fn extract_selection_should_swap_start_and_end_when_reversed() {
         assert_eq!(extract_selection("SELECT 1; SELECT 2", 8, 0), "SELECT 1");
     }
+
+    // ── proptest ──────────────────────────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn extract_statement_at_should_never_panic(
+            sql in ".*",
+            cursor in 0usize..=200,
+        ) {
+            let cursor = cursor.min(sql.len());
+            let _ = extract_statement_at(&sql, cursor);
+        }
+    }
 }

--- a/crates/wf-query/src/export.rs
+++ b/crates/wf-query/src/export.rs
@@ -217,7 +217,8 @@ mod tests {
         let cols = vec!["a".to_string(), "b".to_string()];
         let rows = vec![vec![Some("hello".to_string()), None]];
         let bytes = result_to_json_bytes(&cols, &rows);
-        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("bytes should be valid JSON");
         assert_eq!(
             parsed[0]["a"],
             serde_json::Value::String("hello".to_string())
@@ -234,7 +235,8 @@ mod tests {
             Some("hello".to_string()),
         ]];
         let bytes = result_to_json_bytes(&cols, &rows);
-        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("bytes should be valid JSON");
         assert_eq!(parsed[0]["i"], serde_json::json!(42));
         assert_eq!(parsed[0]["f"], serde_json::json!(1.5));
         assert_eq!(parsed[0]["s"], serde_json::json!("hello"));
@@ -246,7 +248,8 @@ mod tests {
         let rows: Vec<Vec<Option<String>>> = vec![];
         let bytes = result_to_csv_bytes(&cols, &rows);
         assert!(bytes.starts_with(b"\xef\xbb\xbf"), "BOM missing");
-        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        let text =
+            std::str::from_utf8(&bytes[3..]).expect("CSV bytes should be valid UTF-8 after BOM");
         assert!(text.contains("id"), "header missing");
         assert!(text.contains("name"), "header missing");
     }
@@ -256,7 +259,8 @@ mod tests {
         let cols = vec!["a".to_string(), "b".to_string()];
         let rows = vec![vec![Some("hello".to_string()), None]];
         let bytes = result_to_csv_bytes(&cols, &rows);
-        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        let text =
+            std::str::from_utf8(&bytes[3..]).expect("CSV bytes should be valid UTF-8 after BOM");
         assert!(text.contains("hello"), "value missing");
         assert!(text.contains("hello,"), "NULL not serialised as empty");
     }
@@ -266,7 +270,43 @@ mod tests {
         let cols = vec!["v".to_string()];
         let rows = vec![vec![Some("a,b".to_string())]];
         let bytes = result_to_csv_bytes(&cols, &rows);
-        let text = std::str::from_utf8(&bytes[3..]).unwrap();
+        let text =
+            std::str::from_utf8(&bytes[3..]).expect("CSV bytes should be valid UTF-8 after BOM");
         assert!(text.contains("\"a,b\""), "comma not escaped: {text}");
+    }
+
+    // ── proptest ──────────────────────────────────────────────────────────────
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn result_to_csv_should_contain_any_printable_ascii_value(
+            value in "[ -~]{0,80}",
+        ) {
+            let columns = vec!["col".to_string()];
+            let rows = vec![vec![Some(value.clone())]];
+            let csv = result_to_csv_bytes(&columns, &rows);
+            // Skip the 3-byte UTF-8 BOM before checking
+            let text = String::from_utf8_lossy(&csv[3..]);
+            let escaped = value.replace('"', "\"\"");
+            prop_assert!(
+                text.contains(&value) || text.contains(&escaped),
+                "value {value:?} not found in CSV:\n{text}"
+            );
+        }
+
+        #[test]
+        fn result_to_json_should_produce_valid_json_for_any_values(
+            value in "[ -~]{0,80}",
+        ) {
+            let columns = vec!["col".to_string()];
+            let rows = vec![vec![Some(value.clone())]];
+            let bytes = result_to_json_bytes(&columns, &rows);
+            prop_assert!(
+                serde_json::from_slice::<serde_json::Value>(&bytes).is_ok(),
+                "output is not valid JSON for value {value:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds property-based tests using `proptest` to four crates (`wf-query`, `wf-config`, `wf-completion`) and upgrades assertion quality across `wf-db` and those crates. The proptest blocks satisfy the coverage targets mandated by `docs/rules/test.md §3`, and the assertion improvements give actionable failure messages when tests break.

## Changes

- `wf-query/Cargo.toml`, `wf-config/Cargo.toml`, `wf-completion/Cargo.toml`: add `proptest = "1"` dev-dependency
- `analyzer.rs`: proptest — `extract_statement_at_should_never_panic` (arbitrary SQL + cursor never panics)
- `export.rs`: proptest — `result_to_csv_should_contain_any_printable_ascii_value` and `result_to_json_should_produce_valid_json_for_any_values`; `.unwrap()` → `.expect()` in test bodies
- `crypto.rs`: proptest — `encrypt_decrypt_should_roundtrip_any_plaintext`; `assert!(result.is_err())` replaced with `expect_err()` + GCM tag mismatch content check; `.unwrap()` → `.expect()` in setup
- `engine.rs` (`wf-completion`): proptest — `complete_should_never_panic_on_arbitrary_prefix` (Keyword / TableName / ColumnName contexts)
- `service.rs` (`wf-db`): all `.await.unwrap()` setup calls → `.await.expect("…")`; all bare `matches!` assertions now include a failure message

## Related Issues

Closes #266

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes