### PR TITLE
feat(editor): Tab inserts spaces with configurable tab-width

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -14,6 +14,7 @@ pub enum ConfigUpdate {
         read_only: bool,
     },
     ReduceMotion(bool),
+    TabWidth(u32),
 }
 
 /// UI → Controller channel messages.

--- a/app/src/app/controller/config.rs
+++ b/app/src/app/controller/config.rs
@@ -59,6 +59,11 @@ impl AppController {
                     warn!(error = %e, "failed to persist reduce_motion to config");
                 }
             }
+            ConfigUpdate::TabWidth(width) => {
+                if let Err(e) = self.session.save_tab_width(width) {
+                    warn!(error = %e, "failed to persist tab_width to config");
+                }
+            }
         }
     }
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -112,6 +112,20 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Persist `width` as `[editor].tab_width` in `config.toml`.
+    pub fn save_tab_width(&self, width: u32) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for tab_width save")?;
+        config.editor.tab_width = width;
+        self.config_manager
+            .save(&config)
+            .context("failed to save tab_width")?;
+        info!(tab_width = width, "tab_width saved");
+        Ok(())
+    }
+
     /// Persist `reduce_motion` as `[appearance].reduce_motion` in `config.toml`.
     pub fn save_reduce_motion(&self, value: bool) -> anyhow::Result<()> {
         let mut config = self
@@ -182,6 +196,20 @@ mod tests {
     use wf_config::manager::ConfigManager;
 
     use super::SessionManager;
+
+    #[test]
+    fn save_tab_width_should_persist_to_config() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_tab_width(4).unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        assert_eq!(cfg.editor.tab_width, 4);
+    }
 
     #[test]
     fn save_page_size_should_persist_to_config() {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -30,6 +30,7 @@ import { SnippetEditDialog }     from "components/snippet_edit_dialog.slint";
 import { SnippetBar }            from "components/snippet_bar.slint";
 import { MetadataSearch }        from "components/metadata_search.slint";
 import { CommandPalette }        from "components/command_palette.slint";
+import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -270,6 +271,16 @@ export global UiState {
     /// Switch locale; Rust calls select_bundled_translation + set_locale and persists.
     callback set-language(string);
 
+    // ── Editor preferences ────────────────────────────────────────────────────
+    /// Number of spaces inserted when Tab is pressed. Persisted in config.toml.
+    in-out property <int> tab-width: 2;
+    /// Persist a new tab-width; Rust sends Command::UpdateConfig.
+    callback set-tab-width(int);
+    /// Open the editor-preferences dialog.
+    in-out property <bool> show-editor-prefs: false;
+    /// Fired when plain Tab is pressed; Rust inserts spaces and updates editor-text + cursor.
+    callback tab-key-pressed(int);  // cursor-position-byte-offset
+
     // ── UI → Controller callbacks ─────────────────────────────────────────────
     callback run-query(string);
     /// Ctrl+Enter from the editor: carries full text + cursor position so Rust
@@ -480,6 +491,10 @@ export component AppWindow inherits Window {
     private property <bool> _bk-edit-open:  UiState.show-snippet-edit;
     changed _bk-edit-open => { if (_bk-edit-open) { _bk-edit-alive = true; } }
 
+    private property <bool> _editor-prefs-alive: false;
+    private property <bool> _editor-prefs-open:  UiState.show-editor-prefs;
+    changed _editor-prefs-open => { if (_editor-prefs-open) { _editor-prefs-alive = true; } }
+
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
     // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
     // of which inner FocusScope — editor, table-view, sidebar, result — has focus.
@@ -504,7 +519,8 @@ export component AppWindow inherits Window {
                     || UiState.show-snippet-list
                     || UiState.show-snippet-edit
                     || UiState.show-metadata-search
-                    || UiState.show-command-palette) {
+                    || UiState.show-command-palette
+                    || UiState.show-editor-prefs) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -662,8 +678,9 @@ export component AppWindow inherits Window {
             run-all(sql)   => { UiState.run-all(sql); }
             cancel-query   => { UiState.cancel-query(); }
             set-language(lang) => { UiState.set-language(lang); }
-            add-snippet   => { UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos); }
-            show-snippets => { UiState.show-snippet-list = true; }
+            add-snippet      => { UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos); }
+            show-snippets    => { UiState.show-snippet-list = true; }
+            open-editor-prefs => { UiState.show-editor-prefs = true; }
         }
 
         // ── Tab bar (above the editor only) ──────────────────────────────────
@@ -769,6 +786,8 @@ export component AppWindow inherits Window {
                     UiState.find-sel-start = -1;
                     UiState.find-sel-end = -1;
                 }
+                tab-width: UiState.tab-width;
+                tab-key-pressed(cursor) => { UiState.tab-key-pressed(cursor); }
                 open-snippet-save(a, c) => { UiState.open-snippet-save(a, c); }
                 focus-sidebar => { root.focused-pane = 0; sidebar-inst.grab-focus(); }
                 focus-result  => {
@@ -1273,6 +1292,20 @@ export component AppWindow inherits Window {
             insert-sql(sql)  => { UiState.load-snippet-sql(sql, editor-inst.cursor-pos); }
             execute-sql(sql) => { UiState.execute-snippet-sql(sql); }
             close => { UiState.show-snippet-bar = false; }
+        }
+
+        // ── Editor preferences dialog ─────────────────────────────────────────
+        if _editor-prefs-alive: EditorPrefsDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:      UiState.show-editor-prefs;
+            tab-width: UiState.tab-width;
+            cancel-clicked => { UiState.show-editor-prefs = false; }
+            apply-clicked(w) => {
+                UiState.set-tab-width(w);
+                UiState.show-editor-prefs = false;
+            }
+            exited => { _editor-prefs-alive = false; }
         }
 
         // ── Metadata search palette (Ctrl+P) ──────────────────────────────────

--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -167,6 +167,51 @@ pub(super) fn register_language_callback(window: &crate::AppWindow, tx_cmd: mpsc
     });
 }
 
+// ── Editor preferences callbacks ──────────────────────────────────────────────
+
+pub(super) fn register_editor_prefs_callbacks(
+    window: &crate::AppWindow,
+    tx_cmd: mpsc::Sender<Command>,
+) {
+    let ui = window.global::<crate::UiState>();
+
+    // Tab key: insert spaces at cursor, then update editor text + cursor target.
+    // Runs on the UI thread (same as format_sql); text is committed before the
+    // cursor target change so set-selection-offsets validates against the new text.
+    let window_weak = window.as_weak(); // clone required: on_tab_key_pressed closure
+    ui.on_tab_key_pressed(move |cursor| {
+        let Some(window) = window_weak.upgrade() else {
+            return;
+        };
+        let ui = window.global::<crate::UiState>();
+        let text = ui.get_editor_text().to_string();
+        let tab_width = (ui.get_tab_width() as usize).max(1);
+        let cursor = cursor as usize;
+
+        if cursor > text.len() || !text.is_char_boundary(cursor) {
+            return;
+        }
+
+        let spaces = " ".repeat(tab_width);
+        let mut new_text = text;
+        new_text.insert_str(cursor, &spaces);
+        let new_cursor = (cursor + tab_width) as i32;
+
+        let shared: slint::SharedString = new_text.into();
+        ui.set_editor_text(shared.clone());
+        ui.set_editor_cursor_target(new_cursor);
+        ui.invoke_update_highlight(shared);
+    });
+
+    let tx_cmd = tx_cmd.clone(); // clone required: on_set_tab_width closure
+    ui.on_set_tab_width(move |width| {
+        send_cmd(
+            &tx_cmd,
+            Command::UpdateConfig(ConfigUpdate::TabWidth(width as u32)),
+        );
+    });
+}
+
 // ── Syntax highlight callback ─────────────────────────────────────────────────
 
 pub(super) fn register_highlight_callbacks(

--- a/app/src/ui/components/dialogs/editor_prefs_dialog.slint
+++ b/app/src/ui/components/dialogs/editor_prefs_dialog.slint
@@ -1,0 +1,109 @@
+import { Colors, Typography, Layout } from "../../theme.slint";
+import { ActionButton, ModalOverlay } from "../common.slint";
+
+export component EditorPrefsDialog inherits ModalOverlay {
+    callback cancel-clicked;
+    callback apply-clicked(int);
+
+    in-out property <int> tab-width: 2;
+
+    VerticalLayout {
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-2xl;
+        alignment: start;
+
+        Text {
+            text: @tr("Editor Preferences");
+            color: Colors.text;
+            font-size: Typography.size-xl;
+            font-weight: 700;
+        }
+
+        // Tab-width selector row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Tab Width");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            // Three segmented buttons: 2 / 4 / 8
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                tw2 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.tab-width == 2 ? Colors.blue : Colors.surface2;
+                    background: root.tab-width == 2 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "2";
+                        color: root.tab-width == 2 ? Colors.base : Colors.text;
+                        font-size: Typography.size-base;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.tab-width = 2; } }
+                }
+
+                tw4 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.tab-width == 4 ? Colors.blue : Colors.surface2;
+                    background: root.tab-width == 4 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "4";
+                        color: root.tab-width == 4 ? Colors.base : Colors.text;
+                        font-size: Typography.size-base;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.tab-width = 4; } }
+                }
+
+                tw8 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.tab-width == 8 ? Colors.blue : Colors.surface2;
+                    background: root.tab-width == 8 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "8";
+                        color: root.tab-width == 8 ? Colors.base : Colors.text;
+                        font-size: Typography.size-base;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.tab-width = 8; } }
+                }
+            }
+        }
+
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: end;
+            ActionButton {
+                width: 80px;
+                text: @tr("Cancel");
+                clicked => { root.cancel-clicked(); }
+            }
+            ActionButton {
+                width: 80px;
+                text: @tr("Apply");
+                bg: Colors.blue;
+                fg: Colors.base;
+                clicked => { root.apply-clicked(root.tab-width); }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -107,6 +107,11 @@ export component Editor inherits Rectangle {
     /// Fired when Esc is pressed while the find bar is open and editor has focus.
     callback close-find-bar();
 
+    /// Number of spaces to insert when Tab is pressed. Forwarded from UiState.
+    in property <int> tab-width: 2;
+    /// Fired when plain Tab is pressed; Rust inserts spaces and updates editor-text + cursor.
+    callback tab-key-pressed(int);  // cursor-position-byte-offset
+
     /// Byte offsets of the current find-bar match highlight (-1 = clear selection).
     in-out property <int> find-sel-start: -1;
     in-out property <int> find-sel-end:   -1;
@@ -478,6 +483,13 @@ export component Editor inherits Rectangle {
                         // Close popup; let event bubble to root key-pressed for tab switching.
                         root.completion-visible = false;
                         EventResult.reject
+                    } else if (event.text == Key.Tab
+                            && !event.modifiers.shift
+                            && !event.modifiers.control
+                            && !event.modifiers.alt) {
+                        root.completion-visible = false;
+                        root.tab-key-pressed(inner-input.cursor-position-byte-offset);
+                        EventResult.accept
                     } else {
                         // Close popup immediately on characters that end a SQL token
                         // (statement terminator, space, comma, parentheses).  This
@@ -597,6 +609,12 @@ export component Editor inherits Rectangle {
                         && root.find-bar-open
                         && !root.completion-visible) {
                     root.close-find-bar();
+                    EventResult.accept
+                } else if (event.text == Key.Tab
+                        && !event.modifiers.shift
+                        && !event.modifiers.control
+                        && !event.modifiers.alt) {
+                    root.tab-key-pressed(inner-input.cursor-position-byte-offset);
                     EventResult.accept
                 } else {
                     EventResult.reject

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -23,6 +23,7 @@ export component MenuBar inherits Rectangle {
     callback set-language(string);
     callback add-snippet();
     callback show-snippets();
+    callback open-editor-prefs();
     in property <string> editor-text;
     in property <string> language: "en";
     in property <bool>   has-active-connection: false;
@@ -109,13 +110,13 @@ export component MenuBar inherits Rectangle {
             edit-popup := PopupWindow {
                 x: 0;
                 y: root.height;
-                width:  180px;
-                height: Layout.height-menu-item;
+                width:  220px;
+                height: 2 * Layout.height-menu-item + 1px;
                 close-policy: PopupClosePolicy.close-on-click;
 
                 Rectangle {
-                    width:  180px;
-                    height: Layout.height-menu-item;
+                    width:  220px;
+                    height: 2 * Layout.height-menu-item + 1px;
                     background:    Colors.surface0;
                     border-radius: Layout.radius-md;
                     border-width:  1px;
@@ -127,6 +128,11 @@ export component MenuBar inherits Rectangle {
                     VerticalLayout {
                         spacing: 0;
                         MenuItem { text: @tr("Toggle Theme"); clicked => { root.toggle-theme(); } }
+                        Rectangle { height: 1px; background: Colors.surface1; }
+                        MenuItem {
+                            text: @tr("Editor Preferences\u{2026}");
+                            clicked => { root.open-editor-prefs(); }
+                        }
                     }
                 }
             }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -457,6 +457,7 @@ impl UI {
         ui_global.set_font_family(config.appearance.font_family.into());
         ui_global.set_font_size(config.appearance.font_size as i32);
         ui_global.set_reduce_motion(config.appearance.reduce_motion);
+        ui_global.set_tab_width(config.editor.tab_width as i32);
         // Apply locale after the Slint component exists — select_bundled_translation
         // requires a live component and is a no-op if called before one is created.
         let lang = &config.ui.language;
@@ -530,6 +531,7 @@ impl UI {
             tx_cmd.clone(),
             enc_key,
         );
+        appearance::register_editor_prefs_callbacks(&window, tx_cmd.clone());
         appearance::register_highlight_callbacks(&window, hl_model.clone());
 
         // Highlight the editor text that was already set from session / tab restore.

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -158,6 +158,7 @@ mod tests {
         let original = Config {
             editor: EditorConfig {
                 page_size: PageSize::Rows100,
+                tab_width: 2,
             },
             ..Config::default()
         };

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -96,10 +96,20 @@ impl Default for AppearanceConfig {
 // EditorConfig  [editor]
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct EditorConfig {
     pub page_size: PageSize,
+    pub tab_width: u32,
+}
+
+impl Default for EditorConfig {
+    fn default() -> Self {
+        Self {
+            page_size: PageSize::default(),
+            tab_width: 2,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -195,6 +205,7 @@ mod tests {
         assert_eq!(cfg.appearance.font_size, 14);
         assert!(!cfg.appearance.reduce_motion);
         assert_eq!(cfg.editor.page_size, PageSize::Rows500);
+        assert_eq!(cfg.editor.tab_width, 2);
         assert_eq!(cfg.session.last_query, None);
         assert_eq!(cfg.ui.language, "en");
     }
@@ -210,6 +221,7 @@ reduce_motion = true
 
 [editor]
 page_size = 1000
+tab_width = 4
 
 [session]
 last_query = "SELECT * FROM users"
@@ -223,6 +235,7 @@ language = "ja"
         assert_eq!(cfg.appearance.font_family, "Fira Code");
         assert_eq!(cfg.appearance.font_size, 16);
         assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
+        assert_eq!(cfg.editor.tab_width, 4);
         assert_eq!(
             cfg.session.last_query,
             Some("SELECT * FROM users".to_string())
@@ -273,6 +286,7 @@ language = "ja"
             },
             editor: EditorConfig {
                 page_size: PageSize::Rows100,
+                tab_width: 4,
             },
             session: SessionConfig {
                 last_query: Some("SELECT 1".to_string()),


### PR DESCRIPTION
## Summary

Tab key now inserts spaces (default 2) instead of a literal tab character, matching the behaviour of most code editors. Tab width (2, 4, or 8 spaces) is configurable via the new Edit → Editor Preferences dialog and persisted to `config.toml` under `[editor].tab_width`.

## Changes

- `crates/wf-config/src/models.rs`: added `tab_width: u32` (default 2) to `EditorConfig` with a manual `Default` impl; updated serialization tests
- `app/src/app/command.rs`: added `ConfigUpdate::TabWidth(u32)` variant
- `app/src/app/controller/config.rs`: handle `TabWidth` by calling `session.save_tab_width`
- `app/src/app/session.rs`: added `save_tab_width` that persists to `[editor].tab_width` in `config.toml`
- `app/src/ui/components/dialogs/editor_prefs_dialog.slint` (new): modal dialog with 2/4/8 segmented button selector and Apply/Cancel actions
- `app/src/ui/components/menu_bar.slint`: added Edit → "Editor Preferences…" menu item
- `app/src/ui/components/editor.slint`: intercept plain Tab in `capture-key-pressed` (both when completion popup is open and when closed); fire `tab-key-pressed(cursor)` callback and return `EventResult.accept` to block TextInput from inserting a literal tab
- `app/src/ui/app.slint`: added `tab-width`, `set-tab-width`, `show-editor-prefs`, `tab-key-pressed` to `UiState`; wired dialog lifecycle and editor properties; added `show-editor-prefs` to modal guard
- `app/src/ui/appearance.rs`: `register_editor_prefs_callbacks` — `on_tab_key_pressed` inserts spaces via `set_editor_text` + `set_editor_cursor_target` (same pattern as `format_sql`, avoids `is_char_boundary` panic from deferred text buffer updates); `on_set_tab_width` persists via command
- `app/src/ui/mod.rs`: initialise `tab-width` from `config.editor.tab_width` at startup; call `register_editor_prefs_callbacks`

## Related Issues

Closes #259

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes