### PR TITLE
fix(crypto): zero plaintext passwords from heap memory after decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7026,6 +7026,7 @@ dependencies = [
  "wf-history",
  "wf-query",
  "windows 0.62.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -7063,6 +7064,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -25,6 +25,7 @@ serde              = { workspace = true, features = ["derive"] }
 toml               = "1"
 rust-i18n          = "4.0.0"
 regex              = "1.12.3"
+zeroize            = "1"
 fuzzy-matcher      = "0.3.7"
 directories        = "6.0.0"
 thiserror          = { workspace = true }

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -1,5 +1,6 @@
 use wf_config::models::{PageSize, Theme};
 use wf_db::models::DbConnection;
+use zeroize::Zeroizing;
 
 /// Granular config change sent from the UI.
 #[derive(Debug)]
@@ -22,12 +23,12 @@ pub enum ConfigUpdate {
 pub enum Command {
     /// Connect to a database. The second field carries the plaintext password
     /// (decrypted by the caller); `wf-db` must not depend on `wf-config::crypto`.
-    /// Password encryption is wired in T028.
-    Connect(DbConnection, Option<String>),
+    /// Wrapped in `Zeroizing` so the plaintext is scrubbed from heap on drop.
+    Connect(DbConnection, Option<Zeroizing<String>>),
     /// Test a connection without persisting it to state or the sidebar.
     /// On success sends [`Event::TestConnectionOk`]; on failure sends
     /// [`Event::TestConnectionFailed`].
-    TestConnection(DbConnection, Option<String>),
+    TestConnection(DbConnection, Option<Zeroizing<String>>),
     Disconnect(String),       // connection_id
     RemoveConnection(String), // connection_id — disconnect + delete from config
     RunQuery(String),         // sql
@@ -74,6 +75,7 @@ impl Command {
 #[cfg(test)]
 mod tests {
     use wf_db::models::{DbConnection, DbType};
+    use zeroize::Zeroizing;
 
     use super::Command;
 
@@ -93,19 +95,19 @@ mod tests {
 
     #[test]
     fn variant_name_should_return_connect_for_connect_command() {
-        let cmd = Command::Connect(dummy_conn(), Some("s3cret".to_string()));
+        let cmd = Command::Connect(dummy_conn(), Some(Zeroizing::new("s3cret".to_string())));
         assert_eq!(cmd.variant_name(), "Connect");
     }
 
     #[test]
     fn variant_name_should_not_expose_password_in_connect() {
-        let cmd = Command::Connect(dummy_conn(), Some("s3cret".to_string()));
+        let cmd = Command::Connect(dummy_conn(), Some(Zeroizing::new("s3cret".to_string())));
         assert!(!cmd.variant_name().contains("s3cret"));
     }
 
     #[test]
     fn variant_name_should_not_expose_password_in_test_connection() {
-        let cmd = Command::TestConnection(dummy_conn(), Some("s3cret".to_string()));
+        let cmd = Command::TestConnection(dummy_conn(), Some(Zeroizing::new("s3cret".to_string())));
         assert!(!cmd.variant_name().contains("s3cret"));
     }
 

--- a/app/src/app/controller/connection.rs
+++ b/app/src/app/controller/connection.rs
@@ -1,15 +1,24 @@
 use tracing::{info, warn};
 use wf_db::models::DbConnection;
+use zeroize::Zeroizing;
 
 use crate::app::{LocalizedMessage, event::Event, session::db_to_config_conn};
 
 use super::AppController;
 
 impl AppController {
-    pub(super) async fn handle_connect(&self, conn: DbConnection, password: Option<String>) {
+    pub(super) async fn handle_connect(
+        &self,
+        conn: DbConnection,
+        password: Option<Zeroizing<String>>,
+    ) {
         let id = conn.id.clone();
         info!(conn_id = %id, "handling Connect command");
-        match self.db.connect(&conn, password.as_deref()).await {
+        match self
+            .db
+            .connect(&conn, password.as_ref().map(|z| z.as_str()))
+            .await
+        {
             Ok(()) => {
                 let conn_cfg = db_to_config_conn(&conn);
                 if let Err(e) = self.repo.upsert(&conn_cfg).await {
@@ -74,11 +83,15 @@ impl AppController {
     pub(super) async fn handle_test_connection(
         &self,
         conn: DbConnection,
-        password: Option<String>,
+        password: Option<Zeroizing<String>>,
     ) {
         let id = conn.id.clone();
         info!(conn_id = %id, "handling TestConnection command");
-        match self.db.connect(&conn, password.as_deref()).await {
+        match self
+            .db
+            .connect(&conn, password.as_ref().map(|z| z.as_str()))
+            .await
+        {
             Ok(()) => {
                 self.db.disconnect(&id);
                 info!(conn_id = %id, "test connection succeeded");

--- a/app/src/ui/connection.rs
+++ b/app/src/ui/connection.rs
@@ -32,7 +32,10 @@ pub(super) fn db_type_label_config(dt: &DbTypeName) -> &'static str {
 /// The plaintext password is also AES-256-GCM encrypted with `enc_key` and stored in
 /// `DbConnection.password_encrypted` so the session manager can persist it and
 /// `main.rs` can decrypt it on the next startup for auto-reconnect.
-fn build_conn_from_form(ui: &crate::UiState, enc_key: &[u8; 32]) -> (DbConnection, Option<String>) {
+fn build_conn_from_form(
+    ui: &crate::UiState,
+    enc_key: &[u8; 32],
+) -> (DbConnection, Option<zeroize::Zeroizing<String>>) {
     let db_type = match ui.get_form_db_type() {
         0 => DbType::PostgreSQL,
         1 => DbType::MySQL,
@@ -48,7 +51,7 @@ fn build_conn_from_form(ui: &crate::UiState, enc_key: &[u8; 32]) -> (DbConnectio
     let password = if is_conn_string {
         None
     } else {
-        opt(ui.get_form_password())
+        opt(ui.get_form_password()).map(zeroize::Zeroizing::new)
     };
 
     // Encrypt the plaintext password for safe storage in config.toml.
@@ -307,11 +310,13 @@ pub(super) fn register_sidebar_callbacks(
             let safe_dml = conn_cfg.safe_dml;
             let read_only = conn_cfg.read_only;
 
-            // Decrypt stored password (only present for individual-field connections).
-            let stored_password = conn
+            // Decrypt stored password for pre-filling the UI form. Convert to plain
+            // String at this point since it flows directly into SharedString UI fields.
+            let stored_password: String = conn
                 .password_encrypted
                 .as_ref()
                 .and_then(|enc| crypto::decrypt(enc, &enc_key).ok())
+                .map(|z| z.as_str().to_owned())
                 .unwrap_or_default();
 
             let is_conn_string = conn.connection_string.is_some();

--- a/crates/wf-config/Cargo.toml
+++ b/crates/wf-config/Cargo.toml
@@ -24,6 +24,7 @@ aes-gcm     = "0.10.3"
 directories = "6.0.0"
 rand        = "0.10.0"
 base64      = "0.22.1"
+zeroize     = "1.8.2"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/crates/wf-config/src/crypto.rs
+++ b/crates/wf-config/src/crypto.rs
@@ -6,6 +6,7 @@ use aes_gcm::{
 };
 use anyhow::Context as _;
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+use zeroize::{Zeroize, Zeroizing};
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -35,6 +36,9 @@ pub fn encrypt(plaintext: &str, key: &[u8; 32]) -> String {
 
 /// Decrypts a `"<nonce>:<ciphertext>"` Base64 string produced by [`encrypt`].
 ///
+/// The returned `Zeroizing<String>` zeroes the plaintext bytes from heap memory
+/// when dropped, preventing passwords from lingering in process memory.
+///
 /// # Errors
 ///
 /// Returns `Err` if:
@@ -43,7 +47,7 @@ pub fn encrypt(plaintext: &str, key: &[u8; 32]) -> String {
 /// - The nonce is not exactly 12 bytes
 /// - The GCM authentication tag does not match (tampered or corrupt data)
 /// - The decrypted bytes are not valid UTF-8
-pub fn decrypt(ciphertext: &str, key: &[u8; 32]) -> anyhow::Result<String> {
+pub fn decrypt(ciphertext: &str, key: &[u8; 32]) -> anyhow::Result<Zeroizing<String>> {
     let (nonce_b64, ct_b64) = ciphertext
         .split_once(':')
         .ok_or_else(|| anyhow::anyhow!("invalid ciphertext format: expected '<nonce>:<ct>'"))?;
@@ -64,11 +68,14 @@ pub fn decrypt(ciphertext: &str, key: &[u8; 32]) -> anyhow::Result<String> {
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     let nonce = Nonce::from_slice(&nonce_bytes);
 
-    let plaintext_bytes = cipher
+    let mut plaintext_bytes = cipher
         .decrypt(nonce, ct_bytes.as_slice())
         .map_err(|_| anyhow::anyhow!("decryption failed: GCM authentication tag mismatch"))?;
 
-    String::from_utf8(plaintext_bytes).context("decrypted bytes are not valid UTF-8")
+    let s = String::from_utf8(plaintext_bytes.clone())
+        .context("decrypted bytes are not valid UTF-8")?;
+    plaintext_bytes.zeroize();
+    Ok(Zeroizing::new(s))
 }
 
 /// Loads the application encryption key from `dir/.wellfeather.key`.
@@ -159,7 +166,7 @@ mod tests {
         let plaintext = "super-secret-password-123!";
         let encrypted = encrypt(plaintext, TEST_KEY);
         let decrypted = decrypt(&encrypted, TEST_KEY).expect("decrypt should succeed");
-        assert_eq!(decrypted, plaintext);
+        assert_eq!(decrypted.as_str(), plaintext);
     }
 
     #[test]
@@ -304,7 +311,7 @@ mod tests {
             let ciphertext = encrypt(&plaintext, &key);
             let decrypted = decrypt(&ciphertext, &key)
                 .expect("decrypt should succeed for valid ciphertext");
-            prop_assert_eq!(decrypted, plaintext);
+            prop_assert_eq!(decrypted.as_str(), plaintext.as_str());
         }
     }
 }

--- a/crates/wf-config/src/crypto.rs
+++ b/crates/wf-config/src/crypto.rs
@@ -6,7 +6,7 @@ use aes_gcm::{
 };
 use anyhow::Context as _;
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -68,13 +68,15 @@ pub fn decrypt(ciphertext: &str, key: &[u8; 32]) -> anyhow::Result<Zeroizing<Str
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     let nonce = Nonce::from_slice(&nonce_bytes);
 
-    let mut plaintext_bytes = cipher
-        .decrypt(nonce, ct_bytes.as_slice())
-        .map_err(|_| anyhow::anyhow!("decryption failed: GCM authentication tag mismatch"))?;
+    // Zeroizing<Vec<u8>> ensures bytes are zeroed on drop in both success and error paths.
+    let plaintext_bytes = Zeroizing::new(
+        cipher
+            .decrypt(nonce, ct_bytes.as_slice())
+            .map_err(|_| anyhow::anyhow!("decryption failed: GCM authentication tag mismatch"))?,
+    );
 
-    let s = String::from_utf8(plaintext_bytes.clone())
+    let s = String::from_utf8((*plaintext_bytes).clone())
         .context("decrypted bytes are not valid UTF-8")?;
-    plaintext_bytes.zeroize();
     Ok(Zeroizing::new(s))
 }
 


### PR DESCRIPTION
## Summary

Decrypted passwords were retained in heap memory indefinitely after `crypto::decrypt` returned. This fix adds `zeroize` to scrub the intermediate `Vec<u8>` of raw plaintext bytes before the `String` is created, and wraps the return value in `Zeroizing<String>` so the final plaintext is scrubbed when it goes out of scope. The `Zeroizing` wrapper is propagated through `Command::Connect` and `Command::TestConnection` to maximize the time credentials spend protected.

## Changes

- **Root cause**: `crypto::decrypt` allocated a `Vec<u8>` of plaintext bytes and a `String` from it, neither of which was ever zeroed
- **Fix**: Added `zeroize` crate to `wf-config`; `decrypt` now zeros `plaintext_bytes` before returning and returns `Zeroizing<String>` instead of `String`
- **Propagation**: `Command::Connect` and `Command::TestConnection` now carry `Option<Zeroizing<String>>`; `handle_connect` / `handle_test_connection` updated accordingly; `build_conn_from_form` wraps user-typed passwords in `Zeroizing::new()`
- **UI boundary**: `stored_password` used to pre-fill the connection form is converted to plain `String` at the `SharedString` boundary, where the password is displayed in clear text anyway
- **Tests**: Updated `assert_eq!` comparisons in `crypto.rs` to compare via `.as_str()`; updated `command.rs` test fixtures to use `Zeroizing::new(...)`

## Related Issues

Fixes #274

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes