### PR TITLE
fix(security): redact password in logs and connection errors

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -49,3 +49,75 @@ pub enum Command {
         page_size: usize,
     },
 }
+
+impl Command {
+    /// Returns the variant name for logging.  Does **not** include any payload,
+    /// so credentials carried by `Connect` and `TestConnection` are never logged.
+    pub(crate) fn variant_name(&self) -> &'static str {
+        match self {
+            Self::Connect(..) => "Connect",
+            Self::TestConnection(..) => "TestConnection",
+            Self::Disconnect(..) => "Disconnect",
+            Self::RemoveConnection(..) => "RemoveConnection",
+            Self::RunQuery(..) => "RunQuery",
+            Self::RunAll(..) => "RunAll",
+            Self::CancelQuery => "CancelQuery",
+            Self::FetchCompletion(..) => "FetchCompletion",
+            Self::UpdateConfig(..) => "UpdateConfig",
+            Self::FetchDdl { .. } => "FetchDdl",
+            Self::FetchTableData { .. } => "FetchTableData",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wf_db::models::{DbConnection, DbType};
+
+    use super::Command;
+
+    fn dummy_conn() -> DbConnection {
+        DbConnection {
+            id: "test".to_string(),
+            name: "test".to_string(),
+            db_type: DbType::SQLite,
+            connection_string: Some("sqlite::memory:".to_string()),
+            host: None,
+            port: None,
+            user: None,
+            password_encrypted: None,
+            database: None,
+        }
+    }
+
+    #[test]
+    fn variant_name_should_return_connect_for_connect_command() {
+        let cmd = Command::Connect(dummy_conn(), Some("s3cret".to_string()));
+        assert_eq!(cmd.variant_name(), "Connect");
+    }
+
+    #[test]
+    fn variant_name_should_not_expose_password_in_connect() {
+        let cmd = Command::Connect(dummy_conn(), Some("s3cret".to_string()));
+        assert!(!cmd.variant_name().contains("s3cret"));
+    }
+
+    #[test]
+    fn variant_name_should_not_expose_password_in_test_connection() {
+        let cmd = Command::TestConnection(dummy_conn(), Some("s3cret".to_string()));
+        assert!(!cmd.variant_name().contains("s3cret"));
+    }
+
+    #[test]
+    fn variant_name_should_return_correct_name_for_each_variant() {
+        assert_eq!(
+            Command::Disconnect("id".to_string()).variant_name(),
+            "Disconnect"
+        );
+        assert_eq!(
+            Command::RunQuery("SELECT 1".to_string()).variant_name(),
+            "RunQuery"
+        );
+        assert_eq!(Command::CancelQuery.variant_name(), "CancelQuery");
+    }
+}

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -93,7 +93,7 @@ impl AppController {
 
         let mut this = self;
         while let Some(cmd) = this.rx_cmd.recv().await {
-            debug!("received command: {:?}", cmd);
+            debug!("received command: {}", cmd.variant_name());
             match cmd {
                 Command::Connect(conn, pw) => this.handle_connect(conn, pw).await,
                 Command::TestConnection(conn, pw) => this.handle_test_connection(conn, pw).await,

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -30,21 +30,21 @@ impl DbPool {
                 let url = pg_url(conn, password);
                 let pool = PgPool::connect(&url)
                     .await
-                    .map_err(|e| DbError::ConnectionFailed(e.to_string()))?;
+                    .map_err(|e| DbError::ConnectionFailed(redact_url_password(&e.to_string())))?;
                 Ok(DbPool::Pg(pool))
             }
             DbType::MySQL => {
                 let url = my_url(conn, password);
                 let pool = MySqlPool::connect(&url)
                     .await
-                    .map_err(|e| DbError::ConnectionFailed(e.to_string()))?;
+                    .map_err(|e| DbError::ConnectionFailed(redact_url_password(&e.to_string())))?;
                 Ok(DbPool::My(pool))
             }
             DbType::SQLite => {
                 let url = sqlite_url(conn);
                 let pool = SqlitePool::connect(&url)
                     .await
-                    .map_err(|e| DbError::ConnectionFailed(e.to_string()))?;
+                    .map_err(|e| DbError::ConnectionFailed(redact_url_password(&e.to_string())))?;
                 Ok(DbPool::Sqlite(pool))
             }
         }
@@ -144,6 +144,44 @@ pub(crate) fn sqlite_url(conn: &DbConnection) -> String {
         Some(":memory:") | None => "sqlite::memory:".to_string(),
         Some(path) => format!("sqlite:{}", path),
     }
+}
+
+// ---------------------------------------------------------------------------
+// URL password redaction
+// ---------------------------------------------------------------------------
+
+/// Replace the password component in any `scheme://user:password@host` URLs
+/// found in `s` with `***`.  Handles multiple URLs in one string.
+/// URLs without a password (no `:pw@` in the authority) are left unchanged.
+pub(crate) fn redact_url_password(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(scheme_end) = rest.find("://") {
+        // copy everything up to and including "://"
+        result.push_str(&rest[..scheme_end + 3]);
+        rest = &rest[scheme_end + 3..];
+
+        // authority ends at the first '/' or end-of-string
+        let authority_len = rest.find('/').unwrap_or(rest.len());
+        let authority = &rest[..authority_len];
+
+        if let Some(at_pos) = authority.find('@') {
+            let user_info = &authority[..at_pos];
+            if let Some(colon_pos) = user_info.find(':') {
+                // user_info has a password — redact it
+                result.push_str(&user_info[..colon_pos + 1]); // "user:"
+                result.push_str("***");
+                result.push_str(&authority[at_pos..]); // "@host:port/..."
+                rest = &rest[authority_len..];
+                continue;
+            }
+        }
+        // No password found — copy authority verbatim
+        result.push_str(authority);
+        rest = &rest[authority_len..];
+    }
+    result.push_str(rest);
+    result
 }
 
 // ---------------------------------------------------------------------------
@@ -276,5 +314,47 @@ mod tests {
         let conn = sqlite_conn_memory();
         let pool = DbPool::connect(&conn, None).await.unwrap();
         assert_eq!(pool.kind(), DbKind::Sqlite);
+    }
+
+    // -- redact_url_password --------------------------------------------------
+
+    #[test]
+    fn redact_url_password_should_replace_password_in_pg_url() {
+        let input = "failed: postgresql://alice:s3cret@localhost:5432/db";
+        let out = redact_url_password(input);
+        assert!(!out.contains("s3cret"), "password still present: {out}");
+        assert!(out.contains("***"), "redaction marker missing: {out}");
+        assert!(
+            out.contains("alice:***@localhost"),
+            "user and host lost: {out}"
+        );
+    }
+
+    #[test]
+    fn redact_url_password_should_replace_password_in_mysql_url() {
+        let input = "error: mysql://bob:pass123@mysql.host:3306/shop";
+        let out = redact_url_password(input);
+        assert!(!out.contains("pass123"), "password still present: {out}");
+        assert!(out.contains("bob:***@"), "expected bob:***@: {out}");
+    }
+
+    #[test]
+    fn redact_url_password_should_leave_url_without_password_unchanged() {
+        let input = "error: postgresql://alice@localhost:5432/db";
+        assert_eq!(redact_url_password(input), input);
+    }
+
+    #[test]
+    fn redact_url_password_should_leave_plain_text_unchanged() {
+        let input = "connection refused: timeout after 5s";
+        assert_eq!(redact_url_password(input), input);
+    }
+
+    #[test]
+    fn redact_url_password_should_handle_multiple_urls_in_one_string() {
+        let input = "pg://u:p1@h1/db and mysql://v:p2@h2/db2";
+        let out = redact_url_password(input);
+        assert!(!out.contains("p1"), "first password still present: {out}");
+        assert!(!out.contains("p2"), "second password still present: {out}");
     }
 }


### PR DESCRIPTION
## Summary

`Command::Connect` carried the plaintext password through `{:?}` debug formatting in the controller's command-received log, exposing credentials to any log sink. `DbError::ConnectionFailed` also wrapped raw sqlx error strings that may embed the connection URL (which contains the password for PG/MySQL). Both paths are now hardened.

## Changes

- **Root cause (log)**: `debug!("received command: {:?}", cmd)` used the auto-derived `Debug` impl which printed the full `Connect` payload including the plaintext password
- **Fix**: Added `Command::variant_name() -> &'static str` that returns only the enum arm name with no payload; changed the log line to `debug!("received command: {}", cmd.variant_name())`
- **Root cause (error)**: `DbPool::connect` wrapped sqlx errors verbatim via `e.to_string()`; sqlx may include the full connection URL (containing `user:password@host`) in certain error messages
- **Fix**: Added `redact_url_password(s)` in `wf-db/src/pool.rs` that replaces `:password@` with `:***@` in any URL-like patterns found in the error string; applied at all three `DbError::ConnectionFailed` construction sites (PG, MySQL, SQLite)
- **Tests**: 4 tests for `variant_name` (no password exposed for Connect/TestConnection); 5 tests for `redact_url_password` (PG URL, MySQL URL, URL without password, plain text, multiple URLs in one string)

## Related Issues

Fixes #268

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes