### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-08
+
+### Fixed
+
+- Suppress Windows console window appearing behind the GUI app in release builds
+
 ## [0.9.0] - 2026-05-07
 
 ### v0.9.0 - Editor Polish & Security Hardening

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6998,7 +6998,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wellfeather"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -7030,7 +7030,7 @@ dependencies = [
 
 [[package]]
 name = "wf-completion"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -7047,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "wf-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "wf-db"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "wf-history"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "wf-query"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.93.0"
 description = "A lightweight, keyboard-centric SQL client built with Rust and Slint"


### PR DESCRIPTION
## Summary

Prepares the v0.9.1 patch release.

## Changes

- `Cargo.toml`: version 0.9.0 -> 0.9.1
- `CHANGELOG.md`: add [0.9.1] section

## Related Issues

Fixes #304

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes