### PR TITLE
fix(query): strip leading comments from extracted SQL before execution

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -141,7 +141,9 @@ fn apply_limit(sql: &str, limit: usize) -> String {
     }
     let trimmed = sql.trim().trim_end_matches(';').trim_end();
     let upper = trimmed.to_uppercase();
-    if upper.starts_with("SELECT") && !upper.contains(" LIMIT ") && !trimmed.contains(';') {
+    // Split on whitespace so "\nLIMIT" (formatted SQL) matches as well as " LIMIT ".
+    let has_limit = upper.split_whitespace().any(|w| w == "LIMIT");
+    if upper.starts_with("SELECT") && !has_limit && !trimmed.contains(';') {
         format!("{} LIMIT {}", trimmed, limit)
     } else {
         sql.to_string()
@@ -257,6 +259,23 @@ mod tests {
     #[test]
     fn apply_limit_should_not_apply_to_multi_statement_sql() {
         let sql = "SELECT 1; SELECT 2";
+        assert_eq!(apply_limit(sql, 500), sql);
+    }
+
+    #[test]
+    fn apply_limit_should_append_to_formatted_multiline_select() {
+        // format_sql("select name from users;") produces this output
+        let sql = "SELECT\n  name\nFROM\n  users;";
+        assert_eq!(
+            apply_limit(sql, 500),
+            "SELECT\n  name\nFROM\n  users LIMIT 500"
+        );
+    }
+
+    #[test]
+    fn apply_limit_should_not_duplicate_limit_on_formatted_sql_with_existing_limit() {
+        // If the user already wrote LIMIT on its own line, do not append another.
+        let sql = "SELECT\n  *\nFROM\n  t\nLIMIT 10";
         assert_eq!(apply_limit(sql, 500), sql);
     }
 

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -181,7 +181,9 @@ pub(super) fn register_editor_callbacks(window: &crate::AppWindow, tx_cmd: mpsc:
         let tx_cmd = tx_cmd.clone(); // clone required: callback closure needs owned tx_cmd
         let window_weak = window.as_weak(); // clone required: check_safe_dml needs window ref
         ui.on_run_query(move |sql| {
+            tracing::debug!(sql = %sql, "on_run_query called");
             if check_safe_dml(&window_weak, &sql, "query") {
+                tracing::debug!("on_run_query: blocked by safe_dml");
                 return;
             }
             send_cmd(&tx_cmd, Command::RunQuery(sql.to_string()));
@@ -192,12 +194,21 @@ pub(super) fn register_editor_callbacks(window: &crate::AppWindow, tx_cmd: mpsc:
         let window_weak = window.as_weak(); // clone required: check_safe_dml needs window ref
         ui.on_run_query_at_cursor(move |sql, cursor| {
             let stmt = wf_query::analyzer::extract_statement_at(sql.as_str(), cursor as usize);
-            if !stmt.is_empty() {
-                if check_safe_dml(&window_weak, stmt, "cursor") {
-                    return;
-                }
-                send_cmd(&tx_cmd, Command::RunQuery(stmt.to_owned()));
+            tracing::debug!(
+                sql_len = sql.len(),
+                cursor = cursor,
+                stmt = %stmt,
+                "on_run_query_at_cursor called"
+            );
+            if stmt.is_empty() {
+                tracing::warn!("on_run_query_at_cursor: stmt is empty, no command sent");
+                return;
             }
+            if check_safe_dml(&window_weak, stmt, "cursor") {
+                tracing::debug!("on_run_query_at_cursor: blocked by safe_dml");
+                return;
+            }
+            send_cmd(&tx_cmd, Command::RunQuery(stmt.to_owned()));
         });
     }
     {
@@ -218,6 +229,7 @@ pub(super) fn register_formatter_callback(
         with_ui(&window_weak, |ui| {
             let text = ui.get_editor_text().to_string();
             let formatted = wf_query::formatter::format_sql(&text);
+            tracing::debug!(input = %text, output = %formatted, "on_format_sql called");
             let spans = compute_highlight_spans(&formatted);
             ui.set_editor_text(formatted.into());
             apply_highlight_spans(&hl_model, spans);

--- a/crates/wf-query/src/analyzer.rs
+++ b/crates/wf-query/src/analyzer.rs
@@ -1,11 +1,17 @@
-/// Returns the SQL statement that contains `cursor_pos` (byte offset).
+/// Returns the SQL statement that contains `cursor_pos` (byte offset),
+/// with leading block comments (`/* … */`) and line comments (`--`) stripped.
 ///
 /// The input is split on `;` and the segment whose byte range covers
-/// `cursor_pos` is returned, trimmed of surrounding whitespace.
+/// `cursor_pos` is returned, trimmed of surrounding whitespace and with any
+/// leading comment preamble removed.  This means a comment that acts as a
+/// header for a statement (e.g. `/* docs */\nSELECT …`) is excluded from the
+/// returned text so that the caller receives only the executable SQL.
+///
 /// A cursor positioned exactly on a `;` is considered part of the
 /// statement that precedes it.
 ///
-/// If the input has no semicolon the whole string is returned trimmed.
+/// If the input has no semicolon the whole string is returned (trimmed,
+/// comments stripped).
 pub fn extract_statement_at(sql: &str, cursor_pos: usize) -> &str {
     let mut pos: usize = 0;
     let mut last: &str = "";
@@ -23,16 +29,18 @@ pub fn extract_statement_at(sql: &str, cursor_pos: usize) -> &str {
             if cursor_pos < pos + prefix_len && segment[..prefix_len].contains('\n') {
                 return last;
             }
-            return trimmed;
+            return strip_leading_comments(trimmed);
         }
         let t = segment.trim();
-        if !t.is_empty() {
-            last = t;
+        let effective = strip_leading_comments(t);
+        if !effective.is_empty() {
+            last = effective;
         }
         pos = end + 1; // skip the ';'
     }
     // cursor_pos is past the end of the string
-    if last.is_empty() { sql.trim() } else { last }
+    let fallback = if last.is_empty() { sql.trim() } else { last };
+    strip_leading_comments(fallback)
 }
 
 /// Splits `sql` on semicolons and returns all non-empty, trimmed statements.
@@ -229,6 +237,94 @@ mod tests {
         let sql = "SELECT 1;\nSELECT 2;\n";
         assert_eq!(extract_statement_at(sql, 19), "SELECT 2");
         assert_eq!(extract_statement_at(sql, 20), "SELECT 2");
+    }
+
+    #[test]
+    fn extract_statement_at_should_handle_formatted_multiline_single_statement() {
+        // format_sql("select name from users;") produces this layout
+        let sql = "SELECT\n  name\nFROM\n  users;";
+        // Any cursor position inside the statement should return it (stripped)
+        assert_eq!(
+            extract_statement_at(sql, 0),
+            "SELECT\n  name\nFROM\n  users"
+        );
+        assert_eq!(
+            extract_statement_at(sql, 6),
+            "SELECT\n  name\nFROM\n  users"
+        );
+        assert_eq!(
+            extract_statement_at(sql, 13),
+            "SELECT\n  name\nFROM\n  users"
+        );
+        // Cursor on the semicolon or past the end
+        assert_eq!(
+            extract_statement_at(sql, 26),
+            "SELECT\n  name\nFROM\n  users"
+        );
+        assert_eq!(
+            extract_statement_at(sql, 27),
+            "SELECT\n  name\nFROM\n  users"
+        );
+    }
+
+    #[test]
+    fn extract_statement_at_should_handle_formatted_multiline_multi_statement() {
+        // Two formatted statements: "SELECT\n  1;\nSELECT\n  2;"
+        //  positions:              0-9=first stmt, 10=';', 11='\n', 12-21=second stmt, 22=';'
+        let sql = "SELECT\n  1;\nSELECT\n  2;";
+        // Cursor inside first statement
+        assert_eq!(extract_statement_at(sql, 0), "SELECT\n  1");
+        // Cursor on the semicolon — belongs to first
+        assert_eq!(extract_statement_at(sql, 10), "SELECT\n  1");
+        // Cursor on the '\n' after the semicolon — visually end-of-line, belongs to first
+        assert_eq!(extract_statement_at(sql, 11), "SELECT\n  1");
+        // Cursor at 'S' of the second SELECT
+        assert_eq!(extract_statement_at(sql, 12), "SELECT\n  2");
+        // Cursor inside second statement
+        assert_eq!(extract_statement_at(sql, 19), "SELECT\n  2");
+    }
+
+    #[test]
+    fn extract_statement_at_should_strip_block_comment_header() {
+        // Comment block + formatted SELECT in the same `;`-delimited segment
+        let sql = "/*\n Code Snippets\n e.g. select\n*/\n-- Fetch user info\nSELECT\n  first_name\nFROM\n  staffs;\nselect first_name from staffs;";
+        // Cursor at byte 0 (inside comment) → returns the SELECT without the comment
+        let result = extract_statement_at(sql, 0);
+        assert_eq!(
+            result, "SELECT\n  first_name\nFROM\n  staffs",
+            "cursor=0: {result:?}"
+        );
+        // Cursor at byte 53 (newline after "-- Fetch user info") → same
+        let result = extract_statement_at(sql, 53);
+        assert_eq!(
+            result, "SELECT\n  first_name\nFROM\n  staffs",
+            "cursor=53: {result:?}"
+        );
+        // Cursor at byte 89 (start of second statement) → single-line statement
+        let result = extract_statement_at(sql, 89);
+        assert_eq!(
+            result, "select first_name from staffs",
+            "cursor=89: {result:?}"
+        );
+    }
+
+    #[test]
+    fn extract_statement_at_should_strip_line_comment_header() {
+        let sql = "-- Get user\nSELECT id FROM users;";
+        assert_eq!(extract_statement_at(sql, 0), "SELECT id FROM users");
+        assert_eq!(extract_statement_at(sql, 11), "SELECT id FROM users");
+        assert_eq!(extract_statement_at(sql, 12), "SELECT id FROM users");
+    }
+
+    #[test]
+    fn extract_statement_at_should_handle_comment_only_segment() {
+        // Segment 0 = "/* header only */" (comment only → stripped → empty)
+        // Segment 1 = "\nSELECT 1"
+        let sql = "/* header only */;\nSELECT 1;";
+        // Cursor inside the comment → comment stripped → empty → return ""
+        assert_eq!(extract_statement_at(sql, 0), "");
+        // Cursor at 'S' of SELECT 1 (byte 20) → return "SELECT 1"
+        assert_eq!(extract_statement_at(sql, 20), "SELECT 1");
     }
 
     // ── has_dangerous_dml ────────────────────────────────────────────────────

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ build-release:
 run:
     cargo run -p wellfeather
 
+# Run the app with info-level logging (for debugging)
+run-debug:
+    RUST_LOG="wellfeather=info" cargo run -p wellfeather
+
 # Run the app in release mode
 run-release:
     cargo run -p wellfeather --release


### PR DESCRIPTION
## Summary

`extract_statement_at` was returning the full SQL segment including leading
block/line comments (e.g. `/* … */\n-- …\nSELECT …`). This caused formatted
multi-line SQL to produce no results: `apply_limit` couldn't recognise the
statement as a SELECT (it started with `/*`), and the raw comment text was
sent to the database alongside the SQL.

## Changes

- `crates/wf-query/src/analyzer.rs`: apply `strip_leading_comments` inside
  `extract_statement_at` before returning any segment, and also when updating
  the `last` fallback pointer — 3 new unit tests cover block-comment header,
  line-comment header, and comment-only segment
- `app/src/app/controller.rs`: fix `apply_limit` to detect `LIMIT` via
  `split_whitespace` so that `\nLIMIT` (formatted SQL) is recognised — 2 new
  unit tests cover formatted SELECT and existing LIMIT on its own line
- `app/src/ui/query.rs`: downgrade diagnostic `info!` calls added during
  debugging to `debug!` level
- `justfile`: add `run-debug` recipe (`RUST_LOG="wellfeather=info"`) for
  convenient debug logging without manual env-var export

## Related Issues

Fixes #296

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes