### PR TITLE
fix(editor): eliminate text-jump on Enter in syntax-highlight overlay

### DIFF
--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -26,6 +26,13 @@ pub(super) fn compute_highlight_spans(sql: &str) -> Vec<crate::HighlightSpan> {
 
 /// Update a persistent highlight VecModel in-place to avoid destroying and
 /// recreating all overlay Text elements on every keystroke.
+///
+/// The model grows monotonically — rows are never removed. Excess rows (when
+/// span count decreases) are overwritten with a sentinel span whose `text` is
+/// empty and therefore renders nothing. This replaces `model.remove()` calls,
+/// which send `row_removed` notifications that can cause Text elements to be
+/// destroyed and recreated in a separate compositing step from the TextInput
+/// cursor-position update, producing a one-frame visual misalignment.
 pub(super) fn apply_highlight_spans(
     model: &Rc<slint::VecModel<crate::HighlightSpan>>,
     spans: Vec<crate::HighlightSpan>,
@@ -38,8 +45,16 @@ pub(super) fn apply_highlight_spans(
     for span in spans.into_iter().skip(n) {
         model.push(span);
     }
-    while model.row_count() > m {
-        model.remove(model.row_count() - 1);
+    // Clear excess rows with a sentinel rather than removing them.
+    // kind=4 is the gap-fill (identifier) value; empty text renders nothing.
+    let sentinel = crate::HighlightSpan {
+        line: 0,
+        col: 0,
+        text: "".into(),
+        kind: 4,
+    };
+    for i in m..n {
+        model.set_row_data(i, sentinel.clone());
     }
 }
 

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -340,11 +340,8 @@ export component Editor inherits Rectangle {
         }
     }
 
-    // Derive line height directly from TextInput's actual rendered height divided
-    // by line count.  This eliminates drift caused by fractional font metrics
-    // that accumulate across many lines.
-    property <length> line-h: inner-input.preferred-height > 0px
-        ? inner-input.preferred-height / root.line-count
+    property <length> line-h: line-h-ruler.preferred-height > 0px
+        ? line-h-ruler.preferred-height / 10
         : root.font-size-px * 1px + 5px;
 
     // Effective visible height — clamped to at least 80 px so auto-scroll has
@@ -370,6 +367,20 @@ export component Editor inherits Rectangle {
     property <length> char-w: char-ruler.preferred-width > 0px
         ? char-ruler.preferred-width / 30
         : root.font-size-px * 0.6px;
+
+    // ── Line height measurement ───────────────────────────────────────────────
+    // 10-line ruler: preferred-height depends only on font metrics, never on
+    // editor content. This avoids the one-frame stale value that occurs when
+    // line-count updates synchronously on text change but inner-input.preferred-height
+    // waits for the layout pass — previously causing a visible jump on Enter.
+    // Slint uses uniform line spacing, so preferred-height(10) / 10 ==
+    // preferred-height(N) / N for any N; there is no accumulated drift.
+    line-h-ruler := Text {
+        visible: false;
+        text: "M\nM\nM\nM\nM\nM\nM\nM\nM\nM";
+        font-family: root.font-family;
+        font-size: root.font-size-px * 1px;
+    }
 
     // ── Current-line highlight ───────────────────────────────────────────────
     // Rendered first (= behind all other content).


### PR DESCRIPTION
## Summary

Pressing Enter in the SQL editor caused the syntax-highlight overlay to visibly
jump for one frame. Two independent causes were identified and fixed.

## Changes

**Root cause 1 — stale `line-h` (primary fix, `editor.slint`)**

`line-h` was computed as `inner-input.preferred-height / line-count`. When
Enter was pressed, `line-count` updated synchronously (pure callback on text
change) while `inner-input.preferred-height` waited for the layout pass. The
one-frame stale ratio made `line-h` smaller than correct, shifting all overlay
span y-positions and the `viewport-y` scroll offset by a few pixels. Because
`viewport-y` is an assigned property it was not auto-corrected when
`preferred-height` later updated.

Fix: mirror the existing `char-ruler` pattern with a fixed 10-line invisible
`Text` element (`line-h-ruler`). Its `preferred-height` depends only on font
metrics and is never content-dependent, so `line-h = line-h-ruler.preferred-height / 10`
is always stable. Slint uses uniform line spacing, so the per-line value is
identical to the old formula without the transient stale state.

**Root cause 2 — `row_removed` notifications on shrink (secondary fix, `appearance.rs`)**

`apply_highlight_spans` called `model.remove()` when span count decreased.
Each `remove()` sends a `row_removed` notification that destroys a `Text`
element in the repeater, potentially in a different compositing step from the
TextInput cursor-position update. Replaced with sentinel overwrites
(`HighlightSpan { text: "" }`): the model grows monotonically, only
`row_changed` notifications are emitted, and no element destruction occurs.

## Related Issues

Fixes #252

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes