### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.9.0] - 2026-05-07
 
+### v0.9.0 - Editor Polish & Security Hardening
+
+#### Added
+
+- SQL syntax highlighting with a color overlay in the editor (keywords, identifiers, strings, comments, operators)
+- Animation system with `reduce-motion` config option; all transitions respect the setting
+- Floating find/replace bar with search history (Ctrl+F)
+- Snippet system: save, browse, and insert reusable SQL snippets via a draggable panel
+- INSERT SQL export from query results (complements existing CSV and JSON export)
+- Metadata search palette (Ctrl+P): fuzzy-search tables, columns, and views
+- Command palette (Ctrl+K): fuzzy-search connections and built-in actions
+- Platform abstraction layer for OS directories, DPI, and native dark-mode detection
+- Distribution packaging: Windows MSIX, macOS DMG, and Linux AppImage via `cargo x package`
+- Tab key inserts spaces with configurable width (2 / 4 / 8) via Edit → Editor Preferences
+
+#### Fixed
+
+- Text-jump on Enter in the syntax-highlight overlay (stale `line-h` for one frame) (#252)
+- Password redacted from controller command log and `ConnectionFailed` error messages (#268)
+- Username and password in PostgreSQL/MySQL connection URLs are now percent-encoded (#269)
+- Key file and directory permissions restricted to owner-only on Unix (0o600 / 0o700) (#270)
+- Leading SQL comments (`--`, `/* */`) no longer bypass DML safety checks (#271, #296)
+- Completion popup stays open after Backspace clears the word prefix (#260)
+- Accepted completion item text was not syntax-highlighted until next keystroke (#301)
+- Re-connecting to an already-active connection from the command palette is now a no-op
+
+#### Changed
+
+- All SQLite databases consolidated into a single `wellfeather.db` file
+
 ## [0.8.0] - 2026-05-02
 
 ### v0.8.0 - Multi-tab Interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-07
+
 ## [0.8.0] - 2026-05-02
 
 ### v0.8.0 - Multi-tab Interface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6845,7 +6845,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wellfeather"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -6877,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "wf-completion"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "wf-config"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "wf-db"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6930,7 +6930,7 @@ dependencies = [
 
 [[package]]
 name = "wf-history"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "wf-query"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.93.0"
 description = "A lightweight, keyboard-centric SQL client built with Rust and Slint"


### PR DESCRIPTION
## Summary

Prepares the v0.9.0 release — editor polish, new productivity features, and security hardening since v0.8.0.

## Changes

- `Cargo.toml`: version 0.8.0 → 0.9.0
- `Cargo.lock`: updated
- `CHANGELOG.md`: add [0.9.0] section with Added / Fixed / Changed entries

## Related Issues

Closes #259, #252, #260, #301, #268, #269, #270, #271, #296, #63, #64, #59, #80, #81, #82, #199, #200, #202, #203, #242, #247

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes