### PR TITLE
feat(history): add HistoryService::search with keyword and connection filter

### DIFF
--- a/crates/wf-history/src/error.rs
+++ b/crates/wf-history/src/error.rs
@@ -1,0 +1,6 @@
+/// Typed error for [`crate::service::HistoryService`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum HistoryError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}

--- a/crates/wf-history/src/find_history.rs
+++ b/crates/wf-history/src/find_history.rs
@@ -1,5 +1,8 @@
-use anyhow::Result;
-use sqlx::SqlitePool;
+use sqlx::{Row as _, SqlitePool};
+
+use crate::error::HistoryError;
+
+type Result<T> = std::result::Result<T, HistoryError>;
 
 /// Persists find/replace bar search terms to a SQLite table.
 ///
@@ -48,7 +51,6 @@ impl FindHistoryService {
                 .fetch_all(&self.pool)
                 .await?;
 
-        use sqlx::Row as _;
         Ok(rows.iter().map(|r| r.get("query")).collect())
     }
 

--- a/crates/wf-history/src/lib.rs
+++ b/crates/wf-history/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod error;
 pub mod find_history;
 pub mod service;
 pub mod session;
+
+pub use error::HistoryError;

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -1,6 +1,9 @@
-use anyhow::Result;
-use sqlx::SqlitePool;
+use sqlx::{Row as _, SqlitePool};
 use wf_db::models::QueryExecution;
+
+use crate::error::HistoryError;
+
+type Result<T> = std::result::Result<T, HistoryError>;
 
 // ---------------------------------------------------------------------------
 // HistoryService
@@ -57,6 +60,47 @@ impl HistoryService {
         Ok(())
     }
 
+    /// Return up to `limit` executions matching `keyword` in the SQL text,
+    /// optionally restricted to a single connection.
+    ///
+    /// Results are ordered newest-first (DESC timestamp).
+    pub async fn search(
+        &self,
+        keyword: &str,
+        filter_conn: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<QueryExecution>> {
+        let pattern = format!("%{keyword}%");
+        let rows = sqlx::query(
+            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id
+             FROM query_executions
+             WHERE sql LIKE ?
+               AND connection_id = COALESCE(?, connection_id)
+             ORDER BY timestamp DESC
+             LIMIT ?",
+        )
+        .bind(&pattern)
+        .bind(filter_conn)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let executions = rows
+            .iter()
+            .map(|row| QueryExecution {
+                id: row.get("id"),
+                sql: row.get("sql"),
+                duration_ms: row.get::<i64, _>("duration_ms") as u128,
+                success: row.get::<i32, _>("success") != 0,
+                error_message: row.get("error_message"),
+                timestamp: row.get("timestamp"),
+                connection_id: row.get("connection_id"),
+            })
+            .collect();
+
+        Ok(executions)
+    }
+
     /// Return up to `limit` most recent executions, newest first (DESC timestamp).
     pub async fn recent(&self, limit: usize) -> Result<Vec<QueryExecution>> {
         let rows = sqlx::query(
@@ -69,7 +113,6 @@ impl HistoryService {
         .fetch_all(&self.pool)
         .await?;
 
-        use sqlx::Row as _;
         let executions = rows
             .iter()
             .map(|row| QueryExecution {
@@ -102,6 +145,16 @@ mod tests {
     use super::*;
 
     fn make_exec(sql: &str, ts: i64, success: bool, err: Option<&str>) -> QueryExecution {
+        make_exec_for("c1", sql, ts, success, err)
+    }
+
+    fn make_exec_for(
+        conn_id: &str,
+        sql: &str,
+        ts: i64,
+        success: bool,
+        err: Option<&str>,
+    ) -> QueryExecution {
         QueryExecution {
             id: 0,
             sql: sql.to_string(),
@@ -109,7 +162,7 @@ mod tests {
             success,
             error_message: err.map(|s| s.to_string()),
             timestamp: ts,
-            connection_id: "c1".to_string(),
+            connection_id: conn_id.to_string(),
         }
     }
 
@@ -152,5 +205,80 @@ mod tests {
         let svc = HistoryService::open_memory().await.unwrap();
         let rows = svc.recent(10).await.unwrap();
         assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_should_filter_by_keyword() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        svc.insert(&make_exec("SELECT name FROM users", 1000, true, None))
+            .await
+            .unwrap();
+        svc.insert(&make_exec(
+            "INSERT INTO orders VALUES (1)",
+            2000,
+            true,
+            None,
+        ))
+        .await
+        .unwrap();
+
+        let rows = svc.search("users", None, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].sql.contains("users"));
+    }
+
+    #[tokio::test]
+    async fn search_should_filter_by_connection() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        svc.insert(&make_exec_for("conn-a", "SELECT 1", 1000, true, None))
+            .await
+            .unwrap();
+        svc.insert(&make_exec_for("conn-b", "SELECT 2", 2000, true, None))
+            .await
+            .unwrap();
+        svc.insert(&make_exec_for("conn-a", "SELECT 3", 3000, true, None))
+            .await
+            .unwrap();
+
+        let rows = svc.search("SELECT", Some("conn-a"), 10).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.connection_id == "conn-a"));
+    }
+
+    #[tokio::test]
+    async fn search_should_filter_by_keyword_and_connection() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        svc.insert(&make_exec_for(
+            "conn-a",
+            "SELECT * FROM users",
+            1000,
+            true,
+            None,
+        ))
+        .await
+        .unwrap();
+        svc.insert(&make_exec_for(
+            "conn-b",
+            "SELECT * FROM users",
+            2000,
+            true,
+            None,
+        ))
+        .await
+        .unwrap();
+        svc.insert(&make_exec_for(
+            "conn-a",
+            "DELETE FROM orders",
+            3000,
+            true,
+            None,
+        ))
+        .await
+        .unwrap();
+
+        let rows = svc.search("users", Some("conn-a"), 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].connection_id, "conn-a");
+        assert!(rows[0].sql.contains("users"));
     }
 }

--- a/crates/wf-history/src/session.rs
+++ b/crates/wf-history/src/session.rs
@@ -1,5 +1,8 @@
-use anyhow::Context as _;
 use sqlx::{Row as _, SqlitePool};
+
+use crate::error::HistoryError;
+
+type Result<T> = std::result::Result<T, HistoryError>;
 
 /// A single SQL Editor tab persisted across app restarts.
 #[derive(Debug, Clone)]
@@ -36,26 +39,16 @@ pub struct SessionService {
 
 impl SessionService {
     /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
-    pub async fn new(pool: SqlitePool) -> anyhow::Result<Self> {
-        sqlx::query(CREATE_TABS)
-            .execute(&pool)
-            .await
-            .context("failed to create session_tabs table")?;
-        sqlx::query(CREATE_STATE)
-            .execute(&pool)
-            .await
-            .context("failed to create session_state table")?;
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
+        sqlx::query(CREATE_TABS).execute(&pool).await?;
+        sqlx::query(CREATE_STATE).execute(&pool).await?;
         Ok(Self { pool })
     }
 
     /// Persist the editor tabs. Replaces all previously saved tabs.
     ///
     /// `active_index` is the index within `tabs` (SQL Editor tabs only) that was active.
-    pub async fn save_tabs(
-        &self,
-        active_index: usize,
-        tabs: &[TabSessionEntry],
-    ) -> anyhow::Result<()> {
+    pub async fn save_tabs(&self, active_index: usize, tabs: &[TabSessionEntry]) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         sqlx::query("DELETE FROM session_tabs")
             .execute(&mut *tx)
@@ -81,7 +74,7 @@ impl SessionService {
     /// Restore tabs from the previous session.
     ///
     /// Returns `None` when no tabs have been saved yet.
-    pub async fn restore_tabs(&self) -> anyhow::Result<Option<(usize, Vec<TabSessionEntry>)>> {
+    pub async fn restore_tabs(&self) -> Result<Option<(usize, Vec<TabSessionEntry>)>> {
         let rows = sqlx::query(
             "SELECT sort_order, id, title, query_text, is_active
              FROM session_tabs ORDER BY sort_order ASC",
@@ -108,13 +101,13 @@ impl SessionService {
                     query_text: row.try_get("query_text")?,
                 })
             })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Some((active_index, entries)))
     }
 
     /// Persist the last active editor query text.
-    pub async fn save_last_query(&self, query: &str) -> anyhow::Result<()> {
+    pub async fn save_last_query(&self, query: &str) -> Result<()> {
         sqlx::query(
             "INSERT INTO session_state (key, value) VALUES ('last_query', ?)
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -128,7 +121,7 @@ impl SessionService {
     /// Restore the last active editor query text.
     ///
     /// Returns `None` when no query has been saved or it is empty.
-    pub async fn restore_last_query(&self) -> anyhow::Result<Option<String>> {
+    pub async fn restore_last_query(&self) -> Result<Option<String>> {
         let value: Option<String> =
             sqlx::query_scalar("SELECT value FROM session_state WHERE key = 'last_query'")
                 .fetch_optional(&self.pool)


### PR DESCRIPTION
## Summary

Adds `HistoryService::search` to `wf-history`, enabling keyword-based and connection-ID-filtered queries over the query execution history. Also migrates all three modules in `wf-history` (`service`, `find_history`, `session`) from `anyhow` to a typed `HistoryError` backed by `thiserror`, consistent with the project's library-crate error policy.

## Changes

- `crates/wf-history/src/error.rs` (new): `HistoryError` with `#[from] sqlx::Error` variant
- `crates/wf-history/src/lib.rs`: expose `pub mod error` and `pub use error::HistoryError`
- `crates/wf-history/src/service.rs`: add `search(keyword, filter_conn, limit)` using `LIKE '%keyword%'` and `COALESCE(?, connection_id)` for optional connection filtering; migrate from `anyhow` to `HistoryError`; consolidate `use sqlx::Row as _` to module top-level
- `crates/wf-history/src/find_history.rs`: migrate from `anyhow` to `HistoryError`; consolidate `use sqlx::Row as _`
- `crates/wf-history/src/session.rs`: migrate from `anyhow::Context` to `HistoryError`; remove `.context(...)` decorators
- Three unit tests added: `search_should_filter_by_keyword`, `search_should_filter_by_connection`, `search_should_filter_by_keyword_and_connection`

## Related Issues

Closes #65

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes