### PR TITLE
feat(ssh): SSH tunnel support for database connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.7",
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -151,11 +161,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
- "ghash",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+dependencies = [
+ "aead 0.6.0-rc.10",
+ "aes 0.9.0",
+ "cipher 0.5.1",
+ "ctr 0.10.0",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -350,6 +374,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
 ]
 
 [[package]]
@@ -624,6 +660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base62"
 version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +682,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "bincode"
@@ -717,12 +770,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -733,6 +795,24 @@ checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
  "zeroize",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -764,6 +844,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -903,6 +993,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
+dependencies = [
+ "cipher 0.5.1",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1054,17 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -985,6 +1104,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
+ "block-buffer 0.12.0",
  "crypto-common 0.2.1",
  "inout 0.2.2",
 ]
@@ -1336,12 +1456,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.0-rc.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -1352,7 +1489,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1395,12 +1545,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
+dependencies = [
+ "cipher 0.5.1",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1408,6 +1568,39 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -1422,13 +1615,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1624,6 +1839,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+dependencies = [
+ "der 0.8.0",
+ "digest 0.11.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 3.0.0",
+ "spki 0.8.0-rc.4",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+dependencies = [
+ "pkcs8 0.11.0-rc.11",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,10 +1889,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "digest 0.11.3",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "once_cell",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "rustcrypto-group",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1797,6 +2088,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -2104,6 +2401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,8 +2437,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2168,7 +2478,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -2398,12 +2717,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2445,7 +2779,10 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
+ "ctutils",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2466,7 +2803,7 @@ dependencies = [
  "i-slint-renderer-software",
  "input",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "raw-window-handle",
  "xkbcommon",
 ]
@@ -2975,7 +3312,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "block-padding 0.3.3",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2984,6 +3322,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -3013,6 +3352,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.18+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f8a978272e3cbdf4768f7363eb1c8e1e6ba63c52a3ed05e29e222da4aec7cb"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "crypto-bigint",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.13.0",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa 0.10.0-rc.16",
+ "sec1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3154,6 +3534,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3392,7 +3792,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3423,6 +3823,12 @@ dependencies = [
  "cfg-if",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3473,6 +3879,30 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8198b5db27ac9773534c371751a59dc18aec8b80aa141e69abfdd1dec2e3f78c"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -3559,6 +3989,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no_std_io2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +4074,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -4149,6 +4592,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,6 +4714,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4735,16 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -4237,6 +4761,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -4308,9 +4841,36 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a777c6e26664bc9504b3ce3f6133f8f20d9071f130a4f9fcbd3186959d8dd6"
+dependencies = [
+ "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
+ "cbc 0.2.0",
+ "der 0.8.0",
+ "pbkdf2 0.13.0",
+ "rand_core 0.10.1",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -4319,8 +4879,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "pkcs5",
+ "rand_core 0.10.1",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -4382,6 +4954,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4390,7 +4973,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -4442,6 +5036,29 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4604,7 +5221,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -4846,6 +5463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+dependencies = [
+ "hmac 0.13.0",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,6 +5509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rowan"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,12 +5554,31 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -4933,6 +5593,112 @@ dependencies = [
  "snafu",
  "unicode-linebreak",
  "unicode-width",
+]
+
+[[package]]
+name = "russh"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e358980fe9b079b99da387117864ee6f0a3fd02f39e5b5fde6af9c2895374"
+dependencies = [
+ "aead 0.6.0-rc.10",
+ "aes 0.8.4",
+ "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
+ "bitflags 2.11.1",
+ "block-padding 0.3.3",
+ "byteorder",
+ "bytes",
+ "cbc 0.1.2",
+ "cbc 0.2.0",
+ "cipher 0.5.1",
+ "crypto-bigint",
+ "ctr 0.10.0",
+ "ctr 0.9.2",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der 0.8.0",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.1",
+ "getrandom 0.2.17",
+ "ghash 0.6.0",
+ "hex-literal",
+ "hkdf 0.13.0",
+ "hmac 0.12.1",
+ "hmac 0.13.0",
+ "inout 0.1.4",
+ "internal-russh-forked-ssh-key",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2 0.12.2",
+ "pbkdf2 0.13.0",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs5",
+ "pkcs8 0.11.0-rc.11",
+ "polyval 0.7.1",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "ring",
+ "rsa 0.10.0-rc.16",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20",
+ "scrypt",
+ "sec1",
+ "sha1 0.10.6",
+ "sha1 0.11.0",
+ "sha2 0.10.9",
+ "sha2 0.11.0",
+ "sha3",
+ "signature 3.0.0",
+ "spki 0.8.0-rc.4",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash 0.6.1",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+dependencies = [
+ "log",
+ "nix 0.31.2",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -5008,6 +5774,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5076,6 +5863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.1",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5103,6 +5900,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "sctk-adwaita"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5113,6 +5922,20 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia 0.11.4",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5220,6 +6043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,6 +6083,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -5285,6 +6139,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5610,7 +6474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -5662,7 +6536,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5700,7 +6574,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5730,9 +6604,9 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itoa",
  "log",
@@ -5741,10 +6615,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "sha1 0.10.6",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5772,7 +6646,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "home",
  "itoa",
@@ -5783,7 +6657,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5817,6 +6691,35 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "cbc 0.1.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6554,10 +7457,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.1",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -7050,7 +7969,7 @@ dependencies = [
 name = "wf-config"
 version = "0.9.1"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "anyhow",
  "base64",
  "directories",
@@ -7074,11 +7993,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
+ "russh",
  "serde",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -8100,7 +9022,7 @@ dependencies = [
  "indexmap",
  "lzma-rust2",
  "memchr",
- "pbkdf2",
+ "pbkdf2 0.13.0",
  "ppmd-rust",
  "sha1 0.11.0",
  "time",

--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -16,3 +16,7 @@ error:
   invalid_config: "Invalid configuration: %{reason}"
   db_error: "Database error: %{reason}"
   read_only_blocked: "Blocked: connection is read-only"
+  ssh_tunnel_failed: "SSH tunnel failed: %{reason}"
+  ssh_host_key_rejected: "SSH host key was not accepted"
+  ssh_fingerprint_mismatch: "SSH host key mismatch — expected: %{expected}, got: %{actual}"
+  ssh_conn_string_unsupported: "SSH tunnel is not supported with connection string mode. Switch to Individual Fields."

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -16,3 +16,7 @@ error:
   invalid_config: "設定が無効です: %{reason}"
   db_error: "データベースエラー: %{reason}"
   read_only_blocked: "読み取り専用接続のため実行できません"
+  ssh_tunnel_failed: "SSHトンネルの確立に失敗しました: %{reason}"
+  ssh_host_key_rejected: "SSHホスト鍵が承認されませんでした"
+  ssh_fingerprint_mismatch: "SSHホスト鍵が一致しません — 期待値: %{expected}、実際値: %{actual}"
+  ssh_conn_string_unsupported: "接続文字列モードではSSHトンネルはサポートされていません。Individual Fieldsに切り替えてください。"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -90,6 +90,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         }
     }
 

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -18,6 +18,7 @@ mod connection;
 mod metadata;
 mod query;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -47,6 +48,10 @@ pub struct AppController {
     completion: CompletionService,
     rx_cmd: mpsc::Receiver<Command>,
     tx_event: mpsc::Sender<Event>,
+    /// App config directory — used for the known-hosts file.
+    pub(crate) config_dir: PathBuf,
+    /// Encryption key for decrypting SSH credentials.
+    pub(crate) enc_key: [u8; 32],
 }
 
 impl AppController {
@@ -56,6 +61,7 @@ impl AppController {
     /// All services are expected to be fully initialised (schema migrations run)
     /// before being passed in. The shared `SqlitePool` backing them is managed by
     /// the caller (`main.rs`).
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         state: SharedState,
         db: DbService,
@@ -63,6 +69,8 @@ impl AppController {
         repo: Arc<ConnectionRepository>,
         history: HistoryService,
         metadata_cache: MetadataCache,
+        config_dir: PathBuf,
+        enc_key: [u8; 32],
     ) -> (Self, mpsc::Sender<Command>, mpsc::Receiver<Event>) {
         let (tx_cmd, rx_cmd) = mpsc::channel(CMD_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = mpsc::channel(CMD_CHANNEL_CAPACITY);
@@ -78,6 +86,8 @@ impl AppController {
                 completion,
                 rx_cmd,
                 tx_event,
+                config_dir,
+                enc_key,
             },
             tx_cmd,
             rx_event,
@@ -204,6 +214,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         }
     }
 
@@ -292,6 +303,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -318,6 +331,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         let bad = DbConnection {
@@ -330,6 +345,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         };
         tx_cmd
             .send(Command::TestConnection(bad, None))
@@ -358,6 +374,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -384,6 +402,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         let bad = DbConnection {
@@ -396,6 +416,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         };
         tx_cmd.send(Command::Connect(bad, None)).await.unwrap();
         drop(tx_cmd);
@@ -417,6 +438,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -456,6 +479,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -499,6 +524,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -524,6 +551,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd.send(Command::CancelQuery).await.unwrap();
@@ -546,6 +575,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd
@@ -579,6 +610,8 @@ mod tests {
             test_repo().await,
             test_history().await,
             test_metadata_cache().await,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
         );
 
         tx_cmd

--- a/app/src/app/controller/connection.rs
+++ b/app/src/app/controller/connection.rs
@@ -1,5 +1,12 @@
+use tokio::sync::oneshot;
 use tracing::{info, warn};
-use wf_db::models::DbConnection;
+use wf_config::crypto;
+use wf_db::{
+    models::DbConnection,
+    tunnel::{
+        KnownHostStatus, check_known_host, connect_tunnel, probe_fingerprint, save_known_host,
+    },
+};
 use zeroize::Zeroizing;
 
 use crate::app::{LocalizedMessage, event::Event, session::db_to_config_conn};
@@ -9,11 +16,111 @@ use super::AppController;
 impl AppController {
     pub(super) async fn handle_connect(
         &self,
-        conn: DbConnection,
+        mut conn: DbConnection,
         password: Option<Zeroizing<String>>,
     ) {
         let id = conn.id.clone();
         info!(conn_id = %id, "handling Connect command");
+
+        // ── SSH tunnel setup ──────────────────────────────────────────────────
+        if let Some(ssh_cfg) = &conn.ssh {
+            let known_hosts_path = self.config_dir.join("known_hosts.toml");
+
+            // Phase 1: probe fingerprint
+            let fingerprint = match probe_fingerprint(&ssh_cfg.host, ssh_cfg.port).await {
+                Ok(fp) => fp,
+                Err(e) => {
+                    warn!(conn_id = %id, error = %e, "SSH fingerprint probe failed");
+                    let _ = self
+                        .tx_event
+                        .send(Event::ConnectError(e.localized_message()))
+                        .await;
+                    return;
+                }
+            };
+
+            // Phase 2: check known hosts
+            let status =
+                check_known_host(&ssh_cfg.host, ssh_cfg.port, &fingerprint, &known_hosts_path);
+            match status {
+                KnownHostStatus::Trusted => {
+                    info!(conn_id = %id, "SSH host key trusted");
+                }
+                KnownHostStatus::Mismatch { expected, actual } => {
+                    warn!(conn_id = %id, %expected, %actual, "SSH host key mismatch");
+                    let err = wf_db::error::DbError::SshFingerprintMismatch { expected, actual };
+                    let _ = self
+                        .tx_event
+                        .send(Event::ConnectError(err.localized_message()))
+                        .await;
+                    return;
+                }
+                KnownHostStatus::Unknown => {
+                    // Ask the user to approve
+                    let (approval_tx, approval_rx) = oneshot::channel::<bool>();
+                    let _ = self
+                        .tx_event
+                        .send(Event::SshFingerprintRequired {
+                            fingerprint: fingerprint.clone(),
+                            approval_tx,
+                        })
+                        .await;
+
+                    let approved = approval_rx.await.unwrap_or(false);
+                    if !approved {
+                        info!(conn_id = %id, "SSH host key rejected by user");
+                        return;
+                    }
+                    // Persist trust
+                    if let Err(e) = save_known_host(
+                        &ssh_cfg.host,
+                        ssh_cfg.port,
+                        &fingerprint,
+                        &known_hosts_path,
+                    ) {
+                        warn!(conn_id = %id, error = %e, "failed to save known host");
+                    }
+                }
+            }
+
+            // Phase 3: decrypt SSH credentials and establish tunnel
+            let ssh_password = ssh_cfg
+                .ssh_password_encrypted
+                .as_deref()
+                .and_then(|enc| crypto::decrypt(enc, &self.enc_key).ok());
+            let ssh_passphrase = ssh_cfg
+                .ssh_passphrase_encrypted
+                .as_deref()
+                .and_then(|enc| crypto::decrypt(enc, &self.enc_key).ok());
+
+            let tunnel = match connect_tunnel(
+                ssh_cfg,
+                ssh_password.as_deref().map(|z| z.as_str()),
+                ssh_passphrase.as_deref().map(|z| z.as_str()),
+                &fingerprint,
+            )
+            .await
+            {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(conn_id = %id, error = %e, "SSH tunnel connect failed");
+                    let _ = self
+                        .tx_event
+                        .send(Event::ConnectError(e.localized_message()))
+                        .await;
+                    return;
+                }
+            };
+
+            let local_port = tunnel.local_port;
+            // Store tunnel before mutating conn so lifetime is tied to DbService
+            self.db.store_tunnel(id.clone(), tunnel);
+
+            // Route DB connection through the local tunnel endpoint
+            conn.host = Some("127.0.0.1".to_string());
+            conn.port = Some(local_port);
+        }
+
         match self
             .db
             .connect(&conn, password.as_ref().map(|z| z.as_str()))

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -1,3 +1,4 @@
+use tokio::sync::oneshot;
 use wf_completion::CompletionItem;
 use wf_config::models::{ConnectionConfig, Theme};
 use wf_db::models::{DbMetadata, QueryResult};
@@ -42,6 +43,13 @@ pub enum Event {
         id: String,
         read_only: bool,
         safe_dml: bool,
+    },
+    /// Controller paused a connect attempt awaiting host-key approval.
+    /// The UI shows a fingerprint dialog; sending `true` to `approval_tx` proceeds,
+    /// `false` aborts the connection.
+    SshFingerprintRequired {
+        fingerprint: String,
+        approval_tx: oneshot::Sender<bool>,
     },
     StateChanged(StateEvent),
     DdlLoaded {

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -13,6 +13,15 @@ impl LocalizedMessage for DbError {
             DbError::Cancelled => t!("error.query_cancelled").to_string(),
             DbError::InvalidConfig(s) => t!("error.invalid_config", reason = s).to_string(),
             DbError::Sqlx(e) => t!("error.db_error", reason = e.to_string()).to_string(),
+            DbError::SshTunnelFailed(s) => t!("error.ssh_tunnel_failed", reason = s).to_string(),
+            DbError::SshHostKeyRejected => t!("error.ssh_host_key_rejected").to_string(),
+            DbError::SshFingerprintMismatch { expected, actual } => t!(
+                "error.ssh_fingerprint_mismatch",
+                expected = expected,
+                actual = actual
+            )
+            .to_string(),
+            DbError::KnownHostsWrite(s) => t!("error.ssh_tunnel_failed", reason = s).to_string(),
         }
     }
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -16,9 +16,9 @@ use anyhow::Context as _;
 use tracing::info;
 use wf_config::{
     manager::ConfigManager,
-    models::{ConnectionConfig, DbTypeName, PageSize, Theme},
+    models::{ConnectionConfig, DbTypeName, PageSize, SshAuthMethod, Theme},
 };
-use wf_db::models::{DbConnection, DbType};
+use wf_db::models::{DbConnection, DbType, SshAuth, SshTunnelConfig};
 
 pub use wf_history::session::TabSessionEntry;
 
@@ -150,6 +150,26 @@ impl Default for SessionManager {
 
 /// Convert a stored [`ConnectionConfig`] to the runtime [`DbConnection`] model.
 pub(crate) fn config_to_db_conn(cc: &ConnectionConfig) -> DbConnection {
+    let ssh = if cc.ssh_enabled {
+        cc.ssh_host.as_ref().map(|host| SshTunnelConfig {
+            host: host.clone(),
+            port: cc.ssh_port.unwrap_or(22),
+            user: cc.ssh_user.clone().unwrap_or_default(),
+            auth: match cc.ssh_auth_method {
+                SshAuthMethod::Password => SshAuth::Password,
+                SshAuthMethod::PrivateKey => SshAuth::PrivateKey {
+                    key_path: cc.ssh_key_path.clone().unwrap_or_default(),
+                },
+            },
+            remote_host: cc.host.clone().unwrap_or_default(),
+            remote_port: cc.port.unwrap_or(5432),
+            ssh_password_encrypted: cc.ssh_password_encrypted.clone(),
+            ssh_passphrase_encrypted: cc.ssh_passphrase_encrypted.clone(),
+        })
+    } else {
+        None
+    };
+
     DbConnection {
         id: cc.id.clone(),
         name: cc.name.clone(),
@@ -164,11 +184,39 @@ pub(crate) fn config_to_db_conn(cc: &ConnectionConfig) -> DbConnection {
         user: cc.user.clone(),
         password_encrypted: cc.password_encrypted.clone(),
         database: cc.database.clone(),
+        ssh,
     }
 }
 
 /// Convert a runtime [`DbConnection`] to the storable [`ConnectionConfig`] model.
 pub(crate) fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
+    let ssh_enabled = conn.ssh.is_some();
+    let (
+        ssh_host,
+        ssh_port,
+        ssh_user,
+        ssh_auth_method,
+        ssh_key_path,
+        ssh_password_encrypted,
+        ssh_passphrase_encrypted,
+    ) = if let Some(ref ssh) = conn.ssh {
+        let (auth_method, key_path) = match &ssh.auth {
+            SshAuth::Password => (SshAuthMethod::Password, None),
+            SshAuth::PrivateKey { key_path } => (SshAuthMethod::PrivateKey, Some(key_path.clone())),
+        };
+        (
+            Some(ssh.host.clone()),
+            Some(ssh.port),
+            Some(ssh.user.clone()),
+            auth_method,
+            key_path,
+            ssh.ssh_password_encrypted.clone(),
+            ssh.ssh_passphrase_encrypted.clone(),
+        )
+    } else {
+        (None, None, None, SshAuthMethod::Password, None, None, None)
+    };
+
     ConnectionConfig {
         id: conn.id.clone(),
         name: conn.name.clone(),
@@ -183,8 +231,16 @@ pub(crate) fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
         user: conn.user.clone(),
         password_encrypted: conn.password_encrypted.clone(),
         database: conn.database.clone(),
-        safe_dml: true, // default; overwritten by save_connection when updating existing entry
-        read_only: false, // default; overwritten by save_connection when updating existing entry
+        safe_dml: true,
+        read_only: false,
+        ssh_enabled,
+        ssh_host,
+        ssh_port,
+        ssh_user,
+        ssh_auth_method,
+        ssh_key_path,
+        ssh_password_encrypted,
+        ssh_passphrase_encrypted,
     }
 }
 
@@ -193,9 +249,11 @@ pub(crate) fn db_to_config_conn(conn: &DbConnection) -> ConnectionConfig {
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
-    use wf_config::manager::ConfigManager;
+    use wf_config::{manager::ConfigManager, models::SshAuthMethod};
+    use wf_db::models::{DbType, SshAuth, SshTunnelConfig};
 
-    use super::SessionManager;
+    use super::{SessionManager, config_to_db_conn, db_to_config_conn};
+    use wf_config::models::{ConnectionConfig, DbTypeName};
 
     #[test]
     fn save_tab_width_should_persist_to_config() {
@@ -224,5 +282,110 @@ mod tests {
             .unwrap();
         use wf_config::models::PageSize;
         assert_eq!(cfg.editor.page_size, PageSize::Rows1000);
+    }
+
+    #[test]
+    fn config_to_db_conn_should_map_ssh_fields_when_enabled() {
+        let cc = ConnectionConfig {
+            id: "c1".into(),
+            name: "c1".into(),
+            db_type: DbTypeName::PostgreSQL,
+            connection_string: None,
+            host: Some("db.internal".into()),
+            port: Some(5432),
+            user: Some("admin".into()),
+            password_encrypted: None,
+            database: Some("mydb".into()),
+            safe_dml: true,
+            read_only: false,
+            ssh_enabled: true,
+            ssh_host: Some("bastion.example.com".into()),
+            ssh_port: Some(22),
+            ssh_user: Some("ec2-user".into()),
+            ssh_auth_method: SshAuthMethod::PrivateKey,
+            ssh_password_encrypted: None,
+            ssh_key_path: Some("/home/user/.ssh/id_rsa".into()),
+            ssh_passphrase_encrypted: Some("enc:xyz".into()),
+        };
+
+        let conn = config_to_db_conn(&cc);
+        let ssh = conn.ssh.expect("ssh should be Some when ssh_enabled");
+
+        assert_eq!(ssh.host, "bastion.example.com");
+        assert_eq!(ssh.port, 22);
+        assert_eq!(ssh.user, "ec2-user");
+        assert_eq!(ssh.remote_host, "db.internal");
+        assert_eq!(ssh.remote_port, 5432);
+        assert_eq!(ssh.ssh_passphrase_encrypted.as_deref(), Some("enc:xyz"));
+        assert!(
+            matches!(ssh.auth, SshAuth::PrivateKey { ref key_path } if key_path == "/home/user/.ssh/id_rsa")
+        );
+    }
+
+    #[test]
+    fn config_to_db_conn_should_return_no_ssh_when_disabled() {
+        let cc = ConnectionConfig {
+            id: "c2".into(),
+            name: "c2".into(),
+            db_type: DbTypeName::SQLite,
+            connection_string: Some("sqlite::memory:".into()),
+            host: None,
+            port: None,
+            user: None,
+            password_encrypted: None,
+            database: None,
+            safe_dml: true,
+            read_only: false,
+            ssh_enabled: false,
+            ssh_host: Some("should-be-ignored.example.com".into()),
+            ssh_port: Some(22),
+            ssh_user: None,
+            ssh_auth_method: SshAuthMethod::Password,
+            ssh_password_encrypted: None,
+            ssh_key_path: None,
+            ssh_passphrase_encrypted: None,
+        };
+
+        let conn = config_to_db_conn(&cc);
+        assert!(
+            conn.ssh.is_none(),
+            "ssh should be None when ssh_enabled=false"
+        );
+    }
+
+    #[test]
+    fn db_to_config_conn_should_round_trip_ssh() {
+        use wf_db::models::DbConnection;
+
+        let conn = DbConnection {
+            id: "c3".into(),
+            name: "SSH connection".into(),
+            db_type: DbType::PostgreSQL,
+            connection_string: None,
+            host: Some("db.internal".into()),
+            port: Some(5432),
+            user: Some("admin".into()),
+            password_encrypted: None,
+            database: Some("mydb".into()),
+            ssh: Some(SshTunnelConfig {
+                host: "bastion.example.com".into(),
+                port: 2222,
+                user: "jumper".into(),
+                auth: SshAuth::Password,
+                remote_host: "db.internal".into(),
+                remote_port: 5432,
+                ssh_password_encrypted: Some("enc:abc".into()),
+                ssh_passphrase_encrypted: None,
+            }),
+        };
+
+        let cc = db_to_config_conn(&conn);
+        assert!(cc.ssh_enabled);
+        assert_eq!(cc.ssh_host.as_deref(), Some("bastion.example.com"));
+        assert_eq!(cc.ssh_port, Some(2222));
+        assert_eq!(cc.ssh_user.as_deref(), Some("jumper"));
+        assert_eq!(cc.ssh_auth_method, SshAuthMethod::Password);
+        assert_eq!(cc.ssh_password_encrypted.as_deref(), Some("enc:abc"));
+        assert_eq!(cc.ssh_passphrase_encrypted, None);
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -171,6 +171,8 @@ fn main() -> anyhow::Result<()> {
         repo,
         history_svc,
         metadata_cache,
+        config_dir.clone(),
+        enc_key,
     );
     tokio::spawn(controller.run());
 

--- a/app/src/state/mod.rs
+++ b/app/src/state/mod.rs
@@ -68,6 +68,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: Some("test.db".to_string()),
+            ssh: None,
         }
     }
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -31,6 +31,7 @@ import { SnippetBar }            from "components/snippet_bar.slint";
 import { MetadataSearch }        from "components/metadata_search.slint";
 import { CommandPalette }        from "components/command_palette.slint";
 import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.slint";
+import { FingerprintDialog }    from "components/dialogs/fingerprint_dialog.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -141,6 +142,25 @@ export global UiState {
     in-out property <bool>   form-testing:     false;
     in-out property <bool>   form-safe-dml:    true;
     in-out property <bool>   form-read-only:   false;
+    // ── SSH Tunnel form ───────────────────────────────────────────────────────
+    /// 0 = General, 1 = SSH Tunnel
+    in-out property <int>    form-section:          0;
+    in-out property <string> form-ssh-host:         "";
+    in-out property <string> form-ssh-port:         "22";
+    in-out property <string> form-ssh-user:         "";
+    /// 0 = Password, 1 = Private Key
+    in-out property <int>    form-ssh-auth-method:  0;
+    in-out property <string> form-ssh-password:     "";
+    in-out property <string> form-ssh-key-path:     "";
+    in-out property <string> form-ssh-passphrase:   "";
+    callback browse-ssh-key-file();
+    // ── SSH fingerprint dialog ────────────────────────────────────────────────
+    in-out property <bool>   show-ssh-fingerprint-dialog: false;
+    in-out property <string> ssh-fingerprint-text:        "";
+    callback approve-ssh-fingerprint();
+    callback reject-ssh-fingerprint();
+    // ── SSH active status ─────────────────────────────────────────────────────
+    in-out property <bool>   ssh-active: false;
 
     // ── Connection test / add state ───────────────────────────────────────────
     /// True after a successful Test Connection; reset when form is opened.
@@ -495,6 +515,10 @@ export component AppWindow inherits Window {
     private property <bool> _editor-prefs-open:  UiState.show-editor-prefs;
     changed _editor-prefs-open => { if (_editor-prefs-open) { _editor-prefs-alive = true; } }
 
+    private property <bool> _fp-dialog-alive: false;
+    private property <bool> _fp-dialog-open:  UiState.show-ssh-fingerprint-dialog;
+    changed _fp-dialog-open => { if (_fp-dialog-open) { _fp-dialog-alive = true; } }
+
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
     // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
     // of which inner FocusScope — editor, table-view, sidebar, result — has focus.
@@ -520,7 +544,8 @@ export component AppWindow inherits Window {
                     || UiState.show-snippet-edit
                     || UiState.show-metadata-search
                     || UiState.show-command-palette
-                    || UiState.show-editor-prefs) {
+                    || UiState.show-editor-prefs
+                    || UiState.show-ssh-fingerprint-dialog) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -1053,6 +1078,7 @@ export component AppWindow inherits Window {
             height: 24px;
             connection-text: UiState.status-connection;
             query-status:    UiState.status-message;
+            ssh-active:      UiState.ssh-active;
         }
 
         // ── Inner edge lines ──────────────────────────────────────────────────
@@ -1128,6 +1154,15 @@ export component AppWindow inherits Window {
                 testing     <=> UiState.form-testing;
                 safe-dml    <=> UiState.form-safe-dml;
                 read-only   <=> UiState.form-read-only;
+                form-section      <=> UiState.form-section;
+                ssh-host          <=> UiState.form-ssh-host;
+                ssh-port          <=> UiState.form-ssh-port;
+                ssh-user          <=> UiState.form-ssh-user;
+                ssh-auth-method   <=> UiState.form-ssh-auth-method;
+                ssh-password      <=> UiState.form-ssh-password;
+                ssh-key-path      <=> UiState.form-ssh-key-path;
+                ssh-passphrase    <=> UiState.form-ssh-passphrase;
+                browse-ssh-key-file => { UiState.browse-ssh-key-file(); }
 
                 is-edit: UiState.form-edit-id != "";
                 cancel => { UiState.close-connection-form(); }
@@ -1306,6 +1341,17 @@ export component AppWindow inherits Window {
                 UiState.show-editor-prefs = false;
             }
             exited => { _editor-prefs-alive = false; }
+        }
+
+        // ── SSH fingerprint approval dialog ──────────────────────────────────
+        if _fp-dialog-alive: FingerprintDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:        UiState.show-ssh-fingerprint-dialog;
+            fingerprint: UiState.ssh-fingerprint-text;
+            approve => { UiState.approve-ssh-fingerprint(); }
+            reject  => { UiState.reject-ssh-fingerprint(); }
+            exited  => { _fp-dialog-alive = false; }
         }
 
         // ── Metadata search palette (Ctrl+P) ──────────────────────────────────

--- a/app/src/ui/components/connection_form.slint
+++ b/app/src/ui/components/connection_form.slint
@@ -193,6 +193,27 @@ component CheckRow inherits Rectangle {
     }
 }
 
+// ── Helper: SSH auth toggle button ────────────────────────────────────────────
+
+component AuthToggleButton inherits Rectangle {
+    in property <string> label-text;
+    in property <bool>   active;
+    callback clicked;
+
+    background: active ? Colors.blue : Colors.surface1;
+    border-radius: Layout.radius-md;
+    height: Layout.height-btn-sm;
+    horizontal-stretch: 1;
+    Text {
+        text: label-text;
+        color: active ? Colors.base : Colors.subtext0;
+        font-size: Typography.size-base;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+    TouchArea { clicked => { root.clicked(); } }
+}
+
 // ── Connection form ───────────────────────────────────────────────────────────
 
 export component ConnectionForm inherits Rectangle {
@@ -211,6 +232,17 @@ export component ConnectionForm inherits Rectangle {
     in-out property <bool>   testing:     false;
     in-out property <bool>   safe-dml:    true;
     in-out property <bool>   read-only:   false;
+    // ── Section (0=General, 1=SSH Tunnel) ─────────────────────────────────
+    in-out property <int>    form-section:      0;
+    in-out property <string> ssh-host:          "";
+    in-out property <string> ssh-port:          "22";
+    in-out property <string> ssh-user:          "";
+    /// 0 = Password, 1 = Private Key
+    in-out property <int>    ssh-auth-method:   0;
+    in-out property <string> ssh-password:      "";
+    in-out property <string> ssh-key-path:      "";
+    in-out property <string> ssh-passphrase:    "";
+    callback browse-ssh-key-file();
     /// Set to true after a successful Test Connection; resets to false when the
     /// form is opened or a new test is started.  Used to decide whether Add
     /// shows a confirmation dialog.
@@ -255,174 +287,274 @@ export component ConnectionForm inherits Rectangle {
             label-text: @tr("Name");
             placeholder: @tr("My Database");
             value <=> root.name;
-            move-focus(d) => {
-                if (d > 0) {
-                    if (root.tab-index == 0) { conn-string-input.focus(); }
-                    else { host-field.grab-focus(); }
+            // Forward Tab/Down to the section content; no focus target exposed since
+            // the conn-string and host fields are inside conditional if-blocks.
+            move-focus(_d) => {}
+        }
+
+        // Section tab bar (General / SSH Tunnel)
+        HorizontalLayout {
+            TabButton {
+                label-text: @tr("General");
+                active: root.form-section == 0;
+                clicked => { root.form-section = 0; }
+            }
+            TabButton {
+                label-text: @tr("SSH Tunnel");
+                active: root.form-section == 1;
+                clicked => { root.form-section = 1; }
+            }
+        }
+
+        // ── General section ───────────────────────────────────────────────────
+        if root.form-section == 0: VerticalLayout {
+            spacing: Layout.spacing-xl;
+
+            // DB type selector
+            HorizontalLayout {
+                spacing: Layout.spacing-md;
+                DbTypeButton {
+                    label-text: "PostgreSQL";
+                    icon: Icons.brand-postgresql;
+                    active: root.db-type == 0;
+                    ui-font: root.ui-font;
+                    clicked => { root.db-type = 0; }
                 }
-                // d < 0: Name is the first field — do nothing.
+                DbTypeButton {
+                    label-text: "MySQL";
+                    icon: Icons.brand-mysql;
+                    active: root.db-type == 1;
+                    ui-font: root.ui-font;
+                    clicked => { root.db-type = 1; }
+                }
+                DbTypeButton {
+                    label-text: "SQLite";
+                    icon: Icons.brand-sqlite;
+                    active: root.db-type == 2;
+                    ui-font: root.ui-font;
+                    clicked => { root.db-type = 2; }
+                }
             }
-        }
 
-        // DB type selector
-        HorizontalLayout {
-            spacing: Layout.spacing-md;
-            DbTypeButton {
-                label-text: "PostgreSQL";
-                icon: Icons.brand-postgresql;
-                active: root.db-type == 0;
-                ui-font: root.ui-font;
-                clicked => { root.db-type = 0; }
+            // DB tab bar (Connection String / Individual Fields)
+            HorizontalLayout {
+                TabButton {
+                    label-text: @tr("Connection String");
+                    active: root.tab-index == 0;
+                    clicked => { root.tab-index = 0; }
+                }
+                TabButton {
+                    label-text: @tr("Individual Fields");
+                    active: root.tab-index == 1;
+                    clicked => { root.tab-index = 1; }
+                }
             }
-            DbTypeButton {
-                label-text: "MySQL";
-                icon: Icons.brand-mysql;
-                active: root.db-type == 1;
-                ui-font: root.ui-font;
-                clicked => { root.db-type = 1; }
-            }
-            DbTypeButton {
-                label-text: "SQLite";
-                icon: Icons.brand-sqlite;
-                active: root.db-type == 2;
-                ui-font: root.ui-font;
-                clicked => { root.db-type = 2; }
-            }
-        }
 
-        // Tab bar
-        HorizontalLayout {
-            TabButton {
-                label-text: @tr("Connection String");
-                active: root.tab-index == 0;
-                clicked => { root.tab-index = 0; }
-            }
-            TabButton {
-                label-text: @tr("Individual Fields");
-                active: root.tab-index == 1;
-                clicked => { root.tab-index = 1; }
-            }
-        }
+            // Spacer
+            Rectangle { vertical-stretch: 1; }
 
-        // Spacer — pushes tab content + status + buttons toward the bottom of the dialog.
-        Rectangle { vertical-stretch: 1; }
-
-        // ── Tab content (single panel for both tabs) ─────────────────────────
-        // Using one panel instead of two eliminates the phantom 10px spacing that
-        // a 0-height sibling would introduce, moving the conn-string input lower.
-        // Height always equals the Individual Fields preferred height so the flex
-        // spacer above distributes equally for both tabs.
-        Rectangle {
-            height: fields-layout.preferred-height;
-            clip: true;
-
-            // Connection String tab — input pinned to the bottom of the panel,
-            // aligned with the Database field in the Individual Fields tab.
+            // Tab content
             Rectangle {
-                visible: root.tab-index == 0;
-                background: Colors.base;
-                border-radius: Layout.radius-md;
-                width: parent.width;
-                height: Layout.height-row;
-                y: parent.height - Layout.height-row;
+                height: fields-layout.preferred-height;
+                clip: true;
 
-                if root.conn-string == "": Text {
-                    x: Layout.padding-input;
-                    y: 0;
-                    width: parent.width - Layout.padding-input * 2;
+                Rectangle {
+                    visible: root.tab-index == 0;
+                    background: Colors.base;
+                    border-radius: Layout.radius-md;
+                    width: parent.width;
                     height: Layout.height-row;
-                    text: "postgres://user:pass@host:5432/db";
-                    color: Colors.surface2;
-                    vertical-alignment: center;
+                    y: parent.height - Layout.height-row;
+
+                    if root.conn-string == "": Text {
+                        x: Layout.padding-input;
+                        y: 0;
+                        width: parent.width - Layout.padding-input * 2;
+                        height: Layout.height-row;
+                        text: "postgres://user:pass@host:5432/db";
+                        color: Colors.surface2;
+                        vertical-alignment: center;
+                    }
+                    conn-string-input := TextInput {
+                        x: Layout.padding-input;
+                        y: 0;
+                        width: parent.width - Layout.padding-input * 2;
+                        height: Layout.height-row;
+                        vertical-alignment: center;
+                        text <=> root.conn-string;
+                        color: Colors.text;
+                        key-pressed(event) => {
+                            if (event.text == Key.UpArrow
+                                    || (event.text == Key.Tab && event.modifiers.shift)) {
+                                name-field.grab-focus();
+                                EventResult.accept
+                            } else if (event.text == Key.Escape) {
+                                root.cancel();
+                                EventResult.accept
+                            } else {
+                                EventResult.reject
+                            }
+                        }
+                    }
                 }
-                conn-string-input := TextInput {
-                    x: Layout.padding-input;
-                    y: 0;
-                    width: parent.width - Layout.padding-input * 2;
-                    height: Layout.height-row;
-                    vertical-alignment: center;
-                    text <=> root.conn-string;
-                    color: Colors.text;
-                    key-pressed(event) => {
-                        if (event.text == Key.UpArrow
-                                || (event.text == Key.Tab && event.modifiers.shift)) {
-                            name-field.grab-focus();
-                            EventResult.accept
-                        } else if (event.text == Key.Escape) {
-                            root.cancel();
-                            EventResult.accept
-                        } else {
-                            EventResult.reject
+
+                fields-layout := VerticalLayout {
+                    visible: root.tab-index == 1;
+                    spacing: Layout.spacing-md;
+
+                    host-field := FieldRow {
+                        label-text: @tr("Host");
+                        placeholder: "localhost";
+                        value <=> root.host;
+                        move-focus(d) => {
+                            if (d > 0) { port-field.grab-focus(); }
+                            else { name-field.grab-focus(); }
+                        }
+                    }
+                    port-field := FieldRow {
+                        label-text: @tr("Port");
+                        placeholder: "5432";
+                        value <=> root.port;
+                        move-focus(d) => {
+                            if (d > 0) { user-field.grab-focus(); }
+                            else { host-field.grab-focus(); }
+                        }
+                    }
+                    user-field := FieldRow {
+                        label-text: @tr("User");
+                        placeholder: @tr("username");
+                        value <=> root.user;
+                        move-focus(d) => {
+                            if (d > 0) { pass-field.grab-focus(); }
+                            else { port-field.grab-focus(); }
+                        }
+                    }
+                    pass-field := FieldRow {
+                        label-text: @tr("Password");
+                        value <=> root.password;
+                        is-password: true;
+                        move-focus(d) => {
+                            if (d > 0) { db-field.grab-focus(); }
+                            else { user-field.grab-focus(); }
+                        }
+                    }
+                    db-field := FieldRow {
+                        label-text: @tr("Database");
+                        placeholder: @tr("database name");
+                        value <=> root.database;
+                        move-focus(d) => {
+                            if (d < 0) { pass-field.grab-focus(); }
                         }
                     }
                 }
             }
 
-            // Individual Fields tab
-            fields-layout := VerticalLayout {
-                visible: root.tab-index == 1;
-                spacing: Layout.spacing-md;
-
-                host-field := FieldRow {
-                    label-text: @tr("Host");
-                    placeholder: "localhost";
-                    value <=> root.host;
-                    move-focus(d) => {
-                        if (d > 0) { port-field.grab-focus(); }
-                        else { name-field.grab-focus(); }
-                    }
+            // Connection behaviour flags
+            HorizontalLayout {
+                spacing: Layout.spacing-2xl;
+                CheckRow {
+                    label-text: @tr("Safe DML");
+                    hint-text: @tr("(confirm UPDATE/DELETE without WHERE)");
+                    checked <=> root.safe-dml;
                 }
-                port-field := FieldRow {
-                    label-text: @tr("Port");
-                    placeholder: "5432";
-                    value <=> root.port;
-                    move-focus(d) => {
-                        if (d > 0) { user-field.grab-focus(); }
-                        else { host-field.grab-focus(); }
-                    }
-                }
-                user-field := FieldRow {
-                    label-text: @tr("User");
-                    placeholder: @tr("username");
-                    value <=> root.user;
-                    move-focus(d) => {
-                        if (d > 0) { pass-field.grab-focus(); }
-                        else { port-field.grab-focus(); }
-                    }
-                }
-                pass-field := FieldRow {
-                    label-text: @tr("Password");
-                    value <=> root.password;
-                    is-password: true;
-                    move-focus(d) => {
-                        if (d > 0) { db-field.grab-focus(); }
-                        else { user-field.grab-focus(); }
-                    }
-                }
-                db-field := FieldRow {
-                    label-text: @tr("Database");
-                    placeholder: @tr("database name");
-                    value <=> root.database;
-                    move-focus(d) => {
-                        if (d < 0) { pass-field.grab-focus(); }
-                    }
+                CheckRow {
+                    label-text: @tr("Read-only");
+                    hint-text: @tr("(block all write statements)");
+                    checked <=> root.read-only;
                 }
             }
         }
 
-        // Connection behaviour flags
-        HorizontalLayout {
-            spacing: Layout.spacing-2xl;
-            CheckRow {
-                label-text: @tr("Safe DML");
-                hint-text: @tr("(confirm UPDATE/DELETE without WHERE)");
-                checked <=> root.safe-dml;
+        // ── SSH Tunnel section ────────────────────────────────────────────────
+        if root.form-section == 1: VerticalLayout {
+            spacing: Layout.spacing-md;
+
+            // SSH Host + Port
+            HorizontalLayout {
+                spacing: Layout.spacing-md;
+                FieldRow {
+                    label-text: @tr("SSH Host");
+                    placeholder: "bastion.example.com";
+                    value <=> root.ssh-host;
+                    horizontal-stretch: 3;
+                    move-focus(_d) => {}
+                }
+                FieldRow {
+                    label-text: @tr("Port");
+                    placeholder: "22";
+                    value <=> root.ssh-port;
+                    horizontal-stretch: 1;
+                    move-focus(_d) => {}
+                }
             }
-            CheckRow {
-                label-text: @tr("Read-only");
-                hint-text: @tr("(block all write statements)");
-                checked <=> root.read-only;
+
+            // SSH User
+            FieldRow {
+                label-text: @tr("SSH User");
+                placeholder: @tr("username");
+                value <=> root.ssh-user;
+                move-focus(_d) => {}
             }
+
+            // Auth method toggle
+            HorizontalLayout {
+                spacing: 0px;
+                Text {
+                    text: @tr("Auth");
+                    color: Colors.subtext0;
+                    width: 80px;
+                    vertical-alignment: center;
+                }
+                HorizontalLayout {
+                    spacing: Layout.spacing-sm;
+                    AuthToggleButton {
+                        label-text: @tr("Password");
+                        active: root.ssh-auth-method == 0;
+                        clicked => { root.ssh-auth-method = 0; }
+                    }
+                    AuthToggleButton {
+                        label-text: @tr("Private Key");
+                        active: root.ssh-auth-method == 1;
+                        clicked => { root.ssh-auth-method = 1; }
+                    }
+                }
+            }
+
+            // Password (visible when auth = Password)
+            if root.ssh-auth-method == 0: FieldRow {
+                label-text: @tr("Password");
+                value <=> root.ssh-password;
+                is-password: true;
+                move-focus(_d) => {}
+            }
+
+            // Key path + Browse (visible when auth = Private Key)
+            if root.ssh-auth-method == 1: HorizontalLayout {
+                spacing: Layout.spacing-md;
+                FieldRow {
+                    label-text: @tr("Key Path");
+                    placeholder: @tr("~/.ssh/id_rsa");
+                    value <=> root.ssh-key-path;
+                    horizontal-stretch: 1;
+                    move-focus(_d) => {}
+                }
+                ActionButton {
+                    width: 80px;
+                    text: @tr("Browse\u{2026}");
+                    clicked => { root.browse-ssh-key-file(); }
+                }
+            }
+
+            // Passphrase (visible when auth = Private Key)
+            if root.ssh-auth-method == 1: FieldRow {
+                label-text: @tr("Passphrase");
+                value <=> root.ssh-passphrase;
+                is-password: true;
+                move-focus(_d) => {}
+            }
+
+            // Spacer to push buttons down
+            Rectangle { vertical-stretch: 1; }
         }
 
         // Status message (shown only when not empty)

--- a/app/src/ui/components/dialogs/fingerprint_dialog.slint
+++ b/app/src/ui/components/dialogs/fingerprint_dialog.slint
@@ -1,0 +1,81 @@
+import { Colors, Typography, Layout, Icons } from "../../theme.slint";
+import { ActionButton, ModalOverlay } from "../common.slint";
+
+export component FingerprintDialog inherits ModalOverlay {
+    in property <string> fingerprint;
+    callback approve();
+    callback reject();
+
+    VerticalLayout {
+        padding: Layout.padding-2xl;
+        spacing: Layout.spacing-xl;
+        alignment: start;
+
+        // Warning icon + title
+        HorizontalLayout {
+            alignment: center;
+            spacing: Layout.spacing-md;
+            Image {
+                width: Layout.icon-xl;
+                source: Icons.alert-error;
+                colorize: Colors.yellow;
+                image-fit: contain;
+            }
+            Text {
+                text: @tr("Unknown SSH Host Key");
+                color: Colors.text;
+                font-size: Typography.size-xl;
+                font-weight: 700;
+                vertical-alignment: center;
+            }
+        }
+
+        Text {
+            text: @tr("The server presented a host key that has not been seen before. Verify the fingerprint below matches what your server administrator provided, then click Approve to trust it.");
+            color: Colors.subtext0;
+            font-size: Typography.size-base;
+            wrap: word-wrap;
+        }
+
+        // Fingerprint display
+        Rectangle {
+            background: Colors.mantle;
+            border-radius: Layout.radius-md;
+            height: Layout.height-row * 1.5;
+
+            HorizontalLayout {
+                padding-left:  Layout.padding-lg;
+                padding-right: Layout.padding-lg;
+
+                Text {
+                    text: root.fingerprint;
+                    color: Colors.green;
+                    font-size: Typography.size-base;
+                    vertical-alignment: center;
+                    overflow: elide;
+                    horizontal-stretch: 1;
+                }
+            }
+        }
+
+        // Buttons
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: end;
+
+            ActionButton {
+                width: 90px;
+                text: @tr("Reject");
+                clicked => { root.reject(); }
+            }
+
+            ActionButton {
+                width: 90px;
+                text: @tr("Approve");
+                bg: Colors.green;
+                fg: Colors.base;
+                clicked => { root.approve(); }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/status_bar.slint
+++ b/app/src/ui/components/status_bar.slint
@@ -13,6 +13,8 @@ export component StatusBar inherits Rectangle {
     /// Query lifecycle status string pushed from Rust (status-message in UiState).
     /// Examples: "Running…"  |  "42 ms  ·  128 rows"  |  "Cancelled"  |  "Error: …"
     in property <string> query-status;
+    /// When true, a green "SSH" badge is shown next to the connection text.
+    in property <bool> ssh-active: false;
 
     HorizontalLayout {
         padding-left:  Layout.padding-md;
@@ -25,6 +27,21 @@ export component StatusBar inherits Rectangle {
             font-size: Typography.size-base;
             vertical-alignment: center;
             horizontal-stretch: 1;
+        }
+
+        // SSH badge
+        if root.ssh-active: Rectangle {
+            width: 34px;
+            height: 16px;
+            background: Colors.green;
+            border-radius: 3px;
+            Text {
+                text: "SSH";
+                color: Colors.base;
+                font-size: Typography.size-sm;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
         }
 
         Text {

--- a/app/src/ui/connection.rs
+++ b/app/src/ui/connection.rs
@@ -2,10 +2,11 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use rust_i18n::t;
 use slint::{ComponentHandle, Model as _};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use wf_config::{crypto, models::DbTypeName};
-use wf_db::models::{DbConnection, DbType};
+use wf_db::models::{DbConnection, DbType, SshAuth, SshTunnelConfig};
 
 use crate::app::{
     command::{Command, ConfigUpdate},
@@ -24,6 +25,18 @@ pub(super) fn db_type_label_config(dt: &DbTypeName) -> &'static str {
         DbTypeName::MySQL => "MySQL",
         DbTypeName::SQLite => "SQLite",
     }
+}
+
+/// Returns a localized error string when the form state is invalid, or `None` when valid.
+///
+/// Currently catches: connection string mode + SSH host both set (remote_host would be empty).
+fn validate_form(ui: &crate::UiState) -> Option<String> {
+    let is_conn_string = ui.get_form_tab_index() == 0;
+    let ssh_host_set = !ui.get_form_ssh_host().is_empty();
+    if is_conn_string && ssh_host_set {
+        return Some(t!("error.ssh_conn_string_unsupported").to_string());
+    }
+    None
 }
 
 /// Build a `DbConnection` from the current values in the connection form global,
@@ -66,6 +79,53 @@ fn build_conn_from_form(
         edit_id
     };
 
+    // SSH is active when SSH Host is filled in; `opt` returns None for empty strings.
+    let ssh = opt(ui.get_form_ssh_host()).map(|host| {
+        let auth = if ui.get_form_ssh_auth_method() == 1 {
+            SshAuth::PrivateKey {
+                key_path: ui.get_form_ssh_key_path().to_string(),
+            }
+        } else {
+            SshAuth::Password
+        };
+
+        let ssh_password_raw = opt(ui.get_form_ssh_password()).map(zeroize::Zeroizing::new);
+        let ssh_password_encrypted = ssh_password_raw
+            .as_deref()
+            .map(|p| crypto::encrypt(p, enc_key));
+
+        let ssh_passphrase_raw = opt(ui.get_form_ssh_passphrase()).map(zeroize::Zeroizing::new);
+        let ssh_passphrase_encrypted = ssh_passphrase_raw
+            .as_deref()
+            .map(|p| crypto::encrypt(p, enc_key));
+
+        SshTunnelConfig {
+            host,
+            port: ui
+                .get_form_ssh_port()
+                .to_string()
+                .parse::<u16>()
+                .unwrap_or(22),
+            user: ui.get_form_ssh_user().to_string(),
+            auth,
+            remote_host: if is_conn_string {
+                String::new()
+            } else {
+                opt(ui.get_form_host()).unwrap_or_default()
+            },
+            remote_port: if is_conn_string {
+                5432
+            } else {
+                ui.get_form_port()
+                    .to_string()
+                    .parse::<u16>()
+                    .unwrap_or(5432)
+            },
+            ssh_password_encrypted,
+            ssh_passphrase_encrypted,
+        }
+    });
+
     let conn = DbConnection {
         id,
         name: ui.get_form_name().to_string(),
@@ -96,6 +156,7 @@ fn build_conn_from_form(
         } else {
             opt(ui.get_form_database())
         },
+        ssh,
     };
 
     (conn, password)
@@ -286,6 +347,15 @@ pub(super) fn register_sidebar_callbacks(
                 ui.set_form_edit_id("".into());
                 ui.set_form_safe_dml(true);
                 ui.set_form_read_only(false);
+                // Reset SSH tunnel fields
+                ui.set_form_section(0);
+                ui.set_form_ssh_host("".into());
+                ui.set_form_ssh_port("22".into());
+                ui.set_form_ssh_user("".into());
+                ui.set_form_ssh_auth_method(0);
+                ui.set_form_ssh_password("".into());
+                ui.set_form_ssh_key_path("".into());
+                ui.set_form_ssh_passphrase("".into());
                 ui.set_show_connection_form(true);
             });
         });
@@ -353,6 +423,58 @@ pub(super) fn register_sidebar_callbacks(
                 )
             };
 
+            // Decrypt SSH credentials for pre-filling the form.
+            let (
+                ssh_host,
+                ssh_port,
+                ssh_user,
+                ssh_auth_method,
+                ssh_password,
+                ssh_key_path,
+                ssh_passphrase,
+            ) = match &conn.ssh {
+                Some(ssh_cfg) => {
+                    let pw = ssh_cfg
+                        .ssh_password_encrypted
+                        .as_ref()
+                        .and_then(|enc| crypto::decrypt(enc, &enc_key).ok())
+                        .map(|z| z.as_str().to_owned())
+                        .unwrap_or_default();
+                    let pp = ssh_cfg
+                        .ssh_passphrase_encrypted
+                        .as_ref()
+                        .and_then(|enc| crypto::decrypt(enc, &enc_key).ok())
+                        .map(|z| z.as_str().to_owned())
+                        .unwrap_or_default();
+                    let auth_idx = match &ssh_cfg.auth {
+                        SshAuth::PrivateKey { .. } => 1,
+                        SshAuth::Password => 0,
+                    };
+                    let key_path = match &ssh_cfg.auth {
+                        SshAuth::PrivateKey { key_path } => key_path.clone(),
+                        SshAuth::Password => String::new(),
+                    };
+                    (
+                        ssh_cfg.host.clone(),
+                        ssh_cfg.port,
+                        ssh_cfg.user.clone(),
+                        auth_idx,
+                        pw,
+                        key_path,
+                        pp,
+                    )
+                }
+                None => (
+                    String::new(),
+                    22u16,
+                    String::new(),
+                    0i32,
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ),
+            };
+
             with_ui(&window_weak, move |ui| {
                 ui.set_form_edit_id(conn.id.clone().into());
                 ui.set_form_name(conn.name.clone().into());
@@ -369,6 +491,15 @@ pub(super) fn register_sidebar_callbacks(
                 ui.set_form_test_ok(false);
                 ui.set_form_safe_dml(safe_dml);
                 ui.set_form_read_only(read_only);
+                // SSH tunnel fields
+                ui.set_form_section(0);
+                ui.set_form_ssh_host(ssh_host.into());
+                ui.set_form_ssh_port(ssh_port.to_string().into());
+                ui.set_form_ssh_user(ssh_user.into());
+                ui.set_form_ssh_auth_method(ssh_auth_method);
+                ui.set_form_ssh_password(ssh_password.into());
+                ui.set_form_ssh_key_path(ssh_key_path.into());
+                ui.set_form_ssh_passphrase(ssh_passphrase.into());
                 ui.set_show_test_result_popup(false);
                 ui.set_show_add_confirm_popup(false);
                 ui.set_show_connection_form(true);
@@ -617,6 +748,7 @@ pub(super) fn register_connection_form_callbacks(
     window: &crate::AppWindow,
     tx_cmd: mpsc::Sender<Command>,
     enc_key: [u8; 32],
+    fp_approval_tx: Arc<Mutex<Option<oneshot::Sender<bool>>>>,
 ) {
     let ui_state = window.global::<crate::UiState>();
 
@@ -641,6 +773,10 @@ pub(super) fn register_connection_form_callbacks(
         let tx_cmd = tx_cmd.clone();
         ui_state.on_test_connection(move || {
             with_ui(&window_weak, |ui| {
+                if let Some(err) = validate_form(ui) {
+                    ui.set_form_status(err.into());
+                    return;
+                }
                 ui.set_form_testing(true);
                 ui.set_form_status("".into());
                 ui.set_form_test_ok(false);
@@ -657,6 +793,10 @@ pub(super) fn register_connection_form_callbacks(
         let tx_cmd = tx_cmd.clone();
         ui_state.on_add_connection(move || {
             with_ui(&window_weak, |ui| {
+                if let Some(err) = validate_form(ui) {
+                    ui.set_form_status(err.into());
+                    return;
+                }
                 if ui.get_form_test_ok() {
                     ui.set_form_testing(true);
                     let (conn, password) = build_conn_from_form(ui, &enc_key);
@@ -686,6 +826,10 @@ pub(super) fn register_connection_form_callbacks(
         let tx_cmd = tx_cmd.clone();
         ui_state.on_confirm_add_connection(move || {
             with_ui(&window_weak, |ui| {
+                if let Some(err) = validate_form(ui) {
+                    ui.set_form_status(err.into());
+                    return;
+                }
                 ui.set_show_add_confirm_popup(false);
                 ui.set_form_testing(true);
                 let (conn, password) = build_conn_from_form(ui, &enc_key);
@@ -734,6 +878,62 @@ pub(super) fn register_connection_form_callbacks(
                     ui.set_show_connection_form(false);
                 }
             });
+        });
+    }
+
+    // browse-ssh-key-file: open a file picker and set form-ssh-key-path.
+    {
+        let window_weak = window.as_weak();
+        ui_state.on_browse_ssh_key_file(move || {
+            let window_weak = window_weak.clone(); // clone required: async move
+            tokio::spawn(async move {
+                if let Some(file) = rfd::AsyncFileDialog::new()
+                    .add_filter("Private key", &["pem", "key", "ppk", ""])
+                    .pick_file()
+                    .await
+                {
+                    let path = file.path().to_string_lossy().into_owned();
+                    slint::invoke_from_event_loop(move || {
+                        if let Some(w) = window_weak.upgrade() {
+                            w.global::<crate::UiState>()
+                                .set_form_ssh_key_path(path.into());
+                        }
+                    })
+                    .ok();
+                }
+            });
+        });
+    }
+
+    // approve-ssh-fingerprint: user approved the unknown host key.
+    {
+        let fp_approval_tx = Arc::clone(&fp_approval_tx); // clone required: callback closure
+        let window_weak = window.as_weak();
+        ui_state.on_approve_ssh_fingerprint(move || {
+            if let Some(tx) = fp_approval_tx
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .take()
+            {
+                let _ = tx.send(true);
+            }
+            with_ui(&window_weak, |ui| ui.set_show_ssh_fingerprint_dialog(false));
+        });
+    }
+
+    // reject-ssh-fingerprint: user rejected the unknown host key.
+    {
+        let fp_approval_tx = Arc::clone(&fp_approval_tx); // clone required: callback closure
+        let window_weak = window.as_weak();
+        ui_state.on_reject_ssh_fingerprint(move || {
+            if let Some(tx) = fp_approval_tx
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .take()
+            {
+                let _ = tx.send(false);
+            }
+            with_ui(&window_weak, |ui| ui.set_show_ssh_fingerprint_dialog(false));
         });
     }
 }

--- a/app/src/ui/event.rs
+++ b/app/src/ui/event.rs
@@ -26,6 +26,7 @@ pub(super) fn spawn_event_handler(
     sidebar_state: Arc<Mutex<SidebarUiState>>,
     original_data: SharedOriginalData,
     snippet_repo: Arc<SnippetRepository>,
+    fp_approval_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<bool>>>>,
 ) {
     let window_weak = window.as_weak();
     tokio::spawn(async move {
@@ -38,11 +39,17 @@ pub(super) fn spawn_event_handler(
                     read_only,
                 } => {
                     let conn_id = id.clone();
+                    let ssh_active = connections
+                        .iter()
+                        .find(|c| c.id == id)
+                        .map(|c| c.ssh_enabled)
+                        .unwrap_or(false);
                     handle_connected(
                         id,
                         connections,
                         safe_dml,
                         read_only,
+                        ssh_active,
                         window_weak.clone(),
                         Arc::clone(&sidebar_state),
                     );
@@ -114,6 +121,20 @@ pub(super) fn spawn_event_handler(
                     state.clone(),
                     Arc::clone(&sidebar_state),
                 ),
+                Event::SshFingerprintRequired {
+                    fingerprint,
+                    approval_tx,
+                } => {
+                    // Store the sender so the approve/reject callbacks can consume it.
+                    *fp_approval_tx.lock().unwrap_or_else(|p| p.into_inner()) = Some(approval_tx);
+                    let ww = window_weak.clone();
+                    let _ = slint::invoke_from_event_loop(move || {
+                        with_ui(&ww, move |ui| {
+                            ui.set_ssh_fingerprint_text(fingerprint.into());
+                            ui.set_show_ssh_fingerprint_dialog(true);
+                        });
+                    });
+                }
                 _ => {}
             }
         }
@@ -127,6 +148,7 @@ fn handle_connected(
     connections: Vec<ConnectionConfig>,
     safe_dml: bool,
     read_only: bool,
+    ssh_active: bool,
     ww: slint::Weak<crate::AppWindow>,
     sidebar_state: Arc<Mutex<SidebarUiState>>,
 ) {
@@ -170,6 +192,7 @@ fn handle_connected(
             ui.set_active_connection_id(id.into());
             ui.set_conn_safe_dml(safe_dml);
             ui.set_conn_read_only(read_only);
+            ui.set_ssh_active(ssh_active);
             ui.set_show_connection_form(false);
             // Reopen the DB manager if the form was launched from within it.
             if ui.get_reopen_db_manager_on_form_close() {
@@ -344,6 +367,7 @@ fn handle_disconnected(id: String, ww: slint::Weak<crate::AppWindow>) {
         with_ui(&ww, move |ui| {
             ui.set_status_message(t!("status.disconnected", id = id).to_string().into());
             ui.set_status_connection(t!("status.not_connected").to_string().into());
+            ui.set_ssh_active(false);
         });
     });
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -397,6 +397,12 @@ impl UI {
         // handler on QueryFinished, read by the filter callbacks on the UI thread.
         let original_data: SharedOriginalData = Arc::new(Mutex::new(None));
 
+        // Shared slot for the SSH fingerprint approval oneshot sender.
+        // Written by the async event handler when a new fingerprint needs user approval;
+        // consumed by the approve/reject UI callbacks on the Slint thread.
+        let fp_approval_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<bool>>>> =
+            Arc::new(Mutex::new(None));
+
         // Restore or create tab state. Track whether tabs were loaded from DB
         // so we can fall back to last_query on first launch.
         let handle = tokio::runtime::Handle::current();
@@ -425,7 +431,12 @@ impl UI {
             enc_key,
             Rc::clone(&tabs_state),
         );
-        connection::register_connection_form_callbacks(&window, tx_cmd.clone(), enc_key);
+        connection::register_connection_form_callbacks(
+            &window,
+            tx_cmd.clone(),
+            enc_key,
+            Arc::clone(&fp_approval_tx),
+        );
         query::register_editor_callbacks(&window, tx_cmd.clone());
         completion::register_completion_callbacks(&window, tx_cmd.clone());
         completion::register_completion_accept_callback(&window);
@@ -569,6 +580,7 @@ impl UI {
             Arc::clone(&sidebar_state),
             Arc::clone(&original_data),
             Arc::clone(&snippet_repo),
+            Arc::clone(&fp_approval_tx),
         );
 
         Ok(Self { window })
@@ -598,6 +610,14 @@ mod tests {
             database: None,
             safe_dml: true,
             read_only: false,
+            ssh_enabled: false,
+            ssh_host: None,
+            ssh_port: None,
+            ssh_user: None,
+            ssh_auth_method: wf_config::models::SshAuthMethod::Password,
+            ssh_password_encrypted: None,
+            ssh_key_path: None,
+            ssh_passphrase_encrypted: None,
         }
     }
 

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -141,6 +141,18 @@ impl Default for UiConfig {
 }
 
 // ---------------------------------------------------------------------------
+// SshAuthMethod
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SshAuthMethod {
+    #[default]
+    Password,
+    PrivateKey,
+}
+
+// ---------------------------------------------------------------------------
 // ConnectionConfig  [[connections]]
 // ---------------------------------------------------------------------------
 
@@ -170,6 +182,25 @@ pub struct ConnectionConfig {
     /// When true, write statements (INSERT/UPDATE/DELETE/DDL) are blocked before execution.
     #[serde(default)]
     pub read_only: bool,
+    // ── SSH Tunnel ────────────────────────────────────────────────────────────
+    #[serde(default)]
+    pub ssh_enabled: bool,
+    #[serde(default)]
+    pub ssh_host: Option<String>,
+    #[serde(default)]
+    pub ssh_port: Option<u16>,
+    #[serde(default)]
+    pub ssh_user: Option<String>,
+    #[serde(default)]
+    pub ssh_auth_method: SshAuthMethod,
+    /// AES-256-GCM encrypted SSH password
+    #[serde(default)]
+    pub ssh_password_encrypted: Option<String>,
+    #[serde(default)]
+    pub ssh_key_path: Option<String>,
+    /// AES-256-GCM encrypted SSH private-key passphrase
+    #[serde(default)]
+    pub ssh_passphrase_encrypted: Option<String>,
 }
 
 fn default_safe_dml() -> bool {
@@ -273,6 +304,62 @@ language = "ja"
         // Round-trip: integer 500 → PageSize::Rows500
         let back: Wrapper = toml::from_str(&s).expect("failed to deserialize");
         assert_eq!(back.page_size, PageSize::Rows500);
+    }
+
+    #[test]
+    fn ssh_config_defaults_should_be_false_and_none() {
+        let toml = r#"
+            id = "c1"
+            name = "c1"
+            db_type = "sqlite"
+        "#;
+        let cc: ConnectionConfig = toml::from_str(toml).expect("should parse with SSH defaults");
+        assert!(!cc.ssh_enabled);
+        assert_eq!(cc.ssh_host, None);
+        assert_eq!(cc.ssh_port, None);
+        assert_eq!(cc.ssh_user, None);
+        assert_eq!(cc.ssh_auth_method, SshAuthMethod::Password);
+        assert_eq!(cc.ssh_password_encrypted, None);
+        assert_eq!(cc.ssh_key_path, None);
+        assert_eq!(cc.ssh_passphrase_encrypted, None);
+    }
+
+    #[test]
+    fn ssh_config_fields_should_round_trip_through_toml() {
+        let original = ConnectionConfig {
+            id: "ssh-test".into(),
+            name: "SSH Test".into(),
+            db_type: DbTypeName::PostgreSQL,
+            connection_string: None,
+            host: Some("db.internal".into()),
+            port: Some(5432),
+            user: Some("admin".into()),
+            password_encrypted: None,
+            database: Some("mydb".into()),
+            safe_dml: true,
+            read_only: false,
+            ssh_enabled: true,
+            ssh_host: Some("bastion.example.com".into()),
+            ssh_port: Some(22),
+            ssh_user: Some("ec2-user".into()),
+            ssh_auth_method: SshAuthMethod::PrivateKey,
+            ssh_password_encrypted: None,
+            ssh_key_path: Some("/home/user/.ssh/id_rsa".into()),
+            ssh_passphrase_encrypted: Some("enc:abc123".into()),
+        };
+
+        let serialized = toml::to_string(&original).expect("failed to serialize");
+        let deserialized: ConnectionConfig =
+            toml::from_str(&serialized).expect("failed to deserialize");
+
+        assert_eq!(original, deserialized);
+        assert!(deserialized.ssh_enabled);
+        assert_eq!(
+            deserialized.ssh_host.as_deref(),
+            Some("bastion.example.com")
+        );
+        assert_eq!(deserialized.ssh_port, Some(22));
+        assert_eq!(deserialized.ssh_auth_method, SshAuthMethod::PrivateKey);
     }
 
     #[test]

--- a/crates/wf-config/src/repository.rs
+++ b/crates/wf-config/src/repository.rs
@@ -5,22 +5,42 @@ use crate::models::{ConnectionConfig, DbTypeName};
 
 const CREATE_TABLE: &str = "
     CREATE TABLE IF NOT EXISTS connections (
-        id                 TEXT    PRIMARY KEY,
-        name               TEXT    NOT NULL,
-        db_type            TEXT    NOT NULL,
-        connection_string  TEXT,
-        host               TEXT,
-        port               INTEGER,
-        user_name          TEXT,
-        password_encrypted TEXT,
-        database_name      TEXT,
-        safe_dml           INTEGER NOT NULL DEFAULT 1,
-        read_only          INTEGER NOT NULL DEFAULT 0,
-        sort_order         INTEGER NOT NULL DEFAULT 0,
-        created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
-        last_used_at       INTEGER
+        id                       TEXT    PRIMARY KEY,
+        name                     TEXT    NOT NULL,
+        db_type                  TEXT    NOT NULL,
+        connection_string        TEXT,
+        host                     TEXT,
+        port                     INTEGER,
+        user_name                TEXT,
+        password_encrypted       TEXT,
+        database_name            TEXT,
+        safe_dml                 INTEGER NOT NULL DEFAULT 1,
+        read_only                INTEGER NOT NULL DEFAULT 0,
+        sort_order               INTEGER NOT NULL DEFAULT 0,
+        created_at               INTEGER NOT NULL DEFAULT (unixepoch()),
+        last_used_at             INTEGER,
+        ssh_enabled              INTEGER NOT NULL DEFAULT 0,
+        ssh_host                 TEXT,
+        ssh_port                 INTEGER,
+        ssh_user                 TEXT,
+        ssh_auth_method          TEXT    NOT NULL DEFAULT 'password',
+        ssh_password_encrypted   TEXT,
+        ssh_key_path             TEXT,
+        ssh_passphrase_encrypted TEXT
     )
 ";
+
+/// Migrations for existing databases that were created before SSH columns were added.
+const MIGRATE_SSH_COLUMNS: &[&str] = &[
+    "ALTER TABLE connections ADD COLUMN ssh_enabled              INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE connections ADD COLUMN ssh_host                 TEXT",
+    "ALTER TABLE connections ADD COLUMN ssh_port                 INTEGER",
+    "ALTER TABLE connections ADD COLUMN ssh_user                 TEXT",
+    "ALTER TABLE connections ADD COLUMN ssh_auth_method          TEXT NOT NULL DEFAULT 'password'",
+    "ALTER TABLE connections ADD COLUMN ssh_password_encrypted   TEXT",
+    "ALTER TABLE connections ADD COLUMN ssh_key_path             TEXT",
+    "ALTER TABLE connections ADD COLUMN ssh_passphrase_encrypted TEXT",
+];
 
 /// Persists [`ConnectionConfig`] records to SQLite.
 ///
@@ -37,6 +57,11 @@ impl ConnectionRepository {
             .execute(&pool)
             .await
             .context("failed to migrate connections table")?;
+        // Best-effort: add SSH columns to existing databases. Errors are ignored
+        // because the column may already exist (SQLite has no IF NOT EXISTS for ALTER).
+        for stmt in MIGRATE_SSH_COLUMNS {
+            let _ = sqlx::query(stmt).execute(&pool).await;
+        }
         Ok(Self { pool })
     }
 
@@ -50,7 +75,9 @@ impl ConnectionRepository {
     pub async fn all(&self) -> anyhow::Result<Vec<ConnectionConfig>> {
         let rows = sqlx::query(
             "SELECT id, name, db_type, connection_string, host, port, user_name,
-                    password_encrypted, database_name, safe_dml, read_only
+                    password_encrypted, database_name, safe_dml, read_only,
+                    ssh_enabled, ssh_host, ssh_port, ssh_user, ssh_auth_method,
+                    ssh_password_encrypted, ssh_key_path, ssh_passphrase_encrypted
              FROM connections ORDER BY sort_order ASC, created_at ASC",
         )
         .fetch_all(&self.pool)
@@ -62,7 +89,9 @@ impl ConnectionRepository {
     pub async fn find(&self, id: &str) -> anyhow::Result<Option<ConnectionConfig>> {
         let row = sqlx::query(
             "SELECT id, name, db_type, connection_string, host, port, user_name,
-                    password_encrypted, database_name, safe_dml, read_only
+                    password_encrypted, database_name, safe_dml, read_only,
+                    ssh_enabled, ssh_host, ssh_port, ssh_user, ssh_auth_method,
+                    ssh_password_encrypted, ssh_key_path, ssh_passphrase_encrypted
              FROM connections WHERE id = ?",
         )
         .bind(id)
@@ -82,20 +111,34 @@ impl ConnectionRepository {
     }
 
     async fn upsert_with_order(&self, cc: &ConnectionConfig, order: i64) -> anyhow::Result<()> {
+        let ssh_auth_str = match cc.ssh_auth_method {
+            crate::models::SshAuthMethod::Password => "password",
+            crate::models::SshAuthMethod::PrivateKey => "private_key",
+        };
         sqlx::query(
             "INSERT INTO connections
              (id, name, db_type, connection_string, host, port, user_name,
-              password_encrypted, database_name, safe_dml, read_only, sort_order)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              password_encrypted, database_name, safe_dml, read_only, sort_order,
+              ssh_enabled, ssh_host, ssh_port, ssh_user, ssh_auth_method,
+              ssh_password_encrypted, ssh_key_path, ssh_passphrase_encrypted)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
-               name               = excluded.name,
-               db_type            = excluded.db_type,
-               connection_string  = excluded.connection_string,
-               host               = excluded.host,
-               port               = excluded.port,
-               user_name          = excluded.user_name,
-               password_encrypted = excluded.password_encrypted,
-               database_name      = excluded.database_name",
+               name                     = excluded.name,
+               db_type                  = excluded.db_type,
+               connection_string        = excluded.connection_string,
+               host                     = excluded.host,
+               port                     = excluded.port,
+               user_name                = excluded.user_name,
+               password_encrypted       = excluded.password_encrypted,
+               database_name            = excluded.database_name,
+               ssh_enabled              = excluded.ssh_enabled,
+               ssh_host                 = excluded.ssh_host,
+               ssh_port                 = excluded.ssh_port,
+               ssh_user                 = excluded.ssh_user,
+               ssh_auth_method          = excluded.ssh_auth_method,
+               ssh_password_encrypted   = excluded.ssh_password_encrypted,
+               ssh_key_path             = excluded.ssh_key_path,
+               ssh_passphrase_encrypted = excluded.ssh_passphrase_encrypted",
         )
         .bind(&cc.id)
         .bind(&cc.name)
@@ -109,6 +152,14 @@ impl ConnectionRepository {
         .bind(cc.safe_dml as i32)
         .bind(cc.read_only as i32)
         .bind(order)
+        .bind(cc.ssh_enabled as i32)
+        .bind(&cc.ssh_host)
+        .bind(cc.ssh_port.map(|p| p as i64))
+        .bind(&cc.ssh_user)
+        .bind(ssh_auth_str)
+        .bind(&cc.ssh_password_encrypted)
+        .bind(&cc.ssh_key_path)
+        .bind(&cc.ssh_passphrase_encrypted)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -127,7 +178,9 @@ impl ConnectionRepository {
     pub async fn last_used(&self) -> anyhow::Result<Option<ConnectionConfig>> {
         let row = sqlx::query(
             "SELECT id, name, db_type, connection_string, host, port, user_name,
-                    password_encrypted, database_name, safe_dml, read_only
+                    password_encrypted, database_name, safe_dml, read_only,
+                    ssh_enabled, ssh_host, ssh_port, ssh_user, ssh_auth_method,
+                    ssh_password_encrypted, ssh_key_path, ssh_passphrase_encrypted
              FROM connections WHERE last_used_at IS NOT NULL
              ORDER BY last_used_at DESC LIMIT 1",
         )
@@ -183,6 +236,8 @@ impl ConnectionRepository {
 // ── Row → model conversion ────────────────────────────────────────────────────
 
 fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<ConnectionConfig> {
+    use crate::models::SshAuthMethod;
+
     let db_type_str: String = row.try_get("db_type")?;
     let db_type = match db_type_str.as_str() {
         "mysql" => DbTypeName::MySQL,
@@ -190,6 +245,12 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<ConnectionConf
         _ => DbTypeName::PostgreSQL,
     };
     let port_i: Option<i64> = row.try_get("port")?;
+    let ssh_port_i: Option<i64> = row.try_get("ssh_port")?;
+    let ssh_auth_str: Option<String> = row.try_get("ssh_auth_method").ok();
+    let ssh_auth_method = match ssh_auth_str.as_deref() {
+        Some("private_key") => SshAuthMethod::PrivateKey,
+        _ => SshAuthMethod::Password,
+    };
     Ok(ConnectionConfig {
         id: row.try_get("id")?,
         name: row.try_get("name")?,
@@ -202,6 +263,14 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<ConnectionConf
         database: row.try_get("database_name")?,
         safe_dml: row.try_get::<i64, _>("safe_dml")? != 0,
         read_only: row.try_get::<i64, _>("read_only")? != 0,
+        ssh_enabled: row.try_get::<i64, _>("ssh_enabled").unwrap_or(0) != 0,
+        ssh_host: row.try_get("ssh_host").ok().flatten(),
+        ssh_port: ssh_port_i.map(|p| p as u16),
+        ssh_user: row.try_get("ssh_user").ok().flatten(),
+        ssh_auth_method,
+        ssh_password_encrypted: row.try_get("ssh_password_encrypted").ok().flatten(),
+        ssh_key_path: row.try_get("ssh_key_path").ok().flatten(),
+        ssh_passphrase_encrypted: row.try_get("ssh_passphrase_encrypted").ok().flatten(),
     })
 }
 
@@ -233,6 +302,14 @@ mod tests {
             database: None,
             safe_dml: true,
             read_only: false,
+            ssh_enabled: false,
+            ssh_host: None,
+            ssh_port: None,
+            ssh_user: None,
+            ssh_auth_method: crate::models::SshAuthMethod::Password,
+            ssh_password_encrypted: None,
+            ssh_key_path: None,
+            ssh_passphrase_encrypted: None,
         }
     }
 

--- a/crates/wf-db/Cargo.toml
+++ b/crates/wf-db/Cargo.toml
@@ -22,3 +22,8 @@ chrono    = { workspace = true }
 anyhow            = { workspace = true }
 tracing           = { workspace = true }
 percent-encoding  = "2.3.2"
+russh             = { version = "0.60.2", default-features = false, features = ["ring", "flate2", "rsa"] }
+toml              = "1"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/wf-db/src/error.rs
+++ b/crates/wf-db/src/error.rs
@@ -18,6 +18,18 @@ pub enum DbError {
 
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+
+    #[error("SSH tunnel failed: {0}")]
+    SshTunnelFailed(String),
+
+    #[error("SSH host key rejected: server key not trusted")]
+    SshHostKeyRejected,
+
+    #[error("SSH fingerprint mismatch: expected {expected}, got {actual}")]
+    SshFingerprintMismatch { expected: String, actual: String },
+
+    #[error("failed to write known-hosts file: {0}")]
+    KnownHostsWrite(String),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wf-db/src/lib.rs
+++ b/crates/wf-db/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod models;
 pub mod pool;
 pub mod service;
+pub mod tunnel;

--- a/crates/wf-db/src/models.rs
+++ b/crates/wf-db/src/models.rs
@@ -23,6 +23,37 @@ pub enum DbKind {
 }
 
 // ---------------------------------------------------------------------------
+// SSH tunnel types
+// ---------------------------------------------------------------------------
+
+/// Authentication method for an SSH tunnel.
+#[derive(Debug, Clone)]
+pub enum SshAuth {
+    /// Authenticate with a password (plaintext passed at connect time).
+    Password,
+    /// Authenticate with a private key file.
+    PrivateKey { key_path: String },
+}
+
+/// Configuration for an SSH tunnel that proxies the database connection.
+#[derive(Debug, Clone)]
+pub struct SshTunnelConfig {
+    pub host: String,
+    /// SSH server port (typically 22).
+    pub port: u16,
+    pub user: String,
+    pub auth: SshAuth,
+    /// Remote hostname the SSH server should forward to (usually the DB host).
+    pub remote_host: String,
+    /// Remote port to forward to (the DB port).
+    pub remote_port: u16,
+    /// AES-256-GCM encrypted SSH password (for `SshAuth::Password`).
+    pub ssh_password_encrypted: Option<String>,
+    /// AES-256-GCM encrypted SSH key passphrase (for `SshAuth::PrivateKey`).
+    pub ssh_passphrase_encrypted: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // DbConnection
 // ---------------------------------------------------------------------------
 
@@ -47,6 +78,9 @@ pub struct DbConnection {
     /// AES-256-GCM encrypted password (see `wf-config::crypto`).
     pub password_encrypted: Option<String>,
     pub database: Option<String>,
+    /// Optional SSH tunnel configuration. When present, the controller
+    /// establishes a port-forward tunnel before connecting to the database.
+    pub ssh: Option<SshTunnelConfig>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wf-db/src/pool.rs
+++ b/crates/wf-db/src/pool.rs
@@ -244,6 +244,7 @@ mod tests {
             user: Some("alice".to_string()),
             password_encrypted: None,
             database: Some("mydb".to_string()),
+            ssh: None,
         }
     }
 
@@ -258,6 +259,7 @@ mod tests {
             user: Some("bob".to_string()),
             password_encrypted: None,
             database: Some("shop".to_string()),
+            ssh: None,
         }
     }
 
@@ -272,6 +274,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         }
     }
 
@@ -286,6 +289,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None, // None → :memory:
+            ssh: None,
         }
     }
 

--- a/crates/wf-db/src/service.rs
+++ b/crates/wf-db/src/service.rs
@@ -6,6 +6,7 @@ use tokio_util::sync::CancellationToken;
 use crate::error::DbError;
 use crate::models::{DbConnection, DbMetadata, QueryResult};
 use crate::pool::DbPool;
+use crate::tunnel::SshTunnel;
 
 // ---------------------------------------------------------------------------
 // DbService
@@ -17,6 +18,7 @@ use crate::pool::DbPool;
 #[derive(Clone, Default)]
 pub struct DbService {
     pools: Arc<RwLock<HashMap<String, DbPool>>>,
+    tunnels: Arc<RwLock<HashMap<String, SshTunnel>>>,
 }
 
 impl DbService {
@@ -49,12 +51,29 @@ impl DbService {
         Ok(())
     }
 
+    /// Store an SSH tunnel for `conn_id`.
+    ///
+    /// If a tunnel already exists for this id it is replaced (and the old
+    /// forwarding task is aborted via `SshTunnel`'s `Drop` impl).
+    pub fn store_tunnel(&self, conn_id: String, tunnel: SshTunnel) {
+        self.tunnels
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(conn_id, tunnel);
+    }
+
     /// Disconnect from the database identified by `conn_id`.
     ///
     /// Removing the pool from the map drops it, which closes all underlying
-    /// connections held by the pool. If `conn_id` is not found, this is a no-op.
+    /// connections held by the pool.  Any SSH tunnel for this id is also
+    /// dropped, aborting the forwarding task.  If `conn_id` is not found,
+    /// this is a no-op.
     pub fn disconnect(&self, conn_id: &str) {
         self.pools
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(conn_id);
+        self.tunnels
             .write()
             .unwrap_or_else(|p| p.into_inner())
             .remove(conn_id);
@@ -159,6 +178,7 @@ mod tests {
             user: None,
             password_encrypted: None,
             database: None,
+            ssh: None,
         }
     }
 

--- a/crates/wf-db/src/tunnel/mod.rs
+++ b/crates/wf-db/src/tunnel/mod.rs
@@ -1,0 +1,6 @@
+mod ssh;
+
+pub use ssh::{
+    KnownHostStatus, SshTunnel, check_known_host, connect_tunnel, probe_fingerprint,
+    save_known_host,
+};

--- a/crates/wf-db/src/tunnel/ssh.rs
+++ b/crates/wf-db/src/tunnel/ssh.rs
@@ -1,0 +1,361 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use russh::client;
+use russh::keys::{HashAlg, PrivateKeyWithHashAlg, load_secret_key};
+use tokio::net::TcpListener;
+
+use crate::error::DbError;
+use crate::models::{SshAuth, SshTunnelConfig};
+
+// ---------------------------------------------------------------------------
+// SshTunnel
+// ---------------------------------------------------------------------------
+
+/// An active SSH port-forwarding tunnel.
+///
+/// Backed by a tokio task that accepts local TCP connections and forwards
+/// each through an SSH direct-tcpip channel.  Dropping aborts the task.
+pub struct SshTunnel {
+    /// OS-assigned local port; use as the database host port.
+    pub local_port: u16,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        self._task.abort();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Known-hosts helpers
+// ---------------------------------------------------------------------------
+
+/// Result of comparing a host fingerprint against the known-hosts store.
+#[derive(Debug)]
+pub enum KnownHostStatus {
+    Trusted,
+    Unknown,
+    Mismatch { expected: String, actual: String },
+}
+
+fn load_known_hosts(path: &Path) -> HashMap<String, String> {
+    if !path.exists() {
+        return HashMap::new();
+    }
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return HashMap::new(),
+    };
+    toml::from_str::<HashMap<String, String>>(&content).unwrap_or_default()
+}
+
+fn write_known_hosts(path: &Path, hosts: &HashMap<String, String>) -> Result<(), DbError> {
+    let content = toml::to_string(hosts).map_err(|e| DbError::KnownHostsWrite(e.to_string()))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| DbError::KnownHostsWrite(e.to_string()))?;
+    }
+    std::fs::write(path, &content).map_err(|e| DbError::KnownHostsWrite(e.to_string()))?;
+    // Restrict to owner-read/write on Unix so fingerprints aren't world-readable.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+/// Check `host:port` against the known-hosts TOML file.
+pub fn check_known_host(host: &str, port: u16, fingerprint: &str, path: &Path) -> KnownHostStatus {
+    let hosts = load_known_hosts(path);
+    let key = format!("{host}:{port}");
+    match hosts.get(&key) {
+        None => KnownHostStatus::Unknown,
+        Some(stored) if stored == fingerprint => KnownHostStatus::Trusted,
+        Some(stored) => KnownHostStatus::Mismatch {
+            expected: stored.clone(),
+            actual: fingerprint.to_string(),
+        },
+    }
+}
+
+/// Persist a trusted fingerprint for `host:port` into the known-hosts TOML file.
+pub fn save_known_host(
+    host: &str,
+    port: u16,
+    fingerprint: &str,
+    path: &Path,
+) -> Result<(), DbError> {
+    let mut hosts = load_known_hosts(path);
+    hosts.insert(format!("{host}:{port}"), fingerprint.to_string());
+    write_known_hosts(path, &hosts)
+}
+
+// ---------------------------------------------------------------------------
+// Probe handler — captures fingerprint, always rejects
+// ---------------------------------------------------------------------------
+
+struct ProbeHandler {
+    fingerprint: Arc<Mutex<Option<String>>>,
+}
+
+impl client::Handler for ProbeHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::PublicKey,
+    ) -> Result<bool, russh::Error> {
+        let fp = format!("{}", server_public_key.fingerprint(HashAlg::Sha256));
+        *self.fingerprint.lock().unwrap_or_else(|p| p.into_inner()) = Some(fp);
+        Ok(false) // reject — we only want the fingerprint
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tunnel handler — stores actual fingerprint for mismatch detection
+// ---------------------------------------------------------------------------
+
+struct TunnelHandler {
+    trusted_fp: String,
+    /// Populated in check_server_key so the caller can detect mismatches.
+    actual_fp: Arc<Mutex<Option<String>>>,
+}
+
+impl client::Handler for TunnelHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::PublicKey,
+    ) -> Result<bool, russh::Error> {
+        let actual = format!("{}", server_public_key.fingerprint(HashAlg::Sha256));
+        *self.actual_fp.lock().unwrap_or_else(|p| p.into_inner()) = Some(actual.clone());
+        // Return false (reject) when fingerprint doesn't match; caller checks actual_fp.
+        Ok(actual == self.trusted_fp)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Probe an SSH server and return its host-key fingerprint (SHA-256 format).
+///
+/// The connection is rejected immediately after the fingerprint is captured,
+/// so any resulting I/O error is suppressed.  Returns `Err` only when the
+/// server is unreachable.
+pub async fn probe_fingerprint(host: &str, port: u16) -> Result<String, DbError> {
+    let fp_store: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let handler = ProbeHandler {
+        fingerprint: Arc::clone(&fp_store),
+    };
+    let config = Arc::new(client::Config::default());
+    // connect returns Err because check_server_key returns Ok(false) — expected
+    let _ = client::connect(config, (host, port), handler).await;
+    fp_store
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .take()
+        .ok_or_else(|| {
+            DbError::SshTunnelFailed(format!(
+                "could not reach SSH server at {host}:{port} or retrieve host key"
+            ))
+        })
+}
+
+/// Establish an SSH tunnel that port-forwards to the DB host in `config`.
+///
+/// Returns an [`SshTunnel`] whose `local_port` should replace the database
+/// host port.  Dropping the tunnel aborts the forwarding task.
+pub async fn connect_tunnel(
+    config: &SshTunnelConfig,
+    ssh_password: Option<&str>,
+    ssh_passphrase: Option<&str>,
+    trusted_fp: &str,
+) -> Result<SshTunnel, DbError> {
+    let actual_fp_store: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let handler = TunnelHandler {
+        trusted_fp: trusted_fp.to_string(),
+        actual_fp: Arc::clone(&actual_fp_store),
+    };
+    let ssh_config = Arc::new(client::Config::default());
+
+    let mut session = client::connect(ssh_config, (config.host.as_str(), config.port), handler)
+        .await
+        .map_err(|e| {
+            // Distinguish fingerprint mismatch from general connection failure.
+            if let Some(actual) = actual_fp_store
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .take()
+                .filter(|a| a != trusted_fp)
+            {
+                return DbError::SshFingerprintMismatch {
+                    expected: trusted_fp.to_string(),
+                    actual,
+                };
+            }
+            DbError::SshTunnelFailed(e.to_string())
+        })?;
+
+    let auth_result = match &config.auth {
+        SshAuth::Password => {
+            let pw = ssh_password.unwrap_or("");
+            session
+                .authenticate_password(&config.user, pw)
+                .await
+                .map_err(|e| DbError::SshTunnelFailed(e.to_string()))?
+        }
+        SshAuth::PrivateKey { key_path } => {
+            let key = load_secret_key(key_path, ssh_passphrase)
+                .map_err(|e| DbError::SshTunnelFailed(e.to_string()))?;
+            let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), None);
+            session
+                .authenticate_publickey(&config.user, key_with_alg)
+                .await
+                .map_err(|e| DbError::SshTunnelFailed(e.to_string()))?
+        }
+    };
+
+    if !auth_result.success() {
+        return Err(DbError::SshTunnelFailed(
+            "SSH authentication failed (wrong credentials)".to_string(),
+        ));
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| DbError::SshTunnelFailed(format!("failed to bind local port: {e}")))?;
+    let local_port = listener
+        .local_addr()
+        .map_err(|e| DbError::SshTunnelFailed(format!("failed to get local port: {e}")))?
+        .port();
+
+    let remote_host = config.remote_host.clone();
+    let remote_port = config.remote_port;
+
+    let task = tokio::spawn(async move {
+        loop {
+            let (mut tcp_stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "SSH tunnel: TCP accept failed, stopping");
+                    break;
+                }
+            };
+            let channel = match session
+                .channel_open_direct_tcpip(remote_host.as_str(), remote_port as u32, "127.0.0.1", 0)
+                .await
+            {
+                Ok(ch) => ch,
+                Err(e) => {
+                    tracing::warn!(error = %e, "SSH tunnel: failed to open channel, stopping");
+                    break;
+                }
+            };
+            tokio::spawn(async move {
+                let mut ssh_stream = channel.into_stream();
+                if let Err(e) =
+                    tokio::io::copy_bidirectional(&mut tcp_stream, &mut ssh_stream).await
+                {
+                    tracing::debug!(error = %e, "SSH tunnel: forwarding ended");
+                }
+            });
+        }
+    });
+
+    Ok(SshTunnel {
+        local_port,
+        _task: task,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn known_host_check_should_return_unknown_for_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        let result = check_known_host("db.example.com", 22, "SHA256:abc", &path);
+        assert!(matches!(result, KnownHostStatus::Unknown));
+    }
+
+    #[test]
+    fn known_host_check_should_return_trusted_for_matching_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        save_known_host("db.example.com", 22, "SHA256:abc123", &path).unwrap();
+        let result = check_known_host("db.example.com", 22, "SHA256:abc123", &path);
+        assert!(matches!(result, KnownHostStatus::Trusted));
+    }
+
+    #[test]
+    fn known_host_check_should_return_mismatch_for_wrong_fingerprint() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        save_known_host("db.example.com", 22, "SHA256:stored", &path).unwrap();
+        let result = check_known_host("db.example.com", 22, "SHA256:different", &path);
+        assert!(
+            matches!(
+                result,
+                KnownHostStatus::Mismatch { ref expected, .. } if expected == "SHA256:stored"
+            ),
+            "expected Mismatch with stored fingerprint"
+        );
+    }
+
+    #[test]
+    fn known_host_save_should_persist_new_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        save_known_host("myhost", 2222, "SHA256:xyz", &path).unwrap();
+        let hosts = load_known_hosts(&path);
+        assert_eq!(
+            hosts.get("myhost:2222").map(|s| s.as_str()),
+            Some("SHA256:xyz")
+        );
+    }
+
+    #[test]
+    fn known_host_save_should_overwrite_existing_entry() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        save_known_host("myhost", 22, "SHA256:old", &path).unwrap();
+        save_known_host("myhost", 22, "SHA256:new", &path).unwrap();
+        let hosts = load_known_hosts(&path);
+        assert_eq!(
+            hosts.get("myhost:22").map(|s| s.as_str()),
+            Some("SHA256:new")
+        );
+    }
+
+    #[test]
+    fn known_host_check_should_distinguish_ports() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("known_hosts.toml");
+        save_known_host("myhost", 22, "SHA256:for22", &path).unwrap();
+        save_known_host("myhost", 2222, "SHA256:for2222", &path).unwrap();
+        assert!(matches!(
+            check_known_host("myhost", 22, "SHA256:for22", &path),
+            KnownHostStatus::Trusted
+        ));
+        assert!(matches!(
+            check_known_host("myhost", 2222, "SHA256:for2222", &path),
+            KnownHostStatus::Trusted
+        ));
+        assert!(matches!(
+            check_known_host("myhost", 22, "SHA256:for2222", &path),
+            KnownHostStatus::Mismatch { .. }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Adds SSH port-forwarding support so databases in private subnets can be reached through a bastion host. Uses `russh` (pure Rust, no OpenSSL required on Windows) to establish a local port-forward before the DB connection, with the tunnel lifetime tied to the DB session via `Drop`.

## Changes

- `crates/wf-db`: new `tunnel/` module — `SshTunnel`, `probe_fingerprint`, `connect_tunnel`, `check_known_host`, `save_known_host`; new `DbError` variants for SSH failures; `DbService` gains a `tunnels` map and `store_tunnel()`/`disconnect()` lifecycle
- `crates/wf-config`: `SshAuthMethod` enum; 8 new SSH fields on `ConnectionConfig` (all `#[serde(default)]`); SQLite migration adds SSH columns to existing `connections` tables
- `app/src/app`: `Event::SshFingerprintRequired` with oneshot approval bridge; `AppController` holds `config_dir` + `enc_key`; `handle_connect` orchestrates probe → known-hosts check → user approval (oneshot) → tunnel → DB connect
- `app/src/ui`: fingerprint approval dialog (`FingerprintDialog`); SSH Tunnel tab in connection form with Password / Private Key auth toggle and Browse button (`rfd`); SSH badge in status bar; `validate_form()` blocks connection-string + SSH combination
- `app/locales/en.yml` + `ja.yml`: SSH error and UI messages

## Related Issues

Closes #204

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes