### PR TITLE
fix(app): suppress Windows console window in release builds

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 //! Application entry point.
 //!
 //! Responsibilities:


### PR DESCRIPTION
## Summary

On Windows, launching the app from Explorer or a ZIP-extracted binary opened a black terminal console window behind the main GUI window. This is because Rust defaults to the `console` subsystem on Windows. Adding `windows_subsystem = "windows"` tells the linker to use the GUI subsystem, which suppresses the console window entirely.

## Changes

- `app/src/main.rs`: added `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` — applies only in release builds so that debug builds retain the console for tracing output

## Related Issues

Fixes #304

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes