### PR TITLE
feat(undo): add panel-scoped undo/redo (Ctrl+Z / Ctrl+Shift+Z)

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -84,6 +84,10 @@ pub enum Command {
         keyword: String,
         conn_id: Option<String>,
     },
+    /// Undo the last group action (create/rename/color/move/delete).
+    UndoGroupAction,
+    /// Redo the last undone group action.
+    RedoGroupAction,
 }
 
 impl Command {
@@ -109,6 +113,8 @@ impl Command {
             Self::SetGroupColor { .. } => "SetGroupColor",
             Self::SetGroupExpanded { .. } => "SetGroupExpanded",
             Self::SearchHistory { .. } => "SearchHistory",
+            Self::UndoGroupAction => "UndoGroupAction",
+            Self::RedoGroupAction => "RedoGroupAction",
         }
     }
 }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -16,6 +16,7 @@
 mod config;
 mod connection;
 mod group;
+mod group_undo;
 mod history;
 mod metadata;
 mod query;
@@ -31,7 +32,7 @@ use wf_db::service::DbService;
 use wf_history::service::HistoryService;
 
 use crate::{
-    app::{command::Command, event::Event, session::SessionManager},
+    app::{command::Command, event::Event, group_undo::GroupUndoStack, session::SessionManager},
     state::SharedState,
 };
 
@@ -55,6 +56,8 @@ pub struct AppController {
     pub(crate) config_dir: PathBuf,
     /// Encryption key for decrypting SSH credentials.
     pub(crate) enc_key: [u8; 32],
+    /// Per-session undo/redo stack for group mutations (create/rename/color/move/delete).
+    pub(crate) group_undo: std::sync::Mutex<GroupUndoStack>,
 }
 
 impl AppController {
@@ -93,6 +96,7 @@ impl AppController {
                 tx_event,
                 config_dir,
                 enc_key,
+                group_undo: std::sync::Mutex::new(GroupUndoStack::new()),
             },
             tx_cmd,
             rx_event,
@@ -152,6 +156,8 @@ impl AppController {
                 Command::SearchHistory { keyword, conn_id } => {
                     this.handle_search_history(keyword, conn_id).await
                 }
+                Command::UndoGroupAction => this.handle_undo_group_action().await,
+                Command::RedoGroupAction => this.handle_redo_group_action().await,
             }
         }
     }

--- a/app/src/app/controller/group.rs
+++ b/app/src/app/controller/group.rs
@@ -44,17 +44,14 @@ impl AppController {
 
     pub(super) async fn handle_rename_group(&self, id: String, name: String) {
         let groups = self.group_repo.all().await.unwrap_or_default();
-        let old_name = groups
-            .iter()
-            .find(|g| g.id == id)
-            .map(|g| g.name.clone())
-            .unwrap_or_default();
-        if let Some(mut g) = groups.iter().find(|g| g.id == id).cloned() {
-            g.name = name.clone();
-            if let Err(e) = self.group_repo.upsert(&g).await {
-                warn!(error = %e, "failed to rename group");
-                return;
-            }
+        let Some(mut g) = groups.into_iter().find(|g| g.id == id) else {
+            return;
+        };
+        let old_name = g.name.clone();
+        g.name = name.clone();
+        if let Err(e) = self.group_repo.upsert(&g).await {
+            warn!(error = %e, "failed to rename group");
+            return;
         }
         self.group_undo
             .lock()
@@ -133,16 +130,14 @@ impl AppController {
         group_id: Option<String>,
     ) {
         let connections = self.repo.all().await.unwrap_or_default();
-        let old_group_id = connections
-            .iter()
-            .find(|c| c.id == conn_id)
-            .and_then(|c| c.group_id.clone());
-        if let Some(mut cc) = connections.iter().find(|c| c.id == conn_id).cloned() {
-            cc.group_id = group_id.clone();
-            if let Err(e) = self.repo.upsert(&cc).await {
-                warn!(conn_id = %conn_id, error = %e, "failed to move connection to group");
-                return;
-            }
+        let Some(mut cc) = connections.into_iter().find(|c| c.id == conn_id) else {
+            return;
+        };
+        let old_group_id = cc.group_id.clone();
+        cc.group_id = group_id.clone();
+        if let Err(e) = self.repo.upsert(&cc).await {
+            warn!(conn_id = %conn_id, error = %e, "failed to move connection to group");
+            return;
         }
         self.group_undo
             .lock()
@@ -170,17 +165,14 @@ impl AppController {
 
     pub(super) async fn handle_set_group_color(&self, group_id: String, color: String) {
         let groups = self.group_repo.all().await.unwrap_or_default();
-        let old_color = groups
-            .iter()
-            .find(|g| g.id == group_id)
-            .map(|g| g.color.clone())
-            .unwrap_or_default();
-        if let Some(mut g) = groups.iter().find(|g| g.id == group_id).cloned() {
-            g.color = color.clone();
-            if let Err(e) = self.group_repo.upsert(&g).await {
-                warn!(error = %e, "failed to set group color");
-                return;
-            }
+        let Some(mut g) = groups.into_iter().find(|g| g.id == group_id) else {
+            return;
+        };
+        let old_color = g.color.clone();
+        g.color = color.clone();
+        if let Err(e) = self.group_repo.upsert(&g).await {
+            warn!(error = %e, "failed to set group color");
+            return;
         }
         self.group_undo
             .lock()

--- a/app/src/app/controller/group.rs
+++ b/app/src/app/controller/group.rs
@@ -2,7 +2,7 @@ use tracing::warn;
 use uuid::Uuid;
 use wf_config::models::GroupConfig;
 
-use crate::app::event::Event;
+use crate::app::{event::Event, group_undo::GroupOp};
 
 use super::AppController;
 
@@ -19,6 +19,17 @@ impl AppController {
             warn!(error = %e, "failed to create group");
             return;
         }
+        self.group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(
+                GroupOp::DeleteGroup {
+                    id: group.id.clone(),
+                },
+                GroupOp::CreateGroup {
+                    group: group.clone(),
+                },
+            );
         let groups = self.group_repo.all().await.unwrap_or_default();
         let connections = self.repo.all().await.unwrap_or_default();
         let _ = self
@@ -33,13 +44,31 @@ impl AppController {
 
     pub(super) async fn handle_rename_group(&self, id: String, name: String) {
         let groups = self.group_repo.all().await.unwrap_or_default();
+        let old_name = groups
+            .iter()
+            .find(|g| g.id == id)
+            .map(|g| g.name.clone())
+            .unwrap_or_default();
         if let Some(mut g) = groups.iter().find(|g| g.id == id).cloned() {
-            g.name = name;
+            g.name = name.clone();
             if let Err(e) = self.group_repo.upsert(&g).await {
                 warn!(error = %e, "failed to rename group");
                 return;
             }
         }
+        self.group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(
+                GroupOp::RenameGroup {
+                    id: id.clone(),
+                    name: old_name,
+                },
+                GroupOp::RenameGroup {
+                    id: id.clone(),
+                    name: name.clone(),
+                },
+            );
         let groups = self.group_repo.all().await.unwrap_or_default();
         let connections = self.repo.all().await.unwrap_or_default();
         let _ = self
@@ -52,8 +81,17 @@ impl AppController {
     }
 
     pub(super) async fn handle_delete_group(&self, id: String) {
-        // Ungroup all connections that belonged to this group.
+        // Capture state before deletion for undo purposes.
+        let all_groups = self.group_repo.all().await.unwrap_or_default();
+        let group_config = all_groups.iter().find(|g| g.id == id).cloned();
         let connections = self.repo.all().await.unwrap_or_default();
+        let member_conn_ids: Vec<String> = connections
+            .iter()
+            .filter(|c| c.group_id.as_deref() == Some(&id))
+            .map(|c| c.id.clone())
+            .collect();
+
+        // Ungroup all connections that belonged to this group.
         for mut cc in connections {
             if cc.group_id.as_deref() == Some(&id) {
                 cc.group_id = None;
@@ -65,6 +103,18 @@ impl AppController {
         if let Err(e) = self.group_repo.delete(&id).await {
             warn!(error = %e, "failed to delete group");
             return;
+        }
+        if let Some(gc) = group_config {
+            self.group_undo
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(
+                    GroupOp::RestoreGroup {
+                        group: gc,
+                        member_conn_ids,
+                    },
+                    GroupOp::DeleteGroup { id: id.clone() },
+                );
         }
         let groups = self.group_repo.all().await.unwrap_or_default();
         let connections = self.repo.all().await.unwrap_or_default();
@@ -83,13 +133,30 @@ impl AppController {
         group_id: Option<String>,
     ) {
         let connections = self.repo.all().await.unwrap_or_default();
+        let old_group_id = connections
+            .iter()
+            .find(|c| c.id == conn_id)
+            .and_then(|c| c.group_id.clone());
         if let Some(mut cc) = connections.iter().find(|c| c.id == conn_id).cloned() {
-            cc.group_id = group_id;
+            cc.group_id = group_id.clone();
             if let Err(e) = self.repo.upsert(&cc).await {
                 warn!(conn_id = %conn_id, error = %e, "failed to move connection to group");
                 return;
             }
         }
+        self.group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(
+                GroupOp::MoveConnectionToGroup {
+                    conn_id: conn_id.clone(),
+                    group_id: old_group_id,
+                },
+                GroupOp::MoveConnectionToGroup {
+                    conn_id: conn_id.clone(),
+                    group_id: group_id.clone(),
+                },
+            );
         let groups = self.group_repo.all().await.unwrap_or_default();
         let connections = self.repo.all().await.unwrap_or_default();
         let _ = self
@@ -103,13 +170,31 @@ impl AppController {
 
     pub(super) async fn handle_set_group_color(&self, group_id: String, color: String) {
         let groups = self.group_repo.all().await.unwrap_or_default();
+        let old_color = groups
+            .iter()
+            .find(|g| g.id == group_id)
+            .map(|g| g.color.clone())
+            .unwrap_or_default();
         if let Some(mut g) = groups.iter().find(|g| g.id == group_id).cloned() {
-            g.color = color;
+            g.color = color.clone();
             if let Err(e) = self.group_repo.upsert(&g).await {
                 warn!(error = %e, "failed to set group color");
                 return;
             }
         }
+        self.group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(
+                GroupOp::SetGroupColor {
+                    id: group_id.clone(),
+                    color: old_color,
+                },
+                GroupOp::SetGroupColor {
+                    id: group_id.clone(),
+                    color: color.clone(),
+                },
+            );
         let groups = self.group_repo.all().await.unwrap_or_default();
         let connections = self.repo.all().await.unwrap_or_default();
         let _ = self

--- a/app/src/app/controller/group_undo.rs
+++ b/app/src/app/controller/group_undo.rs
@@ -1,0 +1,114 @@
+use tracing::warn;
+
+use crate::app::{event::Event, group_undo::GroupOp};
+
+use super::AppController;
+
+impl AppController {
+    pub(super) async fn handle_undo_group_action(&self) {
+        let op = self
+            .group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .pop_undo();
+        if let Some(op) = op {
+            self.execute_group_op(op).await;
+        }
+    }
+
+    pub(super) async fn handle_redo_group_action(&self) {
+        let op = self
+            .group_undo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .pop_redo();
+        if let Some(op) = op {
+            self.execute_group_op(op).await;
+        }
+    }
+
+    async fn execute_group_op(&self, op: GroupOp) {
+        match op {
+            GroupOp::CreateGroup { group } => {
+                if let Err(e) = self.group_repo.upsert(&group).await {
+                    warn!(error = %e, "execute_group_op: CreateGroup failed");
+                    return;
+                }
+            }
+            GroupOp::DeleteGroup { id } => {
+                // Ungroup connections before deleting.
+                let connections = self.repo.all().await.unwrap_or_default();
+                for mut c in connections {
+                    if c.group_id.as_deref() == Some(&id) {
+                        c.group_id = None;
+                        if let Err(e) = self.repo.upsert(&c).await {
+                            warn!(error = %e, "execute_group_op: ungroup connection failed");
+                        }
+                    }
+                }
+                if let Err(e) = self.group_repo.delete(&id).await {
+                    warn!(error = %e, "execute_group_op: DeleteGroup failed");
+                    return;
+                }
+            }
+            GroupOp::RenameGroup { id, name } => {
+                let groups = self.group_repo.all().await.unwrap_or_default();
+                if let Some(mut g) = groups.into_iter().find(|g| g.id == id) {
+                    g.name = name;
+                    if let Err(e) = self.group_repo.upsert(&g).await {
+                        warn!(error = %e, "execute_group_op: RenameGroup failed");
+                        return;
+                    }
+                }
+            }
+            GroupOp::SetGroupColor { id, color } => {
+                let groups = self.group_repo.all().await.unwrap_or_default();
+                if let Some(mut g) = groups.into_iter().find(|g| g.id == id) {
+                    g.color = color;
+                    if let Err(e) = self.group_repo.upsert(&g).await {
+                        warn!(error = %e, "execute_group_op: SetGroupColor failed");
+                        return;
+                    }
+                }
+            }
+            GroupOp::MoveConnectionToGroup { conn_id, group_id } => {
+                let connections = self.repo.all().await.unwrap_or_default();
+                if let Some(mut c) = connections.into_iter().find(|c| c.id == conn_id) {
+                    c.group_id = group_id;
+                    if let Err(e) = self.repo.upsert(&c).await {
+                        warn!(error = %e, "execute_group_op: MoveConnectionToGroup failed");
+                        return;
+                    }
+                }
+            }
+            GroupOp::RestoreGroup {
+                group,
+                member_conn_ids,
+            } => {
+                if let Err(e) = self.group_repo.upsert(&group).await {
+                    warn!(error = %e, "execute_group_op: RestoreGroup (upsert) failed");
+                    return;
+                }
+                let connections = self.repo.all().await.unwrap_or_default();
+                for id in member_conn_ids {
+                    if let Some(mut c) = connections.iter().find(|c| c.id == id).cloned() {
+                        c.group_id = Some(group.id.clone());
+                        if let Err(e) = self.repo.upsert(&c).await {
+                            warn!(error = %e, "execute_group_op: RestoreGroup (reassign) failed");
+                        }
+                    }
+                }
+            }
+        }
+
+        let groups = self.group_repo.all().await.unwrap_or_default();
+        let connections = self.repo.all().await.unwrap_or_default();
+        let _ = self
+            .tx_event
+            .send(Event::GroupsUpdated {
+                groups,
+                connections,
+            })
+            .await;
+    }
+}

--- a/app/src/app/group_undo.rs
+++ b/app/src/app/group_undo.rs
@@ -32,7 +32,6 @@ pub enum GroupOp {
 const ACTION_UNDO_MAX: usize = 50;
 
 pub struct GroupUndoStack {
-    /// Each entry: `(reverse_op, forward_op)` — reverse undoes the action, forward re-applies it.
     undo: Vec<(GroupOp, GroupOp)>,
     redo: Vec<(GroupOp, GroupOp)>,
 }
@@ -73,5 +72,129 @@ impl GroupUndoStack {
             self.undo.remove(0);
         }
         Some(forward)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_group(id: &str) -> GroupConfig {
+        GroupConfig {
+            id: id.to_string(),
+            name: id.to_string(),
+            color: "#6c7086".to_string(),
+            expanded: true,
+        }
+    }
+
+    #[test]
+    fn group_undo_stack_should_pop_undo_and_return_reverse_op() {
+        let mut s = GroupUndoStack::new();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g1".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g1"),
+            },
+        );
+        let op = s.pop_undo().expect("should return op");
+        assert!(matches!(op, GroupOp::DeleteGroup { ref id } if id == "g1"));
+    }
+
+    #[test]
+    fn group_undo_stack_should_populate_redo_after_undo() {
+        let mut s = GroupUndoStack::new();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g1".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g1"),
+            },
+        );
+        s.pop_undo();
+        assert_eq!(s.undo.len(), 0);
+        assert_eq!(s.redo.len(), 1);
+    }
+
+    #[test]
+    fn group_undo_stack_should_pop_redo_and_return_forward_op() {
+        let mut s = GroupUndoStack::new();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g1".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g1"),
+            },
+        );
+        s.pop_undo();
+        let op = s.pop_redo().expect("should return forward op");
+        assert!(matches!(op, GroupOp::CreateGroup { .. }));
+    }
+
+    #[test]
+    fn group_undo_stack_should_repopulate_undo_after_redo() {
+        let mut s = GroupUndoStack::new();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g1".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g1"),
+            },
+        );
+        s.pop_undo();
+        s.pop_redo();
+        assert_eq!(s.undo.len(), 1);
+        assert_eq!(s.redo.len(), 0);
+    }
+
+    #[test]
+    fn group_undo_stack_should_clear_redo_on_new_push() {
+        let mut s = GroupUndoStack::new();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g1".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g1"),
+            },
+        );
+        s.pop_undo();
+        s.push(
+            GroupOp::DeleteGroup {
+                id: "g2".to_string(),
+            },
+            GroupOp::CreateGroup {
+                group: dummy_group("g2"),
+            },
+        );
+        assert_eq!(s.redo.len(), 0);
+    }
+
+    #[test]
+    fn group_undo_stack_should_return_none_when_empty() {
+        let mut s = GroupUndoStack::new();
+        assert!(s.pop_undo().is_none());
+        assert!(s.pop_redo().is_none());
+    }
+
+    #[test]
+    fn group_undo_stack_should_cap_undo_at_max_size() {
+        let mut s = GroupUndoStack::new();
+        for i in 0..=ACTION_UNDO_MAX {
+            s.push(
+                GroupOp::DeleteGroup {
+                    id: format!("g{i}"),
+                },
+                GroupOp::CreateGroup {
+                    group: dummy_group(&format!("g{i}")),
+                },
+            );
+        }
+        assert_eq!(s.undo.len(), ACTION_UNDO_MAX);
     }
 }

--- a/app/src/app/group_undo.rs
+++ b/app/src/app/group_undo.rs
@@ -1,0 +1,77 @@
+use wf_config::models::GroupConfig;
+
+/// A reversible group operation.
+/// Every op can serve as both an undo and a redo entry.
+#[derive(Clone, Debug)]
+pub enum GroupOp {
+    CreateGroup {
+        group: GroupConfig,
+    },
+    DeleteGroup {
+        id: String,
+    },
+    RenameGroup {
+        id: String,
+        name: String,
+    },
+    SetGroupColor {
+        id: String,
+        color: String,
+    },
+    MoveConnectionToGroup {
+        conn_id: String,
+        group_id: Option<String>,
+    },
+    /// Recreate a deleted group and reassign its former connections.
+    RestoreGroup {
+        group: GroupConfig,
+        member_conn_ids: Vec<String>,
+    },
+}
+
+const ACTION_UNDO_MAX: usize = 50;
+
+pub struct GroupUndoStack {
+    /// Each entry: `(reverse_op, forward_op)` — reverse undoes the action, forward re-applies it.
+    undo: Vec<(GroupOp, GroupOp)>,
+    redo: Vec<(GroupOp, GroupOp)>,
+}
+
+impl GroupUndoStack {
+    pub fn new() -> Self {
+        Self {
+            undo: vec![],
+            redo: vec![],
+        }
+    }
+
+    /// Record an action. `reverse` undoes it; `forward` re-applies it.
+    /// Branching: discards the redo stack on every new action.
+    pub fn push(&mut self, reverse: GroupOp, forward: GroupOp) {
+        self.undo.push((reverse, forward));
+        if self.undo.len() > ACTION_UNDO_MAX {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+    }
+
+    /// Returns the op to execute for undo, or `None` if the stack is empty.
+    pub fn pop_undo(&mut self) -> Option<GroupOp> {
+        let (reverse, forward) = self.undo.pop()?;
+        self.redo.push((forward, reverse.clone()));
+        if self.redo.len() > ACTION_UNDO_MAX {
+            self.redo.remove(0);
+        }
+        Some(reverse)
+    }
+
+    /// Returns the op to execute for redo, or `None` if the stack is empty.
+    pub fn pop_redo(&mut self) -> Option<GroupOp> {
+        let (forward, reverse) = self.redo.pop()?;
+        self.undo.push((reverse, forward.clone()));
+        if self.undo.len() > ACTION_UNDO_MAX {
+            self.undo.remove(0);
+        }
+        Some(forward)
+    }
+}

--- a/app/src/app/mod.rs
+++ b/app/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod command;
 pub mod command_registry;
 pub mod controller;
 pub mod event;
+pub mod group_undo;
 pub mod localized_message;
 pub mod session;
 

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -367,6 +367,9 @@ export global UiState {
     in-out property <int>        active-tab-index:   0;
     /// true = active tab is a SQL Editor tab; false = Table View tab.
     in-out property <bool>       active-tab-kind-sql: true;
+    /// UUID of the currently active tab; set by Rust on tab switch / new / close.
+    /// Used by the undo system to scope snapshots to the correct per-tab stack.
+    in-out property <string>     editor-active-tab-id: "";
     callback new-tab();
     callback close-tab(int);
     callback switch-tab(int);
@@ -421,6 +424,20 @@ export global UiState {
     callback history-insert-sql(string, int);
     /// Replace editor text with SQL and execute immediately.
     callback history-execute-sql(string);
+
+    // ── Text undo / redo ─────────────────────────────────────────────────────
+    /// Fired by the editor when the user presses Ctrl+Z.
+    callback editor-undo();
+    /// Fired by the editor when the user presses Ctrl+Shift+Z.
+    callback editor-redo();
+    /// Fired on every user text edit; Rust uses this to drive the debounce snapshot.
+    callback text-changed(string);
+
+    // ── Sidebar action undo / redo ────────────────────────────────────────────
+    /// Fired when Ctrl+Z is pressed while the sidebar has focus.
+    callback sidebar-undo();
+    /// Fired when Ctrl+Shift+Z is pressed while the sidebar has focus.
+    callback sidebar-redo();
 }
 
 export component AppWindow inherits Window {
@@ -718,6 +735,19 @@ export component AppWindow inherits Window {
                 } else {
                     EventResult.reject
                 }
+            } else if (event.modifiers.control
+                    && !event.modifiers.alt
+                    && (event.text == "z" || event.text == "Z")) {
+                // Sidebar undo/redo — editor handles its own via capture-key-pressed
+                // and never lets the bubble reach here when focused.
+                if (root.focused-pane == 0) {
+                    if (event.modifiers.shift) {
+                        UiState.sidebar-redo();
+                    } else {
+                        UiState.sidebar-undo();
+                    }
+                }
+                EventResult.accept
             } else {
                 EventResult.reject
             }
@@ -843,6 +873,7 @@ export component AppWindow inherits Window {
                 text-edited(sql, pos) => {
                     UiState.fetch-completion(sql, pos);
                     UiState.update-highlight(sql);
+                    UiState.text-changed(sql);
                 }
                 trigger-completion(sql, pos) => { UiState.trigger-completion(sql, pos); }
                 format-sql => { UiState.format-sql(); }
@@ -862,6 +893,8 @@ export component AppWindow inherits Window {
                 }
                 tab-width: UiState.tab-width;
                 tab-key-pressed(cursor) => { UiState.tab-key-pressed(cursor); }
+                editor-undo => { UiState.editor-undo(); }
+                editor-redo => { UiState.editor-redo(); }
                 open-snippet-save(a, c) => { UiState.open-snippet-save(a, c); }
                 focus-sidebar => { root.focused-pane = 0; sidebar-inst.grab-focus(); }
                 focus-result  => {

--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -9,6 +9,8 @@ use wf_history::session::SessionService;
 
 use crate::app::command::{Command, ConfigUpdate};
 
+use super::tabs_state::TabsState;
+use super::undo::TextUndoState;
 use super::{send_cmd, tabs_state, with_ui};
 
 /// Tokenize `sql` and return Slint-typed `HighlightSpan` values for rendering.
@@ -172,6 +174,8 @@ pub(super) fn register_language_callback(window: &crate::AppWindow, tx_cmd: mpsc
 pub(super) fn register_editor_prefs_callbacks(
     window: &crate::AppWindow,
     tx_cmd: mpsc::Sender<Command>,
+    tabs_state: Rc<RefCell<TabsState>>,
+    undo_state: Rc<TextUndoState>,
 ) {
     let ui = window.global::<crate::UiState>();
 
@@ -185,6 +189,7 @@ pub(super) fn register_editor_prefs_callbacks(
         };
         let ui = window.global::<crate::UiState>();
         let text = ui.get_editor_text().to_string();
+        let tab_id = ui.get_editor_active_tab_id().to_string();
         let tab_width = (ui.get_tab_width() as usize).max(1);
         let cursor = cursor as usize;
 
@@ -192,11 +197,17 @@ pub(super) fn register_editor_prefs_callbacks(
             return;
         }
 
+        undo_state.flush_before_programmatic_change(&mut tabs_state.borrow_mut(), &tab_id);
+        tabs_state
+            .borrow_mut()
+            .push_undo_snapshot(&tab_id, text.clone());
+
         let spaces = " ".repeat(tab_width);
         let mut new_text = text;
         new_text.insert_str(cursor, &spaces);
         let new_cursor = (cursor + tab_width) as i32;
 
+        *undo_state.last_known.borrow_mut() = new_text.clone();
         let shared: slint::SharedString = new_text.into();
         ui.set_editor_text(shared.clone());
         ui.set_editor_cursor_target(new_cursor);

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -116,6 +116,11 @@ export component Editor inherits Rectangle {
     in-out property <int> find-sel-start: -1;
     in-out property <int> find-sel-end:   -1;
 
+    /// Fired when the user presses Ctrl+Z to undo text.
+    callback editor-undo();
+    /// Fired when the user presses Ctrl+Shift+Z to redo text.
+    callback editor-redo();
+
     /// Syntax highlight spans; updated by Rust on every text edit.
     in property <[HighlightSpan]> highlight-spans: [];
 
@@ -615,6 +620,15 @@ export component Editor inherits Rectangle {
                         && !event.modifiers.control
                         && !event.modifiers.alt) {
                     root.tab-key-pressed(inner-input.cursor-position-byte-offset);
+                    EventResult.accept
+                } else if (event.modifiers.control
+                        && !event.modifiers.alt
+                        && (event.text == "z" || event.text == "Z")) {
+                    if (event.modifiers.shift) {
+                        root.editor-redo();
+                    } else {
+                        root.editor-undo();
+                    }
                     EventResult.accept
                 } else {
                     EventResult.reject

--- a/app/src/ui/history.rs
+++ b/app/src/ui/history.rs
@@ -6,9 +6,16 @@ use tokio::sync::mpsc;
 
 use crate::app::command::Command;
 
+use super::tabs_state::TabsState;
+use super::undo::TextUndoState;
 use super::{send_cmd, with_ui};
 
-pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc::Sender<Command>) {
+pub(super) fn register_history_callbacks(
+    window: &crate::AppWindow,
+    tx_cmd: mpsc::Sender<Command>,
+    tabs_state: Rc<RefCell<TabsState>>,
+    undo_state: Rc<TextUndoState>,
+) {
     let ui = window.global::<crate::UiState>();
 
     // history-open: send SearchHistory with empty keyword to load recent 100 rows.
@@ -58,12 +65,20 @@ pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc
     // history-insert-sql: insert full SQL at the editor cursor position.
     {
         let ww = window.as_weak();
+        let tabs_state = Rc::clone(&tabs_state); // clone required: on_history_insert_sql closure
+        let undo_state = Rc::clone(&undo_state); // clone required: on_history_insert_sql closure
         ui.on_history_insert_sql(move |sql, cursor_pos| {
             with_ui(&ww, |ui| {
                 let current = ui.get_editor_text().to_string();
+                let tab_id = ui.get_editor_active_tab_id().to_string();
+                undo_state.flush_before_programmatic_change(&mut tabs_state.borrow_mut(), &tab_id);
+                tabs_state
+                    .borrow_mut()
+                    .push_undo_snapshot(&tab_id, current.clone());
                 let pos = (cursor_pos as usize).min(current.len());
                 let new_text = format!("{}{}{}", &current[..pos], sql, &current[pos..]);
                 let new_cursor = (pos + sql.len()) as i32;
+                *undo_state.last_known.borrow_mut() = new_text.clone();
                 ui.set_editor_text(new_text.clone().into());
                 ui.invoke_update_highlight(new_text.into());
                 ui.set_editor_cursor_target(new_cursor);
@@ -75,9 +90,16 @@ pub(super) fn register_history_callbacks(window: &crate::AppWindow, tx_cmd: mpsc
     // history-execute-sql: replace editor text and execute immediately.
     {
         let ww = window.as_weak();
+        let tabs_state = Rc::clone(&tabs_state); // clone required: on_history_execute_sql closure
+        let undo_state = Rc::clone(&undo_state); // clone required: on_history_execute_sql closure
         ui.on_history_execute_sql(move |sql| {
             let Some(w) = ww.upgrade() else { return };
             let ui = w.global::<crate::UiState>();
+            let current = ui.get_editor_text().to_string();
+            let tab_id = ui.get_editor_active_tab_id().to_string();
+            undo_state.flush_before_programmatic_change(&mut tabs_state.borrow_mut(), &tab_id);
+            tabs_state.borrow_mut().push_undo_snapshot(&tab_id, current);
+            *undo_state.last_known.borrow_mut() = sql.to_string();
             ui.set_editor_text(sql.clone());
             ui.invoke_update_highlight(sql.clone());
             ui.invoke_run_query(sql);

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -10,6 +10,7 @@ mod query;
 mod snippet;
 mod tabs;
 mod tabs_state;
+mod undo;
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -561,7 +562,21 @@ impl UI {
         window
             .global::<crate::UiState>()
             .set_highlight_spans(hl_model.clone().into());
-        query::register_formatter_callback(&window, hl_model.clone());
+        // Create the shared undo state before registering any callbacks that touch it.
+        let initial_editor_text = {
+            let ts = tabs_state.borrow();
+            match ts.active_tab().map(|t| &t.kind) {
+                Some(tabs_state::TabKind::SqlEditor { query_text }) => query_text.clone(),
+                _ => String::new(),
+            }
+        };
+        let undo_state = undo::TextUndoState::new(initial_editor_text);
+        query::register_formatter_callback(
+            &window,
+            hl_model.clone(),
+            Rc::clone(&tabs_state),
+            Rc::clone(&undo_state),
+        );
         query::register_export_callbacks(&window, Arc::clone(&original_data), state.clone());
         appearance::register_theme_callback(&window, state.clone(), tx_cmd.clone());
         appearance::register_reduce_motion_callback(&window, tx_cmd.clone());
@@ -573,6 +588,7 @@ impl UI {
             Rc::clone(&tabs_state),
             Arc::clone(&sidebar_state),
             hl_model.clone(),
+            Rc::clone(&undo_state),
         );
         // Set initial page size and theme on the Slint window from shared state.
         let ui_global = window.global::<crate::UiState>();
@@ -606,6 +622,9 @@ impl UI {
             let slint_tabs = tabs::tabs_to_slint(&ts.tabs);
             ui_global.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
             ui_global.set_active_tab_index(ts.active_index as i32);
+            if let Some(tab) = ts.active_tab() {
+                ui_global.set_editor_active_tab_id(tab.id.clone().into());
+            }
             match ts.active_tab().map(|t| t.kind.clone()) {
                 Some(tabs_state::TabKind::SqlEditor { query_text }) => {
                     ui_global.set_editor_text(query_text.into());
@@ -651,8 +670,18 @@ impl UI {
         );
         appearance::register_language_callback(&window, tx_cmd.clone());
         find_replace::register_find_replace_callbacks(&window, find_history_svc);
-        history::register_history_callbacks(&window, tx_cmd.clone());
-        snippet::register_snippet_callbacks(&window, Arc::clone(&snippet_repo));
+        history::register_history_callbacks(
+            &window,
+            tx_cmd.clone(),
+            Rc::clone(&tabs_state),
+            Rc::clone(&undo_state),
+        );
+        snippet::register_snippet_callbacks(
+            &window,
+            Arc::clone(&snippet_repo),
+            Rc::clone(&tabs_state),
+            Rc::clone(&undo_state),
+        );
         metadata_search::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
         palette::register_command_palette_callbacks(
             &window,
@@ -660,7 +689,12 @@ impl UI {
             tx_cmd.clone(),
             enc_key,
         );
-        appearance::register_editor_prefs_callbacks(&window, tx_cmd.clone());
+        appearance::register_editor_prefs_callbacks(
+            &window,
+            tx_cmd.clone(),
+            Rc::clone(&tabs_state),
+            Rc::clone(&undo_state),
+        );
         appearance::register_highlight_callbacks(&window, hl_model.clone());
 
         // Highlight the editor text that was already set from session / tab restore.
@@ -689,6 +723,23 @@ impl UI {
                 .unwrap_or((0.0, 100.0));
             ui_global.set_snippet_bar_x(bx);
             ui_global.set_snippet_bar_y(by);
+        }
+
+        // Register text undo/redo callbacks (debounce snapshots + Ctrl+Z/Ctrl+Shift+Z).
+        undo::register_undo_callbacks(&window, Rc::clone(&tabs_state), Rc::clone(&undo_state));
+
+        // Register sidebar undo/redo — routed via Command channel to the controller.
+        {
+            let tx = tx_cmd.clone(); // clone required: on_sidebar_undo closure
+            window.global::<crate::UiState>().on_sidebar_undo(move || {
+                send_cmd(&tx, Command::UndoGroupAction);
+            });
+        }
+        {
+            let tx = tx_cmd.clone(); // clone required: on_sidebar_redo closure
+            window.global::<crate::UiState>().on_sidebar_redo(move || {
+                send_cmd(&tx, Command::RedoGroupAction);
+            });
         }
 
         event::spawn_event_handler(

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -8,6 +9,8 @@ use crate::app::command::{Command, ConfigUpdate};
 use crate::state::SharedState;
 
 use super::appearance::{apply_highlight_spans, compute_highlight_spans};
+use super::tabs_state::TabsState;
+use super::undo::TextUndoState;
 use super::{
     DEFAULT_COLUMN_WIDTH, OriginalQueryData, SharedOriginalData, check_safe_dml, send_cmd,
     set_status, with_ui,
@@ -222,15 +225,23 @@ pub(super) fn register_editor_callbacks(window: &crate::AppWindow, tx_cmd: mpsc:
 pub(super) fn register_formatter_callback(
     window: &crate::AppWindow,
     hl_model: Rc<slint::VecModel<crate::HighlightSpan>>,
+    tabs_state: Rc<RefCell<TabsState>>,
+    undo_state: Rc<TextUndoState>,
 ) {
     let ui = window.global::<crate::UiState>();
     let window_weak = window.as_weak(); // clone required: on_format_sql closure
     ui.on_format_sql(move || {
         with_ui(&window_weak, |ui| {
             let text = ui.get_editor_text().to_string();
+            let tab_id = ui.get_editor_active_tab_id().to_string();
+            undo_state.flush_before_programmatic_change(&mut tabs_state.borrow_mut(), &tab_id);
+            tabs_state
+                .borrow_mut()
+                .push_undo_snapshot(&tab_id, text.clone());
             let formatted = wf_query::formatter::format_sql(&text);
             tracing::debug!(input = %text, output = %formatted, "on_format_sql called");
             let spans = compute_highlight_spans(&formatted);
+            *undo_state.last_known.borrow_mut() = formatted.clone();
             ui.set_editor_text(formatted.into());
             apply_highlight_spans(&hl_model, spans);
         });

--- a/app/src/ui/snippet.rs
+++ b/app/src/ui/snippet.rs
@@ -1,9 +1,12 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use slint::ComponentHandle;
 use wf_config::snippet::SnippetRepository;
 
+use super::tabs_state::TabsState;
+use super::undo::TextUndoState;
 use super::with_ui;
 
 pub(super) fn snippet_to_slint(b: wf_config::snippet::SnippetEntry) -> crate::SnippetEntry {
@@ -33,6 +36,8 @@ pub(super) async fn do_refresh_snippets(
 pub(super) fn register_snippet_callbacks(
     window: &crate::AppWindow,
     snippet_repo: Arc<SnippetRepository>,
+    tabs_state: Rc<RefCell<TabsState>>,
+    undo_state: Rc<TextUndoState>,
 ) {
     let ui = window.global::<crate::UiState>();
 
@@ -165,12 +170,20 @@ pub(super) fn register_snippet_callbacks(
     // load-snippet-sql: insert SQL at editor cursor position.
     {
         let ww = window.as_weak();
+        let tabs_state = Rc::clone(&tabs_state); // clone required: on_load_snippet_sql closure
+        let undo_state = Rc::clone(&undo_state); // clone required: on_load_snippet_sql closure
         ui.on_load_snippet_sql(move |sql, cursor_pos| {
             with_ui(&ww, |ui| {
                 let current = ui.get_editor_text().to_string();
+                let tab_id = ui.get_editor_active_tab_id().to_string();
+                undo_state.flush_before_programmatic_change(&mut tabs_state.borrow_mut(), &tab_id);
+                tabs_state
+                    .borrow_mut()
+                    .push_undo_snapshot(&tab_id, current.clone());
                 let pos = (cursor_pos as usize).min(current.len());
                 let new_text = format!("{}{}{}", &current[..pos], sql, &current[pos..]);
                 let new_cursor = (pos + sql.len()) as i32;
+                *undo_state.last_known.borrow_mut() = new_text.clone();
                 ui.set_editor_text(new_text.into());
                 ui.set_editor_cursor_target(new_cursor);
             });

--- a/app/src/ui/tabs.rs
+++ b/app/src/ui/tabs.rs
@@ -8,6 +8,7 @@ use tokio::sync::mpsc;
 use crate::app::command::Command;
 
 use super::appearance::{apply_highlight_spans, compute_highlight_spans};
+use super::undo::TextUndoState;
 use super::{SidebarUiState, send_cmd, tabs_state, with_sidebar, with_ui};
 
 pub(super) fn tabs_to_slint(tabs: &[tabs_state::TabEntry]) -> Vec<crate::TabEntry> {
@@ -39,6 +40,7 @@ pub(super) fn register_tab_callbacks(
     tabs_state: Rc<RefCell<tabs_state::TabsState>>,
     sidebar_state: Arc<Mutex<SidebarUiState>>,
     hl_model: Rc<slint::VecModel<crate::HighlightSpan>>,
+    undo_state: Rc<TextUndoState>,
 ) {
     let ui = window.global::<crate::UiState>();
 
@@ -46,6 +48,7 @@ pub(super) fn register_tab_callbacks(
     {
         let window_weak = window.as_weak();
         let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
+        let undo_state = Rc::clone(&undo_state); // clone required: on_new_tab closure
         ui.on_new_tab(move || {
             let current_text = window_weak
                 .upgrade()
@@ -55,18 +58,25 @@ pub(super) fn register_tab_callbacks(
                 .upgrade()
                 .map(|w| w.global::<crate::UiState>().get_tv_sub_tab() as usize)
                 .unwrap_or(0);
-            let (slint_tabs, active_idx) = {
+            let (slint_tabs, active_idx, new_tab_id) = {
                 let mut ts = tabs_state.borrow_mut();
                 ts.save_current_text(&current_text);
                 ts.save_tv_sub_tab(current_sub_tab);
-                ts.add_sql_editor();
-                (tabs_to_slint(&ts.tabs), ts.active_index as i32)
+                let (id, _) = ts.add_sql_editor();
+                let slint_tabs = tabs_to_slint(&ts.tabs);
+                let active_idx = ts.active_index as i32;
+                (slint_tabs, active_idx, id)
             };
+            // Reset undo debounce state when switching to a fresh tab.
+            *undo_state.debounce.borrow_mut() = None;
+            *undo_state.burst_start.borrow_mut() = None;
+            *undo_state.last_known.borrow_mut() = String::new();
             with_ui(&window_weak, |ui| {
                 ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
                 ui.set_active_tab_index(active_idx);
                 ui.set_active_tab_kind_sql(true);
                 ui.set_editor_text("".into());
+                ui.set_editor_active_tab_id(new_tab_id.into());
             });
         });
     }
@@ -77,6 +87,7 @@ pub(super) fn register_tab_callbacks(
         let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
         let sidebar_state = Arc::clone(&sidebar_state); // clone required: callback closure needs owned sidebar_state
         let hl_model = Rc::clone(&hl_model); // clone required: on_switch_tab closure
+        let undo_state = Rc::clone(&undo_state); // clone required: on_switch_tab closure
         ui.on_switch_tab(move |i| {
             let i = i as usize;
             let current_text = window_weak
@@ -87,17 +98,28 @@ pub(super) fn register_tab_callbacks(
                 .upgrade()
                 .map(|w| w.global::<crate::UiState>().get_tv_sub_tab() as usize)
                 .unwrap_or(0);
-            let (slint_tabs, active_idx, kind_sql, editor_text, tv_name, tv_cols, tv_sub_tab) = {
+            let (
+                slint_tabs,
+                active_idx,
+                tab_id,
+                kind_sql,
+                editor_text,
+                tv_name,
+                tv_cols,
+                tv_sub_tab,
+            ) = {
                 let mut ts = tabs_state.borrow_mut();
                 ts.save_current_text(&current_text);
                 ts.save_tv_sub_tab(current_sub_tab);
                 ts.set_active(i);
                 let slint_tabs = tabs_to_slint(&ts.tabs);
                 let active_idx = ts.active_index as i32;
+                let tab_id = ts.active_tab().map(|t| t.id.clone()).unwrap_or_default();
                 match ts.active_tab().map(|t| t.kind.clone()) {
                     Some(tabs_state::TabKind::SqlEditor { query_text }) => (
                         slint_tabs,
                         active_idx,
+                        tab_id,
                         true,
                         query_text,
                         String::new(),
@@ -124,6 +146,7 @@ pub(super) fn register_tab_callbacks(
                         (
                             slint_tabs,
                             active_idx,
+                            tab_id,
                             false,
                             String::new(),
                             table_name,
@@ -134,6 +157,7 @@ pub(super) fn register_tab_callbacks(
                     None => (
                         slint_tabs,
                         active_idx,
+                        tab_id,
                         true,
                         String::new(),
                         String::new(),
@@ -142,6 +166,11 @@ pub(super) fn register_tab_callbacks(
                     ),
                 }
             };
+            // Reset undo debounce when switching tabs — next keystroke's burst_start
+            // must capture the new tab's text, not the old tab's.
+            *undo_state.debounce.borrow_mut() = None;
+            *undo_state.burst_start.borrow_mut() = None;
+            *undo_state.last_known.borrow_mut() = editor_text.clone();
             let spans = if kind_sql {
                 compute_highlight_spans(&editor_text)
             } else {
@@ -151,6 +180,7 @@ pub(super) fn register_tab_callbacks(
                 ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
                 ui.set_active_tab_index(active_idx);
                 ui.set_active_tab_kind_sql(kind_sql);
+                ui.set_editor_active_tab_id(tab_id.into());
                 if kind_sql {
                     ui.set_editor_text(editor_text.into());
                     apply_highlight_spans(&hl_model, spans);
@@ -168,6 +198,7 @@ pub(super) fn register_tab_callbacks(
         let window_weak = window.as_weak();
         let tabs_state = Rc::clone(&tabs_state); // clone required: callback closure needs owned tabs_state
         let hl_model = Rc::clone(&hl_model); // clone required: on_close_tab closure
+        let undo_state = Rc::clone(&undo_state); // clone required: on_close_tab closure
         ui.on_close_tab(move |i| {
             let i = i as usize;
             let current_text = window_weak
@@ -183,11 +214,19 @@ pub(super) fn register_tab_callbacks(
             }
             let slint_tabs = tabs_to_slint(&ts.tabs);
             let active_idx = ts.active_index as i32;
-            let (kind_sql, editor_text) = match ts.active_tab().map(|t| t.kind.clone()) {
-                Some(tabs_state::TabKind::SqlEditor { query_text }) => (true, query_text),
-                _ => (false, String::new()),
+            let (tab_id, kind_sql, editor_text) = match ts
+                .active_tab()
+                .map(|t| (t.id.clone(), t.kind.clone()))
+            {
+                Some((id, tabs_state::TabKind::SqlEditor { query_text })) => (id, true, query_text),
+                Some((id, _)) => (id, false, String::new()),
+                None => (String::new(), true, String::new()),
             };
             drop(ts);
+            // Reset undo debounce for the newly active tab.
+            *undo_state.debounce.borrow_mut() = None;
+            *undo_state.burst_start.borrow_mut() = None;
+            *undo_state.last_known.borrow_mut() = editor_text.clone();
             let spans = if kind_sql {
                 compute_highlight_spans(&editor_text)
             } else {
@@ -197,6 +236,7 @@ pub(super) fn register_tab_callbacks(
                 ui.set_tabs(Rc::new(slint::VecModel::from(slint_tabs)).into());
                 ui.set_active_tab_index(active_idx);
                 ui.set_active_tab_kind_sql(kind_sql);
+                ui.set_editor_active_tab_id(tab_id.into());
                 if kind_sql {
                     ui.set_editor_text(editor_text.into());
                     apply_highlight_spans(&hl_model, spans);

--- a/app/src/ui/tabs_state.rs
+++ b/app/src/ui/tabs_state.rs
@@ -1,11 +1,66 @@
+use std::collections::HashMap;
+
 use uuid::Uuid;
 
 use crate::app::session::TabSessionEntry;
+
+// ── Per-tab text undo/redo stack ─────────────────────────────────────────────
+
+const UNDO_MAX: usize = 100;
+
+pub struct TextUndoStack {
+    undo: Vec<String>,
+    redo: Vec<String>,
+}
+
+impl TextUndoStack {
+    fn new() -> Self {
+        Self {
+            undo: vec![],
+            redo: vec![],
+        }
+    }
+
+    /// Push a snapshot of the text *before* a change. Clears redo. Deduplicates top.
+    pub fn push(&mut self, text: String) {
+        if self.undo.last().map(|s| s == &text).unwrap_or(false) {
+            return;
+        }
+        self.undo.push(text);
+        if self.undo.len() > UNDO_MAX {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+    }
+
+    /// Undo: restore previous state. `current` is pushed to redo.
+    pub fn undo(&mut self, current: String) -> Option<String> {
+        let prev = self.undo.pop()?;
+        self.redo.push(current);
+        if self.redo.len() > UNDO_MAX {
+            self.redo.remove(0);
+        }
+        Some(prev)
+    }
+
+    /// Redo: restore next state. `current` is pushed to undo.
+    pub fn redo(&mut self, current: String) -> Option<String> {
+        let next = self.redo.pop()?;
+        self.undo.push(current);
+        if self.undo.len() > UNDO_MAX {
+            self.undo.remove(0);
+        }
+        Some(next)
+    }
+}
+
+// ── TabsState ─────────────────────────────────────────────────────────────────
 
 pub struct TabsState {
     pub tabs: Vec<TabEntry>,
     pub active_index: usize,
     counter: usize,
+    pub undo_stacks: HashMap<String, TextUndoStack>,
 }
 
 #[derive(Clone)]
@@ -39,6 +94,7 @@ impl TabsState {
             }],
             active_index: 0,
             counter: 1,
+            undo_stacks: HashMap::new(),
         }
     }
 
@@ -71,6 +127,7 @@ impl TabsState {
             tabs,
             active_index,
             counter,
+            undo_stacks: HashMap::new(),
         }
     }
 
@@ -141,11 +198,28 @@ impl TabsState {
         if matches!(self.tabs[index].kind, TabKind::SqlEditor { .. }) && sql_count <= 1 {
             return false;
         }
+        let tab_id = self.tabs[index].id.clone();
+        self.undo_stacks.remove(&tab_id);
         self.tabs.remove(index);
         if self.active_index >= self.tabs.len() {
             self.active_index = self.tabs.len().saturating_sub(1);
         }
         true
+    }
+
+    pub fn push_undo_snapshot(&mut self, tab_id: &str, text: String) {
+        self.undo_stacks
+            .entry(tab_id.to_string())
+            .or_insert_with(TextUndoStack::new)
+            .push(text);
+    }
+
+    pub fn text_undo(&mut self, tab_id: &str, current: String) -> Option<String> {
+        self.undo_stacks.get_mut(tab_id)?.undo(current)
+    }
+
+    pub fn text_redo(&mut self, tab_id: &str, current: String) -> Option<String> {
+        self.undo_stacks.get_mut(tab_id)?.redo(current)
     }
 
     pub fn set_active(&mut self, index: usize) {
@@ -213,5 +287,58 @@ impl TabsState {
             .collect();
 
         (active_sql_idx, entries)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_undo_stack_should_push_and_undo() {
+        let mut s = TextUndoStack::new();
+        s.push("hello".to_string());
+        let restored = s.undo("hello world".to_string());
+        assert_eq!(restored, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn text_undo_stack_should_not_push_duplicate() {
+        let mut s = TextUndoStack::new();
+        s.push("hello".to_string());
+        s.push("hello".to_string());
+        assert_eq!(s.undo.len(), 1);
+    }
+
+    #[test]
+    fn text_undo_stack_should_clear_redo_on_push() {
+        let mut s = TextUndoStack::new();
+        s.push("a".to_string());
+        s.undo("b".to_string());
+        assert_eq!(s.redo.len(), 1);
+        s.push("c".to_string());
+        assert_eq!(s.redo.len(), 0);
+    }
+
+    #[test]
+    fn text_undo_stack_should_redo_after_undo() {
+        let mut s = TextUndoStack::new();
+        s.push("before".to_string());
+        let _prev = s.undo("after".to_string());
+        let redone = s.redo("before".to_string());
+        assert_eq!(redone, Some("after".to_string()));
+    }
+
+    #[test]
+    fn text_undo_stack_should_cap_at_max_size() {
+        let mut s = TextUndoStack::new();
+        for i in 0..=UNDO_MAX {
+            s.push(format!("text{i}"));
+        }
+        assert_eq!(s.undo.len(), UNDO_MAX);
     }
 }

--- a/app/src/ui/undo.rs
+++ b/app/src/ui/undo.rs
@@ -1,0 +1,160 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use slint::ComponentHandle;
+
+use crate::ui::tabs_state::TabsState;
+
+use super::with_ui;
+
+/// Shared state for the text undo/redo debounce logic.
+/// Lives on the UI thread; always accessed behind `Rc<RefCell<>>`.
+pub struct TextUndoState {
+    /// Text as of the last observed state (after any keystroke or programmatic change).
+    pub last_known: RefCell<String>,
+    /// Text that existed just before the current typing burst began, plus the tab it belongs to.
+    /// `None` when no burst is in progress.
+    pub burst_start: RefCell<Option<(String, String)>>,
+    /// The active debounce timer; `None` means no burst is pending.
+    pub debounce: RefCell<Option<slint::Timer>>,
+}
+
+impl TextUndoState {
+    pub fn new(initial_text: String) -> Rc<Self> {
+        Rc::new(Self {
+            last_known: RefCell::new(initial_text),
+            burst_start: RefCell::new(None),
+            debounce: RefCell::new(None),
+        })
+    }
+
+    /// Cancel any pending debounce timer and flush its burst_start snapshot
+    /// into the undo stack before a programmatic `set_editor_text` call.
+    ///
+    /// Call this BEFORE pushing `current_text` as a new snapshot and calling
+    /// `set_editor_text`.  After the call, update `last_known` to the new text.
+    pub fn flush_before_programmatic_change(
+        &self,
+        tabs_state: &mut TabsState,
+        current_tab_id: &str,
+    ) {
+        // Cancel debounce (prevents stale burst firing after programmatic change).
+        *self.debounce.borrow_mut() = None;
+        // Flush any in-progress burst snapshot.
+        if let Some((tab_id, before_text)) = self.burst_start.borrow_mut().take() {
+            tabs_state.push_undo_snapshot(&tab_id, before_text);
+        }
+        let _ = current_tab_id; // used by callers to push the programmatic snapshot
+    }
+}
+
+pub(super) fn register_undo_callbacks(
+    window: &crate::AppWindow,
+    tabs_state: Rc<RefCell<TabsState>>,
+    undo_state: Rc<TextUndoState>,
+) {
+    let ui = window.global::<crate::UiState>();
+    let ww = window.as_weak();
+
+    // ── text-changed: debounce 500ms, snapshot pre-burst text ────────────────
+    {
+        let undo_state2 = Rc::clone(&undo_state);
+        let tabs_state2 = Rc::clone(&tabs_state);
+        let ww2 = ww.clone();
+        ui.on_text_changed(move |new_text| {
+            let new_text = new_text.to_string();
+            let is_first_of_burst = undo_state2.debounce.borrow().is_none();
+            if is_first_of_burst {
+                // Capture the text before this burst starts.
+                let before = undo_state2.last_known.borrow().clone();
+                let tab_id = ww2
+                    .upgrade()
+                    .map(|w| {
+                        w.global::<crate::UiState>()
+                            .get_editor_active_tab_id()
+                            .to_string()
+                    })
+                    .unwrap_or_default();
+                *undo_state2.burst_start.borrow_mut() = Some((tab_id, before));
+            }
+            *undo_state2.last_known.borrow_mut() = new_text;
+
+            // Reset debounce timer.
+            *undo_state2.debounce.borrow_mut() = None; // cancel previous
+            let undo_state3 = Rc::clone(&undo_state2); // clone required: SingleShot timer closure
+            let tabs_state3 = Rc::clone(&tabs_state2);
+            let timer = slint::Timer::default();
+            timer.start(
+                slint::TimerMode::SingleShot,
+                Duration::from_millis(500),
+                move || {
+                    let Some((tab_id, before_text)) = undo_state3.burst_start.borrow_mut().take()
+                    else {
+                        return;
+                    };
+                    tabs_state3
+                        .borrow_mut()
+                        .push_undo_snapshot(&tab_id, before_text);
+                    *undo_state3.debounce.borrow_mut() = None;
+                },
+            );
+            *undo_state2.debounce.borrow_mut() = Some(timer);
+        });
+    }
+
+    // ── editor-undo: restore previous text snapshot ───────────────────────────
+    {
+        let undo_state2 = Rc::clone(&undo_state);
+        let tabs_state2 = Rc::clone(&tabs_state);
+        let ww2 = ww.clone();
+        ui.on_editor_undo(move || {
+            with_ui(&ww2, |ui| {
+                let tab_id = ui.get_editor_active_tab_id().to_string();
+                let current = ui.get_editor_text().to_string();
+
+                // Flush any in-progress burst into the stack first so
+                // Ctrl+Z after mid-burst can step back through it.
+                {
+                    let mut ts = tabs_state2.borrow_mut();
+                    if let Some((burst_tab, before_text)) =
+                        undo_state2.burst_start.borrow_mut().take()
+                    {
+                        ts.push_undo_snapshot(&burst_tab, before_text);
+                    }
+                }
+                *undo_state2.debounce.borrow_mut() = None;
+
+                let Some(prev) = tabs_state2.borrow_mut().text_undo(&tab_id, current) else {
+                    return;
+                };
+                *undo_state2.last_known.borrow_mut() = prev.clone();
+                ui.set_editor_text(prev.clone().into());
+                ui.invoke_update_highlight(prev.into());
+            });
+        });
+    }
+
+    // ── editor-redo: restore next text snapshot ───────────────────────────────
+    {
+        let undo_state2 = Rc::clone(&undo_state);
+        let tabs_state2 = Rc::clone(&tabs_state);
+        let ww2 = ww.clone();
+        ui.on_editor_redo(move || {
+            with_ui(&ww2, |ui| {
+                let tab_id = ui.get_editor_active_tab_id().to_string();
+                let current = ui.get_editor_text().to_string();
+
+                *undo_state2.debounce.borrow_mut() = None;
+                *undo_state2.burst_start.borrow_mut() = None;
+
+                let Some(next) = tabs_state2.borrow_mut().text_redo(&tab_id, current) else {
+                    return;
+                };
+                *undo_state2.last_known.borrow_mut() = next.clone();
+                ui.set_editor_text(next.clone().into());
+                ui.invoke_update_highlight(next.into());
+            });
+        });
+    }
+}

--- a/app/src/ui/undo.rs
+++ b/app/src/ui/undo.rs
@@ -59,9 +59,9 @@ pub(super) fn register_undo_callbacks(
 
     // ── text-changed: debounce 500ms, snapshot pre-burst text ────────────────
     {
-        let undo_state2 = Rc::clone(&undo_state);
-        let tabs_state2 = Rc::clone(&tabs_state);
-        let ww2 = ww.clone();
+        let undo_state2 = Rc::clone(&undo_state); // clone required: on_text_changed closure
+        let tabs_state2 = Rc::clone(&tabs_state); // clone required: on_text_changed closure
+        let ww2 = ww.clone(); // clone required: on_text_changed closure
         ui.on_text_changed(move |new_text| {
             let new_text = new_text.to_string();
             let is_first_of_burst = undo_state2.debounce.borrow().is_none();
@@ -83,7 +83,7 @@ pub(super) fn register_undo_callbacks(
             // Reset debounce timer.
             *undo_state2.debounce.borrow_mut() = None; // cancel previous
             let undo_state3 = Rc::clone(&undo_state2); // clone required: SingleShot timer closure
-            let tabs_state3 = Rc::clone(&tabs_state2);
+            let tabs_state3 = Rc::clone(&tabs_state2); // clone required: SingleShot timer closure
             let timer = slint::Timer::default();
             timer.start(
                 slint::TimerMode::SingleShot,
@@ -105,9 +105,9 @@ pub(super) fn register_undo_callbacks(
 
     // ── editor-undo: restore previous text snapshot ───────────────────────────
     {
-        let undo_state2 = Rc::clone(&undo_state);
-        let tabs_state2 = Rc::clone(&tabs_state);
-        let ww2 = ww.clone();
+        let undo_state2 = Rc::clone(&undo_state); // clone required: on_editor_undo closure
+        let tabs_state2 = Rc::clone(&tabs_state); // clone required: on_editor_undo closure
+        let ww2 = ww.clone(); // clone required: on_editor_undo closure
         ui.on_editor_undo(move || {
             with_ui(&ww2, |ui| {
                 let tab_id = ui.get_editor_active_tab_id().to_string();
@@ -137,9 +137,9 @@ pub(super) fn register_undo_callbacks(
 
     // ── editor-redo: restore next text snapshot ───────────────────────────────
     {
-        let undo_state2 = Rc::clone(&undo_state);
-        let tabs_state2 = Rc::clone(&tabs_state);
-        let ww2 = ww.clone();
+        let undo_state2 = Rc::clone(&undo_state); // clone required: on_editor_redo closure
+        let tabs_state2 = Rc::clone(&tabs_state); // clone required: on_editor_redo closure
+        let ww2 = ww.clone(); // clone required: on_editor_redo closure
         ui.on_editor_redo(move || {
             with_ui(&ww2, |ui| {
                 let tab_id = ui.get_editor_active_tab_id().to_string();


### PR DESCRIPTION
## Summary

Implements VSCode-style panel-scoped undo/redo. When the SQL editor is focused, Ctrl+Z / Ctrl+Shift+Z steps through text history (including programmatic changes from format-SQL, history insert, snippet insert, and tab-key). When the sidebar is focused, the same shortcuts undo/redo group CRUD actions (create, rename, color, move-connection, delete).

## Changes

- `tabs_state.rs`: `TextUndoStack` (LIFO, max 100, dedup) per tab stored in `HashMap<tab_id, TextUndoStack>`; helpers `push_undo_snapshot`, `text_undo`, `text_redo`; undo stack cleaned up on tab close; 5 unit tests added
- `undo.rs` (new): `TextUndoState` with 500 ms debounce that snapshots pre-burst text; `flush_before_programmatic_change` used by format/snippet/history/tab-key handlers to push a snapshot before each `set_editor_text` call
- `editor.slint`: intercepts Ctrl+Z / Ctrl+Shift+Z in `capture-key-pressed` before `TextInput` sees them, disabling built-in undo
- `app.slint`: `text-changed(string)`, `editor-undo()`, `editor-redo()`, `sidebar-undo()`, `sidebar-redo()` callbacks added to UiState; `editor-active-tab-id` property for per-tab stack scoping; root `key-pressed` routes sidebar undo/redo when `focused-pane == 0`
- `tabs.rs`: resets debounce/burst state and updates `editor-active-tab-id` on tab new/switch/close
- `query.rs`, `history.rs`, `snippet.rs`, `appearance.rs`: each flushes pending burst and pushes a snapshot before programmatic editor text changes
- `group_undo.rs` (new): `GroupOp` enum and `GroupUndoStack` with `(reverse, forward)` pairs, max 50
- `controller/group_undo.rs` (new): `execute_group_op` re-applies any `GroupOp`; `handle_undo/redo_group_action` dispatch
- `controller/group.rs`: each handler records the undo/redo pair after successful mutations
- `command.rs`: `UndoGroupAction`, `RedoGroupAction` variants

## Related Issues

Closes #318

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes