### PR TITLE
feat(history): add query history panel UI (Ctrl+Shift+H)

### DIFF
--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -27,3 +27,7 @@ error:
   group_create_failed: "Failed to create group: %{reason}"
   group_rename_failed: "Failed to rename group: %{reason}"
   group_delete_failed: "Failed to delete group: %{reason}"
+history:
+  title: "Query History"
+  placeholder: "Search history..."
+  empty: "No history yet"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -27,3 +27,7 @@ error:
   group_create_failed: "グループの作成に失敗しました: %{reason}"
   group_rename_failed: "グループの名前変更に失敗しました: %{reason}"
   group_delete_failed: "グループの削除に失敗しました: %{reason}"
+history:
+  title: "クエリ履歴"
+  placeholder: "履歴を検索..."
+  empty: "履歴がありません"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -79,6 +79,11 @@ pub enum Command {
         id: String,
         expanded: bool,
     },
+    /// Search query execution history. Empty keyword = most recent N rows.
+    SearchHistory {
+        keyword: String,
+        conn_id: Option<String>,
+    },
 }
 
 impl Command {
@@ -103,6 +108,7 @@ impl Command {
             Self::MoveConnectionToGroup { .. } => "MoveConnectionToGroup",
             Self::SetGroupColor { .. } => "SetGroupColor",
             Self::SetGroupExpanded { .. } => "SetGroupExpanded",
+            Self::SearchHistory { .. } => "SearchHistory",
         }
     }
 }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -16,6 +16,7 @@
 mod config;
 mod connection;
 mod group;
+mod history;
 mod metadata;
 mod query;
 
@@ -147,6 +148,9 @@ impl AppController {
                 }
                 Command::SetGroupExpanded { id, expanded } => {
                     this.handle_set_group_expanded(id, expanded).await
+                }
+                Command::SearchHistory { keyword, conn_id } => {
+                    this.handle_search_history(keyword, conn_id).await
                 }
             }
         }

--- a/app/src/app/controller/history.rs
+++ b/app/src/app/controller/history.rs
@@ -1,0 +1,130 @@
+use crate::app::event::Event;
+
+use super::AppController;
+
+const HISTORY_PANEL_LIMIT: usize = 100;
+
+impl AppController {
+    pub(super) async fn handle_search_history(&self, keyword: String, conn_id: Option<String>) {
+        let rows = self
+            .history
+            .search(&keyword, conn_id.as_deref(), HISTORY_PANEL_LIMIT)
+            .await
+            .unwrap_or_default();
+        let _ = self.tx_event.send(Event::HistoryLoaded(rows)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use sqlx::SqlitePool;
+    use tempfile::tempdir;
+    use wf_completion::cache::MetadataCache;
+    use wf_config::{ConnectionRepository, GroupRepository, manager::ConfigManager};
+    use wf_db::models::QueryExecution;
+    use wf_db::service::DbService;
+    use wf_history::service::HistoryService;
+
+    use crate::app::{command::Command, event::Event, session::SessionManager};
+    use crate::state::AppState;
+
+    use super::super::AppController;
+
+    fn make_session() -> SessionManager {
+        let dir = tempdir().unwrap();
+        let path = dir.keep().join("config.toml");
+        SessionManager::with_config_manager(ConfigManager::with_path(path))
+    }
+
+    async fn make_controller(
+        history: HistoryService,
+    ) -> (
+        AppController,
+        tokio::sync::mpsc::Sender<Command>,
+        tokio::sync::mpsc::Receiver<Event>,
+    ) {
+        let state = Arc::new(AppState::new());
+        let db = DbService::new();
+        let repo = Arc::new(ConnectionRepository::open_memory().await.unwrap());
+        let group_repo = Arc::new(GroupRepository::open_memory().await.unwrap());
+        let cache_pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let cache = MetadataCache::new(cache_pool).await.unwrap();
+        AppController::new(
+            state,
+            db,
+            make_session(),
+            repo,
+            group_repo,
+            history,
+            cache,
+            tempdir().unwrap().keep(),
+            [0u8; 32],
+        )
+    }
+
+    fn make_exec(sql: &str, ts: i64) -> QueryExecution {
+        QueryExecution {
+            id: 0,
+            sql: sql.to_string(),
+            duration_ms: 10,
+            success: true,
+            error_message: None,
+            timestamp: ts,
+            connection_id: "c1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn search_history_should_send_history_loaded_event() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let history = HistoryService::new(pool).await.unwrap();
+        history.insert(&make_exec("SELECT 1", 1000)).await.unwrap();
+        history.insert(&make_exec("SELECT 2", 2000)).await.unwrap();
+
+        let (controller, tx_cmd, mut rx_event) = make_controller(history).await;
+        tx_cmd
+            .send(Command::SearchHistory {
+                keyword: "SELECT".to_string(),
+                conn_id: None,
+            })
+            .await
+            .unwrap();
+        drop(tx_cmd);
+        controller.run().await;
+
+        let event = rx_event.recv().await.unwrap();
+        match event {
+            Event::HistoryLoaded(rows) => assert_eq!(rows.len(), 2),
+            _ => panic!("expected HistoryLoaded, got {event:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn search_history_should_return_empty_vec_when_no_rows() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let history = HistoryService::new(pool).await.unwrap();
+
+        let (controller, tx_cmd, mut rx_event) = make_controller(history).await;
+        tx_cmd
+            .send(Command::SearchHistory {
+                keyword: "SELECT".to_string(),
+                conn_id: None,
+            })
+            .await
+            .unwrap();
+        drop(tx_cmd);
+        controller.run().await;
+
+        let event = rx_event.recv().await.unwrap();
+        match event {
+            Event::HistoryLoaded(rows) => assert!(rows.is_empty()),
+            _ => panic!("expected HistoryLoaded, got {event:?}"),
+        }
+    }
+}

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -1,7 +1,7 @@
 use tokio::sync::oneshot;
 use wf_completion::CompletionItem;
 use wf_config::models::{ConnectionConfig, GroupConfig, Theme};
-use wf_db::models::{DbMetadata, QueryResult};
+use wf_db::models::{DbMetadata, QueryExecution, QueryResult};
 
 /// Fine-grained state transitions forwarded to the UI via `StateChanged`.
 #[derive(Debug)]
@@ -68,6 +68,8 @@ pub enum Event {
         tab_id: String,
         msg: String,
     },
+    // ── History panel ────────────────────────────────────────────────────────
+    HistoryLoaded(Vec<QueryExecution>),
     // ── Group events ─────────────────────────────────────────────────────────
     /// A new group was created; `id` is the new group's ID. Used by the UI to
     /// trigger inline rename on the newly added group node.

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -652,7 +652,7 @@ export component AppWindow inherits Window {
             } else if (event.modifiers.control
                     && event.modifiers.shift
                     && !event.modifiers.alt
-                    && event.text == "h") {
+                    && event.text == "H") {
                 if (!UiState.show-history) { UiState.history-open(); }
                 EventResult.accept
             } else if (event.modifiers.control

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem, HistoryEntry } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -30,6 +30,7 @@ import { SnippetEditDialog }     from "components/snippet_edit_dialog.slint";
 import { SnippetBar }            from "components/snippet_bar.slint";
 import { MetadataSearch }        from "components/metadata_search.slint";
 import { CommandPalette }        from "components/command_palette.slint";
+import { HistoryPanel }          from "components/history_panel.slint";
 import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.slint";
 import { FingerprintDialog }    from "components/dialogs/fingerprint_dialog.slint";
 
@@ -407,6 +408,19 @@ export global UiState {
     callback command-palette-search(string);
     /// Execute the command identified by id.
     callback command-palette-execute(string);
+
+    // ── Query History Panel (Ctrl+Shift+H) ───────────────────────────────────
+    in-out property <bool>            show-history:    false;
+    in-out property <string>          history-query:   "";
+    in-out property <[HistoryEntry]>  history-entries: [];
+    /// Load recent history entries on panel open.
+    callback history-open();
+    /// Re-query history on keyword change (debounced in Rust).
+    callback history-search();
+    /// Insert SQL at editor cursor position; cursor-pos is byte offset.
+    callback history-insert-sql(string, int);
+    /// Replace editor text with SQL and execute immediately.
+    callback history-execute-sql(string);
 }
 
 export component AppWindow inherits Window {
@@ -564,6 +578,7 @@ export component AppWindow inherits Window {
                     || UiState.show-snippet-edit
                     || UiState.show-metadata-search
                     || UiState.show-command-palette
+                    || UiState.show-history
                     || UiState.show-editor-prefs
                     || UiState.show-ssh-fingerprint-dialog) {
                 EventResult.reject
@@ -633,6 +648,12 @@ export component AppWindow inherits Window {
                 if (!UiState.show-command-palette) {
                     UiState.command-palette-open();
                 }
+                EventResult.accept
+            } else if (event.modifiers.control
+                    && event.modifiers.shift
+                    && !event.modifiers.alt
+                    && event.text == "h") {
+                if (!UiState.show-history) { UiState.history-open(); }
                 EventResult.accept
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -1432,6 +1453,34 @@ export component AppWindow inherits Window {
             close-on-blur => {
                 UiState.show-command-palette  = false;
                 UiState.command-palette-query = "";
+            }
+        }
+
+        // ── Query History Panel (Ctrl+Shift+H) ────────────────────────────────
+        if UiState.show-history: HistoryPanel {
+            x: sidebar-width + (main-width - self.width) / 2;
+            y: menu-bar-height + tab-bar-height + 20px;
+            query          <=> UiState.history-query;
+            entries:           UiState.history-entries;
+            search-changed => { UiState.history-search(); }
+            insert-sql(sql) => {
+                UiState.history-insert-sql(sql, editor-inst.cursor-pos);
+                editor-inst.grab-focus();
+            }
+            execute-sql(sql) => {
+                UiState.history-execute-sql(sql);
+                UiState.show-history  = false;
+                UiState.history-query = "";
+                editor-inst.grab-focus();
+            }
+            close => {
+                UiState.show-history  = false;
+                UiState.history-query = "";
+                editor-inst.grab-focus();
+            }
+            close-on-blur => {
+                UiState.show-history  = false;
+                UiState.history-query = "";
             }
         }
 

--- a/app/src/ui/components/history_panel.slint
+++ b/app/src/ui/components/history_panel.slint
@@ -1,0 +1,347 @@
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { HistoryEntry } from "../globals.slint";
+
+export component HistoryPanel inherits Rectangle {
+    in-out property <string>        query:          "";
+    in property    <[HistoryEntry]> entries:        [];
+    property <int>           selected-index: 0;
+    callback search-changed();
+    callback insert-sql(string);
+    callback execute-sql(string);
+    callback close();
+    callback close-on-blur();
+
+    property <length> header-h:     40px;
+    property <length> search-row-h: 44px;
+    // Always reserve at least 56px (for the empty-state text when entries is empty).
+    property <length> list-h: clamp(max(1, root.entries.length) * 56px, 56px, 336px);
+
+    width:  700px;
+    height: root.header-h + root.search-row-h + root.list-h;
+
+    background:        Colors.surface0;
+    border-radius:     Layout.radius-md;
+    border-width:      1px;
+    border-color:      Colors.surface1;
+    drop-shadow-blur:  12px;
+    drop-shadow-color: Colors.shadow;
+    clip: true;
+
+    property <bool> _input-focused <=> search-input.has-focus;
+
+    // Bridge for entries-flick.viewport-y to allow auto-scroll without crossing
+    // conditional-block scope boundaries.
+    property <length> _entries-vpy: 0;
+
+    changed query => {
+        root._entries-vpy = 0;
+        root.search-changed();
+    }
+    init => { search-input.focus(); }
+
+    changed _input-focused => {
+        if (!_input-focused) { root.close-on-blur(); }
+    }
+
+    // Auto-scroll so the selected entry stays in view.
+    changed selected-index => {
+        if (root.entries.length > 0 && root.list-h > 0px) {
+            if (root.selected-index * 56px < -root._entries-vpy) {
+                root._entries-vpy = -(root.selected-index * 56px);
+            } else if ((root.selected-index + 1) * 56px > -root._entries-vpy + root.list-h) {
+                root._entries-vpy = -((root.selected-index + 1) * 56px - root.list-h);
+            }
+        }
+    }
+
+    panel-focus := FocusScope {
+        focus-on-click: false;
+
+        capture-key-pressed(event) => {
+            if (event.text == Key.Escape) {
+                root.close();
+                EventResult.accept
+            } else if (event.text == Key.UpArrow) {
+                if (root.selected-index > 0) { root.selected-index -= 1; }
+                EventResult.accept
+            } else if (event.text == Key.DownArrow) {
+                if (root.selected-index < root.entries.length - 1) {
+                    root.selected-index += 1;
+                }
+                EventResult.accept
+            } else if (event.text == Key.Return) {
+                if (root.entries.length > 0) {
+                    root.insert-sql(root.entries[root.selected-index].full-sql);
+                }
+                EventResult.accept
+            } else {
+                EventResult.reject
+            }
+        }
+
+        VerticalLayout {
+            spacing: 0;
+
+            // ── Header ───────────────────────────────────────────────────────
+            Rectangle {
+                height: root.header-h;
+                background: Colors.surface0;
+
+                // Bottom separator
+                Rectangle {
+                    x: 0; y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: Colors.surface1;
+                }
+
+                HorizontalLayout {
+                    padding-left:  Layout.padding-sm;
+                    padding-right: Layout.padding-xs;
+                    spacing: 0;
+
+                    Text {
+                        horizontal-stretch: 1;
+                        text: @tr("Query History");
+                        color: Colors.text;
+                        font-size: Typography.size-base;
+                        font-weight: 600;
+                        vertical-alignment: center;
+                    }
+
+                    // Close button
+                    Rectangle {
+                        width: root.header-h;
+                        height: root.header-h;
+                        border-radius: 2px;
+
+                        states [
+                            hovered when close-ta.has-hover: {
+                                background: Colors.surface1;
+                            }
+                        ]
+
+                        Text {
+                            x: (parent.width  - self.width)  / 2;
+                            y: (parent.height - self.height) / 2;
+                            text: "\u{00D7}";
+                            color: Colors.subtext0;
+                            font-size: Typography.size-base;
+                        }
+
+                        close-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.close(); }
+                        }
+                    }
+                }
+            }
+
+            // ── Search input row ─────────────────────────────────────────────
+            Rectangle {
+                height: root.search-row-h;
+                background: Colors.surface0;
+
+                TouchArea {
+                    mouse-cursor: text;
+                    clicked => { search-input.focus(); }
+                }
+
+                HorizontalLayout {
+                    padding-left:  Layout.padding-sm;
+                    padding-right: Layout.padding-sm;
+                    spacing: Layout.spacing-md;
+
+                    search-input := TextInput {
+                        horizontal-stretch: 1;
+                        single-line: true;
+                        text <=> root.query;
+                        color: Colors.text;
+                        font-size: Typography.size-base;
+                        vertical-alignment: center;
+                    }
+                }
+
+                if root.query == "": Text {
+                    x: Layout.padding-sm;
+                    y: 0;
+                    width: parent.width - Layout.padding-sm;
+                    height: parent.height;
+                    text: @tr("Search history\u{2026}");
+                    color: Colors.overlay0;
+                    font-size: Typography.size-base;
+                    vertical-alignment: center;
+                }
+
+                // Bottom separator
+                Rectangle {
+                    x: 0; y: parent.height - 1px;
+                    width: parent.width; height: 1px;
+                    background: Colors.surface1;
+                }
+            }
+
+            // ── Entries list ─────────────────────────────────────────────────
+            if root.entries.length > 0: Rectangle {
+                width: parent.width;
+                height: root.list-h;
+
+                entries-flick := Flickable {
+                    width: parent.width;
+                    height: parent.height;
+                    viewport-height: max(self.height, root.entries.length * 56px);
+                    viewport-y <=> root._entries-vpy;
+
+                    VerticalLayout {
+                        width: parent.width;
+                        spacing: 0;
+
+                        for e[i] in root.entries: Rectangle {
+                            height: 56px;
+                            width: root.width;
+                            background: i == root.selected-index
+                                ? Colors.sidebar-sel
+                                : transparent;
+
+                            states [
+                                hovered when entry-ta.has-hover && i != root.selected-index: {
+                                    background: Colors.surface1;
+                                }
+                            ]
+
+                            HorizontalLayout {
+                                padding-left:  Layout.padding-sm;
+                                padding-right: Layout.padding-sm;
+                                spacing: Layout.spacing-md;
+
+                                // Success / failure dot
+                                Rectangle {
+                                    width: 8px;
+
+                                    Rectangle {
+                                        x: 0;
+                                        y: (parent.height - 8px) / 2;
+                                        width: 8px; height: 8px;
+                                        border-radius: 4px;
+                                        background: e.success ? Colors.green : Colors.red;
+                                    }
+                                }
+
+                                // SQL preview + timestamp
+                                VerticalLayout {
+                                    horizontal-stretch: 1;
+                                    padding-top: 10px;
+                                    padding-bottom: 10px;
+                                    spacing: 4px;
+
+                                    Text {
+                                        text: e.sql-preview;
+                                        color: Colors.text;
+                                        font-size: Typography.size-base;
+                                        overflow: elide;
+                                    }
+
+                                    Text {
+                                        text: e.timestamp-text;
+                                        color: Colors.subtext1;
+                                        font-size: Typography.size-sm;
+                                    }
+                                }
+
+                                // Duration
+                                Text {
+                                    text: e.duration-text;
+                                    color: Colors.subtext0;
+                                    font-size: Typography.size-sm;
+                                    vertical-alignment: center;
+                                }
+                            }
+
+                            entry-ta := TouchArea {
+                                mouse-cursor: pointer;
+                                clicked => {
+                                    root.selected-index = i;
+                                    root.insert-sql(e.full-sql);
+                                }
+                                double-clicked => {
+                                    root.execute-sql(e.full-sql);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ── Scrollbar overlay ────────────────────────────────────────
+                if entries-flick.viewport-height > entries-flick.height: Rectangle {
+                    property <length> overflow:  entries-flick.viewport-height - entries-flick.height;
+                    property <length> track-h:   parent.height - 4px;
+                    property <length> thumb-h:   clamp(entries-flick.height * entries-flick.height / entries-flick.viewport-height, 20px, track-h);
+                    property <length> _press-my:  0px;
+                    property <length> _press-vpy: 0px;
+
+                    x: parent.width - 14px;
+                    width: 14px;
+                    height: parent.height;
+                    background: transparent;
+
+                    Rectangle {
+                        x: 3px; y: 2px;
+                        width: 8px;
+                        height: parent.track-h;
+                        background: Colors.surface1;
+                    }
+
+                    Rectangle {
+                        x: 3px;
+                        y: clamp(
+                            (-entries-flick.viewport-y) / parent.overflow * (parent.track-h - parent.thumb-h),
+                            0px,
+                            parent.track-h - parent.thumb-h
+                        ) + 2px;
+                        width: 8px;
+                        height: parent.thumb-h;
+                        background: sb-ta.pressed
+                            ? Colors.subtext0
+                            : sb-ta.has-hover ? Colors.overlay1 : Colors.overlay0;
+                        opacity: sb-ta.pressed ? 1.0 : sb-ta.has-hover ? 0.75 : 0.45;
+                    }
+
+                    sb-ta := TouchArea {
+                        pointer-event(e) => {
+                            if (e.kind == PointerEventKind.down) {
+                                parent._press-my  = self.mouse-y;
+                                parent._press-vpy = entries-flick.viewport-y;
+                            }
+                        }
+                        moved => {
+                            entries-flick.viewport-y = clamp(
+                                parent._press-vpy
+                                    - (self.mouse-y - parent._press-my)
+                                    * parent.overflow
+                                    / (parent.track-h - parent.thumb-h),
+                                -parent.overflow,
+                                0px
+                            );
+                        }
+                    }
+                }
+            }
+
+            // ── Empty state ──────────────────────────────────────────────────
+            if root.entries.length == 0: Rectangle {
+                height: 56px;
+                width: parent.width;
+                background: transparent;
+
+                Text {
+                    x: 0; y: 0;
+                    width: parent.width; height: parent.height;
+                    text: @tr("No history yet");
+                    color: Colors.overlay0;
+                    font-size: Typography.size-base;
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/event.rs
+++ b/app/src/ui/event.rs
@@ -6,7 +6,7 @@ use slint::ComponentHandle;
 use tokio::sync::mpsc;
 use wf_config::models::{ConnectionConfig, GroupConfig, Theme};
 use wf_config::snippet::SnippetRepository;
-use wf_db::models::DbMetadata;
+use wf_db::models::{DbMetadata, QueryExecution};
 
 use crate::app::event::{Event, StateEvent};
 use crate::state::SharedState;
@@ -158,10 +158,37 @@ pub(super) fn spawn_event_handler(
                     Arc::clone(&sidebar_state),
                     state.clone(), // clone required: passed to spawned handler
                 ),
+                Event::HistoryLoaded(rows) => handle_history_loaded(rows, window_weak.clone()),
                 _ => {}
             }
         }
     });
+}
+
+pub(super) fn history_rows_to_slint(rows: &[QueryExecution]) -> Vec<crate::HistoryEntry> {
+    rows.iter()
+        .map(|r| {
+            let ts = chrono::DateTime::from_timestamp(r.timestamp, 0)
+                .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                .unwrap_or_default();
+            let duration_text = if r.duration_ms >= 1000 {
+                format!("{:.1}s", r.duration_ms as f64 / 1000.0)
+            } else {
+                format!("{}ms", r.duration_ms)
+            };
+            let preview = r.sql.split_whitespace().collect::<Vec<_>>().join(" ");
+            let preview: String = preview.chars().take(80).collect();
+            crate::HistoryEntry {
+                id: r.id as i32,
+                sql_preview: preview.into(),
+                full_sql: r.sql.clone().into(),
+                timestamp_text: ts.into(),
+                duration_text: duration_text.into(),
+                success: r.success,
+                connection_id: r.connection_id.clone().into(),
+            }
+        })
+        .collect()
 }
 
 // ── Per-event handlers ─────────────────────────────────────────────────────────
@@ -563,6 +590,18 @@ fn handle_table_data_failed(_tab_id: String, msg: String, ww: slint::Weak<crate:
         with_ui(&ww, move |ui| {
             ui.set_tv_data_loading(false);
             ui.set_tv_data_error(msg.into());
+        });
+    });
+}
+
+fn handle_history_loaded(rows: Vec<QueryExecution>, ww: slint::Weak<crate::AppWindow>) {
+    let entries = history_rows_to_slint(&rows);
+    // clone required: invoke_from_event_loop closure must be 'static
+    let _ = slint::invoke_from_event_loop(move || {
+        with_ui(&ww, |ui| {
+            let model = Rc::new(slint::VecModel::from(entries));
+            ui.set_history_entries(model.into());
+            ui.set_show_history(true);
         });
     });
 }

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -97,3 +97,13 @@ export struct HighlightSpan {
     text: string,
     kind: int,
 }
+
+export struct HistoryEntry {
+    id:             int,
+    sql-preview:    string,   // first ~80 chars, newlines collapsed to spaces
+    full-sql:       string,
+    timestamp-text: string,   // "YYYY-MM-DD HH:mm"
+    duration-text:  string,   // "42ms" or "1.2s"
+    success:        bool,
+    connection-id:  string,
+}

--- a/app/src/ui/history.rs
+++ b/app/src/ui/history.rs
@@ -64,7 +64,8 @@ pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc
                 let pos = (cursor_pos as usize).min(current.len());
                 let new_text = format!("{}{}{}", &current[..pos], sql, &current[pos..]);
                 let new_cursor = (pos + sql.len()) as i32;
-                ui.set_editor_text(new_text.into());
+                ui.set_editor_text(new_text.clone().into());
+                ui.invoke_update_highlight(new_text.into());
                 ui.set_editor_cursor_target(new_cursor);
                 ui.set_show_history(false);
             });
@@ -78,6 +79,7 @@ pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc
             let Some(w) = ww.upgrade() else { return };
             let ui = w.global::<crate::UiState>();
             ui.set_editor_text(sql.clone());
+            ui.invoke_update_highlight(sql.clone());
             ui.invoke_run_query(sql);
         });
     }

--- a/app/src/ui/history.rs
+++ b/app/src/ui/history.rs
@@ -1,0 +1,131 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use slint::ComponentHandle;
+use tokio::sync::mpsc;
+
+use crate::app::command::Command;
+
+use super::{send_cmd, with_ui};
+
+pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc::Sender<Command>) {
+    let ui = window.global::<crate::UiState>();
+
+    // history-open: send SearchHistory with empty keyword to load recent 100 rows.
+    {
+        let tx = tx_cmd.clone(); // clone required: on_history_open closure
+        ui.on_history_open(move || {
+            send_cmd(
+                &tx,
+                Command::SearchHistory {
+                    keyword: String::new(),
+                    conn_id: None,
+                },
+            );
+        });
+    }
+
+    // history-search: re-query on keyword change, debounced 150ms.
+    {
+        let tx = tx_cmd.clone(); // clone required: on_history_search closure
+        let debounce: Rc<RefCell<Option<slint::Timer>>> = Rc::new(RefCell::new(None));
+        let ww = window.as_weak();
+        ui.on_history_search(move || {
+            let keyword = ww
+                .upgrade()
+                .map(|w| w.global::<crate::UiState>().get_history_query().to_string())
+                .unwrap_or_default();
+            *debounce.borrow_mut() = None; // drop previous timer (cancels it)
+            let tx = tx.clone(); // clone required: SingleShot timer closure
+            let timer = slint::Timer::default();
+            timer.start(
+                slint::TimerMode::SingleShot,
+                std::time::Duration::from_millis(150),
+                move || {
+                    send_cmd(
+                        &tx,
+                        Command::SearchHistory {
+                            keyword: keyword.clone(),
+                            conn_id: None,
+                        },
+                    );
+                },
+            );
+            *debounce.borrow_mut() = Some(timer);
+        });
+    }
+
+    // history-insert-sql: insert full SQL at the editor cursor position.
+    {
+        let ww = window.as_weak();
+        ui.on_history_insert_sql(move |sql, cursor_pos| {
+            with_ui(&ww, |ui| {
+                let current = ui.get_editor_text().to_string();
+                let pos = (cursor_pos as usize).min(current.len());
+                let new_text = format!("{}{}{}", &current[..pos], sql, &current[pos..]);
+                let new_cursor = (pos + sql.len()) as i32;
+                ui.set_editor_text(new_text.into());
+                ui.set_editor_cursor_target(new_cursor);
+                ui.set_show_history(false);
+            });
+        });
+    }
+
+    // history-execute-sql: replace editor text and execute immediately.
+    {
+        let ww = window.as_weak();
+        ui.on_history_execute_sql(move |sql| {
+            let Some(w) = ww.upgrade() else { return };
+            let ui = w.global::<crate::UiState>();
+            ui.set_editor_text(sql.clone());
+            ui.invoke_run_query(sql);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use wf_db::models::QueryExecution;
+
+    use super::super::event::history_rows_to_slint;
+
+    fn make_exec(sql: &str, duration_ms: u128, success: bool, ts: i64) -> QueryExecution {
+        QueryExecution {
+            id: 1,
+            sql: sql.to_string(),
+            duration_ms,
+            success,
+            error_message: None,
+            timestamp: ts,
+            connection_id: "c1".to_string(),
+        }
+    }
+
+    #[test]
+    fn history_rows_to_slint_should_format_timestamp_and_duration() {
+        let rows = vec![
+            make_exec("SELECT 1", 42, true, 1_700_000_000),
+            make_exec("SELECT 2", 1500, false, 1_700_000_060),
+        ];
+        let entries = history_rows_to_slint(&rows);
+
+        assert_eq!(entries[0].duration_text.as_str(), "42ms");
+        assert_eq!(entries[1].duration_text.as_str(), "1.5s");
+        assert!(entries[0].success);
+        assert!(!entries[1].success);
+        // timestamp should be non-empty (value depends on timezone, just check format)
+        assert!(entries[0].timestamp_text.len() >= 16);
+    }
+
+    #[test]
+    fn history_rows_to_slint_should_truncate_sql_preview_at_80_chars() {
+        let long_sql = "SELECT ".to_string() + &"x".repeat(100);
+        let rows = vec![make_exec(&long_sql, 10, true, 0)];
+        let entries = history_rows_to_slint(&rows);
+        assert!(entries[0].sql_preview.len() <= 80);
+    }
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -3,6 +3,7 @@ mod completion;
 mod connection;
 mod event;
 mod find_replace;
+mod history;
 mod metadata_search;
 mod palette;
 mod query;
@@ -650,6 +651,7 @@ impl UI {
         );
         appearance::register_language_callback(&window, tx_cmd.clone());
         find_replace::register_find_replace_callbacks(&window, find_history_svc);
+        history::register_history_callbacks(&window, tx_cmd.clone());
         snippet::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
         metadata_search::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
         palette::register_command_palette_callbacks(


### PR DESCRIPTION
## Summary

Implements the floating query history panel (Issue #66). Pressing Ctrl+Shift+H opens a 700px overlay showing the 100 most recent query executions with SQL preview, timestamp, and duration. Real-time keyword filtering calls `HistoryService::search` via the Command/Event channel with a 150ms debounce. Single-click inserts the selected SQL at the editor cursor; double-click executes it immediately.

## Changes

- `globals.slint`: add `HistoryEntry` struct (id, sql-preview, full-sql, timestamp-text, duration-text, success, connection-id)
- `history_panel.slint` (new): floating overlay component with header, search input, scrollable entry list, keyboard navigation (Up/Down/Enter/Esc), auto-scroll, custom scrollbar, and empty state
- `app.slint`: add `UiState` properties/callbacks for the history panel; add Ctrl+Shift+H shortcut; add `HistoryPanel` overlay instance
- `command.rs`: add `SearchHistory { keyword, conn_id }` variant and `variant_name` entry
- `event.rs` (app): add `HistoryLoaded(Vec<QueryExecution>)` variant
- `controller.rs`: add `Command::SearchHistory` dispatch arm; add `mod history`
- `controller/history.rs` (new): `handle_search_history` — calls `HistoryService::search`, sends `Event::HistoryLoaded`
- `ui/history.rs` (new): `register_history_callbacks` — wires `history-open`, `history-search` (150ms debounce via `Rc<RefCell<Option<Timer>>>`), `history-insert-sql`, `history-execute-sql`
- `ui/event.rs`: add `handle_history_loaded` named function; add `history_rows_to_slint` helper
- `ui/mod.rs`: add `mod history`; call `register_history_callbacks`
- `locales/en.yml`, `locales/ja.yml`: add `history.*` strings

## Related Issues

Closes #66

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes