### PR TITLE
fix(wf-db): validate SQLite path to reject traversal and special URIs

### DIFF
--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -13,5 +13,6 @@ error:
   db_connect_failed: "Failed to connect: %{reason}"
   query_failed: "Query error: %{reason}"
   query_cancelled: "Query cancelled"
+  invalid_config: "Invalid configuration: %{reason}"
   db_error: "Database error: %{reason}"
   read_only_blocked: "Blocked: connection is read-only"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -13,5 +13,6 @@ error:
   db_connect_failed: "接続に失敗しました: %{reason}"
   query_failed: "クエリエラー: %{reason}"
   query_cancelled: "クエリをキャンセルしました"
+  invalid_config: "設定が無効です: %{reason}"
   db_error: "データベースエラー: %{reason}"
   read_only_blocked: "読み取り専用接続のため実行できません"

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -11,6 +11,7 @@ impl LocalizedMessage for DbError {
             DbError::ConnectionFailed(s) => t!("error.db_connect_failed", reason = s).to_string(),
             DbError::QueryError(s) => t!("error.query_failed", reason = s).to_string(),
             DbError::Cancelled => t!("error.query_cancelled").to_string(),
+            DbError::InvalidConfig(s) => t!("error.invalid_config", reason = s).to_string(),
             DbError::Sqlx(e) => t!("error.db_error", reason = e.to_string()).to_string(),
         }
     }

--- a/crates/wf-db/src/error.rs
+++ b/crates/wf-db/src/error.rs
@@ -13,6 +13,9 @@ pub enum DbError {
     #[error("query cancelled")]
     Cancelled,
 
+    #[error("invalid configuration: {0}")]
+    InvalidConfig(String),
+
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
 }

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -42,7 +42,7 @@ impl DbPool {
                 Ok(DbPool::My(pool))
             }
             DbType::SQLite => {
-                let url = sqlite_url(conn);
+                let url = sqlite_url(conn)?;
                 let pool = SqlitePool::connect(&url)
                     .await
                     .map_err(|e| DbError::ConnectionFailed(redact_url_password(&e.to_string())))?;
@@ -160,14 +160,29 @@ pub(crate) fn my_url(conn: &DbConnection, password: Option<&str>) -> String {
 
 /// Build a SQLite connection URL from `conn`.
 /// Returns `conn.connection_string` unchanged if present.
-/// Treats `":memory:"` and `None` as an in-process SQLite database.
-pub(crate) fn sqlite_url(conn: &DbConnection) -> String {
+/// `None` database maps to an in-process SQLite database.
+///
+/// Rejects paths that start with `:` or `file:` (special SQLite URI forms)
+/// and paths that contain `..` components (path traversal).
+pub(crate) fn sqlite_url(conn: &DbConnection) -> Result<String, DbError> {
     if let Some(url) = &conn.connection_string {
-        return url.clone();
+        return Ok(url.clone());
     }
     match conn.database.as_deref() {
-        Some(":memory:") | None => "sqlite::memory:".to_string(),
-        Some(path) => format!("sqlite:{}", path),
+        None => Ok("sqlite::memory:".to_string()),
+        Some(path) => {
+            if path.starts_with(':') || path.starts_with("file:") {
+                return Err(DbError::InvalidConfig(
+                    "SQLite path must be a file path, not a special URI".into(),
+                ));
+            }
+            if path.split(['/', '\\']).any(|c| c == "..") {
+                return Err(DbError::InvalidConfig(
+                    "SQLite path must not contain '..'".into(),
+                ));
+            }
+            Ok(format!("sqlite:{}", path))
+        }
     }
 }
 
@@ -364,14 +379,54 @@ mod tests {
     #[test]
     fn sqlite_url_should_return_memory_url_when_database_is_none() {
         let conn = sqlite_conn_fields_memory();
-        assert_eq!(sqlite_url(&conn), "sqlite::memory:");
+        assert_eq!(sqlite_url(&conn).unwrap(), "sqlite::memory:");
     }
 
     #[test]
     fn sqlite_url_should_use_database_field_as_path() {
         let mut conn = sqlite_conn_fields_memory();
         conn.database = Some("mydb.sqlite".to_string());
-        assert_eq!(sqlite_url(&conn), "sqlite:mydb.sqlite");
+        assert_eq!(sqlite_url(&conn).unwrap(), "sqlite:mydb.sqlite");
+    }
+
+    #[test]
+    fn sqlite_url_should_reject_parent_dir_traversal() {
+        let mut conn = sqlite_conn_fields_memory();
+        conn.database = Some("../../sensitive.db".to_string());
+        assert!(
+            matches!(sqlite_url(&conn), Err(DbError::InvalidConfig(_))),
+            "expected InvalidConfig for path traversal"
+        );
+    }
+
+    #[test]
+    fn sqlite_url_should_reject_colon_prefix() {
+        let mut conn = sqlite_conn_fields_memory();
+        conn.database = Some(":memory:".to_string());
+        assert!(
+            matches!(sqlite_url(&conn), Err(DbError::InvalidConfig(_))),
+            "expected InvalidConfig for :memory: prefix"
+        );
+    }
+
+    #[test]
+    fn sqlite_url_should_reject_file_uri_prefix() {
+        let mut conn = sqlite_conn_fields_memory();
+        conn.database = Some("file:path.db?mode=memory".to_string());
+        assert!(
+            matches!(sqlite_url(&conn), Err(DbError::InvalidConfig(_))),
+            "expected InvalidConfig for file: prefix"
+        );
+    }
+
+    #[test]
+    fn sqlite_url_should_accept_absolute_path() {
+        let mut conn = sqlite_conn_fields_memory();
+        conn.database = Some("/home/user/data/mydb.sqlite".to_string());
+        assert_eq!(
+            sqlite_url(&conn).unwrap(),
+            "sqlite:/home/user/data/mydb.sqlite"
+        );
     }
 
     // -- Integration tests (require SQLite runtime) ------------------------


### PR DESCRIPTION
## Summary

`sqlite_url()` in `wf-db` passed the `database` field directly into the connection URL without any validation. This allowed paths containing `..` sequences (path traversal) or special SQLite URI forms (`:memory:`, `file:...`) to be accepted silently. This PR adds input validation that rejects such paths with a typed `DbError::InvalidConfig` error before any connection is attempted.

## Changes

- `crates/wf-db/src/error.rs`: added `InvalidConfig(String)` variant to `DbError`
- `crates/wf-db/src/pool.rs`: `sqlite_url` now returns `Result<String, DbError>`; rejects paths starting with `:` or `file:`, and paths whose components contain `..`; 4 new unit tests added
- `app/src/app/localized_message.rs`: added `InvalidConfig` arm to `LocalizedMessage` impl
- `app/locales/en.yml` + `ja.yml`: added `error.invalid_config` translation key

## Related Issues

Fixes #272

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes