### PR TITLE
fix(completion): invoke highlight update after accepting a completion item

### DIFF
--- a/app/src/ui/completion.rs
+++ b/app/src/ui/completion.rs
@@ -239,8 +239,12 @@ pub(super) fn register_completion_accept_callback(window: &crate::AppWindow) {
 
                 // inserted text, e.g. between the quotes in `''`).
                 let at_end = final_cursor as usize == final_text.len();
-                ui.set_editor_text(final_text.clone().into());
+                let final_shared: slint::SharedString = final_text.clone().into();
+                ui.set_editor_text(final_shared.clone());
                 ui.set_editor_cursor_target(final_cursor);
+                // set_editor_text from Rust does not fire text-edited, so the
+                // highlight overlay must be refreshed explicitly here.
+                ui.invoke_update_highlight(final_shared);
                 // Re-trigger only when the cursor is at end of inserted text AND the text
                 // does not end at a syntactically terminal expression (IS NULL, TRUE, FALSE,
                 // a string/numeric literal, ASC/DESC).  Terminal positions use a virtual


### PR DESCRIPTION
## Summary

Accepting a completion item (Enter or click) inserted text that was rendered without syntax highlighting, appearing black against the dark background. This fix explicitly refreshes the highlight overlay immediately after the text is committed.

## Changes

- **Root cause**: `register_completion_accept_callback` calls `ui.set_editor_text()` from Rust. Setting text programmatically does not fire Slint's `text-edited` signal, so `on_update_highlight` was never invoked and the inserted text had no color spans.
- **Fix**: Call `ui.invoke_update_highlight(final_shared)` after `set_editor_text` / `set_editor_cursor_target`, matching the same pattern used in `on_tab_key_pressed` (appearance.rs).

## Related Issues

Fixes #301

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes