### PR TITLE
feat(query): configurable query timeout with auto-cancel

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -441,6 +441,34 @@ msgctxt "MenuBar"
 msgid "Show Snippets"
 msgstr "Show Snippets"
 
+msgctxt "MenuBar"
+msgid "Editor Preferences…"
+msgstr "Editor Preferences…"
+
+msgctxt "EditorPrefsDialog"
+msgid "Editor Preferences"
+msgstr "Editor Preferences"
+
+msgctxt "EditorPrefsDialog"
+msgid "Tab Width"
+msgstr "Tab Width"
+
+msgctxt "EditorPrefsDialog"
+msgid "Query Timeout"
+msgstr "Query Timeout"
+
+msgctxt "EditorPrefsDialog"
+msgid "Off"
+msgstr "Off"
+
+msgctxt "EditorPrefsDialog"
+msgid "Cancel"
+msgstr "Cancel"
+
+msgctxt "EditorPrefsDialog"
+msgid "Apply"
+msgstr "Apply"
+
 msgctxt "SnippetSaveDialog"
 msgid "Save Snippet"
 msgstr "Save Snippet"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -441,6 +441,34 @@ msgctxt "MenuBar"
 msgid "Show Snippets"
 msgstr "スニペットを表示"
 
+msgctxt "MenuBar"
+msgid "Editor Preferences…"
+msgstr "エディター設定…"
+
+msgctxt "EditorPrefsDialog"
+msgid "Editor Preferences"
+msgstr "エディター設定"
+
+msgctxt "EditorPrefsDialog"
+msgid "Tab Width"
+msgstr "タブ幅"
+
+msgctxt "EditorPrefsDialog"
+msgid "Query Timeout"
+msgstr "クエリタイムアウト"
+
+msgctxt "EditorPrefsDialog"
+msgid "Off"
+msgstr "オフ"
+
+msgctxt "EditorPrefsDialog"
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgctxt "EditorPrefsDialog"
+msgid "Apply"
+msgstr "適用"
+
 msgctxt "SnippetSaveDialog"
 msgid "Save Snippet"
 msgstr "スニペットを保存"

--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -23,6 +23,7 @@ error:
   ssh_fingerprint_mismatch: "SSH host key mismatch — expected: %{expected}, got: %{actual}"
   ssh_conn_string_unsupported: "SSH tunnel is not supported with connection string mode. Switch to Individual Fields."
   ssl_error: "SSL/TLS error: %{reason}"
+  query_timeout: "Query timed out"
   ssl_cert_copy_failed: "Failed to copy certificate file: %{reason}"
   group_create_failed: "Failed to create group: %{reason}"
   group_rename_failed: "Failed to rename group: %{reason}"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -23,6 +23,7 @@ error:
   ssh_fingerprint_mismatch: "SSHホスト鍵が一致しません — 期待値: %{expected}、実際値: %{actual}"
   ssh_conn_string_unsupported: "接続文字列モードではSSHトンネルはサポートされていません。Individual Fieldsに切り替えてください。"
   ssl_error: "SSL/TLSエラー: %{reason}"
+  query_timeout: "クエリがタイムアウトしました"
   ssl_cert_copy_failed: "証明書ファイルのコピーに失敗しました: %{reason}"
   group_create_failed: "グループの作成に失敗しました: %{reason}"
   group_rename_failed: "グループの名前変更に失敗しました: %{reason}"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -16,6 +16,8 @@ pub enum ConfigUpdate {
     },
     ReduceMotion(bool),
     TabWidth(u32),
+    /// Set the query execution timeout (seconds; 0 = disabled).
+    QueryTimeout(u64),
 }
 
 /// UI → Controller channel messages.

--- a/app/src/app/controller/config.rs
+++ b/app/src/app/controller/config.rs
@@ -64,6 +64,12 @@ impl AppController {
                     warn!(error = %e, "failed to persist tab_width to config");
                 }
             }
+            ConfigUpdate::QueryTimeout(secs) => {
+                self.state.ui.set_query_timeout_secs(secs);
+                if let Err(e) = self.session.save_query_timeout(secs) {
+                    warn!(error = %e, "failed to persist query_timeout_secs to config");
+                }
+            }
         }
     }
 }

--- a/app/src/app/controller/query.rs
+++ b/app/src/app/controller/query.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use chrono::Utc;
 use rust_i18n::t;
 use tokio_util::sync::CancellationToken;
@@ -49,6 +51,7 @@ impl AppController {
         let _ = self.tx_event.send(Event::QueryStarted).await;
 
         let page_size = self.state.ui.page_size();
+        let timeout_secs = self.state.ui.query_timeout_secs();
         let sql_to_run = super::apply_limit(&sql, page_size);
 
         let db = self.db.clone(); // clone required: tokio::spawn needs 'static
@@ -58,7 +61,23 @@ impl AppController {
         let conn_id_hist = conn_id.clone(); // clone required: history record needs owned id
         tokio::spawn(async move {
             let now = Utc::now().timestamp();
-            match db.execute_with_cancel(&conn_id, &sql_to_run, token).await {
+            let result = if timeout_secs > 0 {
+                match tokio::time::timeout(
+                    Duration::from_secs(timeout_secs),
+                    db.execute_with_cancel(&conn_id, &sql_to_run, token.clone()),
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(_elapsed) => {
+                        token.cancel();
+                        Err(DbError::Timeout)
+                    }
+                }
+            } else {
+                db.execute_with_cancel(&conn_id, &sql_to_run, token).await
+            };
+            match result {
                 Ok(result) => {
                     let exec = wf_db::models::QueryExecution {
                         id: 0,
@@ -142,6 +161,7 @@ impl AppController {
         let _ = self.tx_event.send(Event::QueryStarted).await;
 
         let page_size = self.state.ui.page_size();
+        let timeout_secs = self.state.ui.query_timeout_secs();
         let db = self.db.clone(); // clone required: tokio::spawn needs 'static
         let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
         let history = self.history.clone(); // clone required: tokio::spawn needs 'static
@@ -154,10 +174,25 @@ impl AppController {
                 let sql_to_run = super::apply_limit(stmt, page_size);
                 let is_last = i == stmts.len() - 1;
 
-                match db
-                    .execute_with_cancel(&conn_id, &sql_to_run, token.clone())
+                let stmt_result = if timeout_secs > 0 {
+                    match tokio::time::timeout(
+                        Duration::from_secs(timeout_secs),
+                        db.execute_with_cancel(&conn_id, &sql_to_run, token.clone()),
+                    )
                     .await
-                {
+                    {
+                        Ok(r) => r,
+                        Err(_elapsed) => {
+                            token.cancel();
+                            Err(DbError::Timeout)
+                        }
+                    }
+                } else {
+                    db.execute_with_cancel(&conn_id, &sql_to_run, token.clone())
+                        .await
+                };
+
+                match stmt_result {
                     Ok(result) => {
                         if is_last {
                             let exec = wf_db::models::QueryExecution {

--- a/app/src/app/localized_message.rs
+++ b/app/src/app/localized_message.rs
@@ -23,6 +23,7 @@ impl LocalizedMessage for DbError {
             .to_string(),
             DbError::KnownHostsWrite(s) => t!("error.ssh_tunnel_failed", reason = s).to_string(),
             DbError::SslError(s) => t!("error.ssl_error", reason = s).to_string(),
+            DbError::Timeout => t!("error.query_timeout").to_string(),
         }
     }
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -138,6 +138,20 @@ impl SessionManager {
             .context("failed to save reduce_motion")?;
         Ok(())
     }
+
+    /// Persist `secs` as `[editor].query_timeout_secs` in `config.toml`.
+    pub fn save_query_timeout(&self, secs: u64) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for query_timeout_secs save")?;
+        config.editor.query_timeout_secs = secs;
+        self.config_manager
+            .save(&config)
+            .context("failed to save query_timeout_secs")?;
+        info!(query_timeout_secs = secs, "query_timeout_secs saved");
+        Ok(())
+    }
 }
 
 impl Default for SessionManager {
@@ -313,6 +327,20 @@ mod tests {
             .load()
             .unwrap();
         assert_eq!(cfg.editor.tab_width, 4);
+    }
+
+    #[test]
+    fn save_query_timeout_should_persist_to_config() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_query_timeout(30).unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        assert_eq!(cfg.editor.query_timeout_secs, 30);
     }
 
     #[test]

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -98,6 +98,9 @@ fn main() -> anyhow::Result<()> {
         state
             .ui
             .set_page_size(u32::from(config.editor.page_size) as usize);
+        state
+            .ui
+            .set_query_timeout_secs(config.editor.query_timeout_secs);
         // On first launch (no saved config): auto-detect the system dark/light mode.
         // On subsequent launches: respect the theme the user explicitly chose and saved.
         let theme = if config_file_exists {

--- a/app/src/state/ui_state.rs
+++ b/app/src/state/ui_state.rs
@@ -9,6 +9,7 @@ use wf_config::models::Theme;
 struct UiData {
     theme: Theme,
     page_size: usize,
+    query_timeout_secs: u64,
 }
 
 impl Default for UiData {
@@ -16,6 +17,7 @@ impl Default for UiData {
         Self {
             theme: Theme::Dark,
             page_size: 500,
+            query_timeout_secs: 0,
         }
     }
 }
@@ -69,5 +71,21 @@ impl UiState {
             .write()
             .unwrap_or_else(|p| p.into_inner())
             .page_size = size;
+    }
+
+    /// Returns the current query timeout in seconds (0 = disabled).
+    pub fn query_timeout_secs(&self) -> u64 {
+        self.data
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .query_timeout_secs
+    }
+
+    /// Updates the query timeout.
+    pub fn set_query_timeout_secs(&self, secs: u64) {
+        self.data
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .query_timeout_secs = secs;
     }
 }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -317,6 +317,10 @@ export global UiState {
     in-out property <int> tab-width: 2;
     /// Persist a new tab-width; Rust sends Command::UpdateConfig.
     callback set-tab-width(int);
+    /// Query execution timeout in seconds (0 = disabled). Persisted in config.toml.
+    in-out property <int> query-timeout-secs: 0;
+    /// Persist a new query-timeout-secs; Rust sends Command::UpdateConfig.
+    callback set-query-timeout-secs(int);
     /// Open the editor-preferences dialog.
     in-out property <bool> show-editor-prefs: false;
     /// Fired when plain Tab is pressed; Rust inserts spaces and updates editor-text + cursor.
@@ -1422,11 +1426,15 @@ export component AppWindow inherits Window {
         if _editor-prefs-alive: EditorPrefsDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
-            show:      UiState.show-editor-prefs;
-            tab-width: UiState.tab-width;
+            show:               UiState.show-editor-prefs;
+            tab-width:          UiState.tab-width;
+            query-timeout-secs: UiState.query-timeout-secs;
             cancel-clicked => { UiState.show-editor-prefs = false; }
-            apply-clicked(w) => {
+            apply-clicked(w, t) => {
+                UiState.tab-width = w;
                 UiState.set-tab-width(w);
+                UiState.query-timeout-secs = t;
+                UiState.set-query-timeout-secs(t);
                 UiState.show-editor-prefs = false;
             }
             exited => { _editor-prefs-alive = false; }

--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -214,11 +214,20 @@ pub(super) fn register_editor_prefs_callbacks(
         ui.invoke_update_highlight(shared);
     });
 
-    let tx_cmd = tx_cmd.clone(); // clone required: on_set_tab_width closure
-    ui.on_set_tab_width(move |width| {
+    {
+        let tx_cmd = tx_cmd.clone(); // clone required: on_set_tab_width closure
+        ui.on_set_tab_width(move |width| {
+            send_cmd(
+                &tx_cmd,
+                Command::UpdateConfig(ConfigUpdate::TabWidth(width as u32)),
+            );
+        });
+    }
+
+    ui.on_set_query_timeout_secs(move |secs| {
         send_cmd(
             &tx_cmd,
-            Command::UpdateConfig(ConfigUpdate::TabWidth(width as u32)),
+            Command::UpdateConfig(ConfigUpdate::QueryTimeout(secs.max(0) as u64)),
         );
     });
 }

--- a/app/src/ui/components/dialogs/editor_prefs_dialog.slint
+++ b/app/src/ui/components/dialogs/editor_prefs_dialog.slint
@@ -3,9 +3,11 @@ import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component EditorPrefsDialog inherits ModalOverlay {
     callback cancel-clicked;
-    callback apply-clicked(int);
+    // tab-width, query-timeout-secs
+    callback apply-clicked(int, int);
 
     in-out property <int> tab-width: 2;
+    in-out property <int> query-timeout-secs: 0;
 
     VerticalLayout {
         padding: Layout.padding-2xl;
@@ -89,6 +91,93 @@ export component EditorPrefsDialog inherits ModalOverlay {
             }
         }
 
+        // Query-timeout selector row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Query Timeout");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            // Four segmented buttons: Off / 10s / 30s / 60s
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                qt0 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.query-timeout-secs == 0 ? Colors.blue : Colors.surface2;
+                    background: root.query-timeout-secs == 0 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("Off");
+                        color: root.query-timeout-secs == 0 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.query-timeout-secs = 0; } }
+                }
+
+                qt10 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.query-timeout-secs == 10 ? Colors.blue : Colors.surface2;
+                    background: root.query-timeout-secs == 10 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "10s";
+                        color: root.query-timeout-secs == 10 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.query-timeout-secs = 10; } }
+                }
+
+                qt30 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.query-timeout-secs == 30 ? Colors.blue : Colors.surface2;
+                    background: root.query-timeout-secs == 30 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "30s";
+                        color: root.query-timeout-secs == 30 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.query-timeout-secs = 30; } }
+                }
+
+                qt60 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.query-timeout-secs == 60 ? Colors.blue : Colors.surface2;
+                    background: root.query-timeout-secs == 60 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: "60s";
+                        color: root.query-timeout-secs == 60 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.query-timeout-secs = 60; } }
+                }
+            }
+        }
+
         HorizontalLayout {
             spacing: Layout.spacing-lg;
             alignment: end;
@@ -102,7 +191,7 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 text: @tr("Apply");
                 bg: Colors.blue;
                 fg: Colors.base;
-                clicked => { root.apply-clicked(root.tab-width); }
+                clicked => { root.apply-clicked(root.tab-width, root.query-timeout-secs); }
             }
         }
     }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -601,6 +601,7 @@ impl UI {
         ui_global.set_font_size(config.appearance.font_size as i32);
         ui_global.set_reduce_motion(config.appearance.reduce_motion);
         ui_global.set_tab_width(config.editor.tab_width as i32);
+        ui_global.set_query_timeout_secs(config.editor.query_timeout_secs as i32);
         // Apply locale after the Slint component exists — select_bundled_translation
         // requires a live component and is a no-op if called before one is created.
         let lang = &config.ui.language;

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -159,6 +159,7 @@ mod tests {
             editor: EditorConfig {
                 page_size: PageSize::Rows100,
                 tab_width: 2,
+                query_timeout_secs: 0,
             },
             ..Config::default()
         };

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -101,6 +101,8 @@ impl Default for AppearanceConfig {
 pub struct EditorConfig {
     pub page_size: PageSize,
     pub tab_width: u32,
+    /// Query timeout in seconds. `0` means no timeout.
+    pub query_timeout_secs: u64,
 }
 
 impl Default for EditorConfig {
@@ -108,6 +110,7 @@ impl Default for EditorConfig {
         Self {
             page_size: PageSize::default(),
             tab_width: 2,
+            query_timeout_secs: 0,
         }
     }
 }
@@ -294,6 +297,7 @@ mod tests {
         assert!(!cfg.appearance.reduce_motion);
         assert_eq!(cfg.editor.page_size, PageSize::Rows500);
         assert_eq!(cfg.editor.tab_width, 2);
+        assert_eq!(cfg.editor.query_timeout_secs, 0);
         assert_eq!(cfg.session.last_query, None);
         assert_eq!(cfg.ui.language, "en");
     }
@@ -526,6 +530,7 @@ language = "ja"
             editor: EditorConfig {
                 page_size: PageSize::Rows100,
                 tab_width: 4,
+                query_timeout_secs: 30,
             },
             session: SessionConfig {
                 last_query: Some("SELECT 1".to_string()),

--- a/crates/wf-db/src/error.rs
+++ b/crates/wf-db/src/error.rs
@@ -33,6 +33,9 @@ pub enum DbError {
 
     #[error("SSL/TLS error: {0}")]
     SslError(String),
+
+    #[error("query timed out")]
+    Timeout,
 }
 
 // ---------------------------------------------------------------------------
@@ -58,5 +61,10 @@ mod tests {
     fn db_error_query_error_should_include_message() {
         let e = DbError::QueryError("syntax error".to_string());
         assert_eq!(e.to_string(), "query execution error: syntax error");
+    }
+
+    #[test]
+    fn db_error_timeout_should_display_correctly() {
+        assert_eq!(DbError::Timeout.to_string(), "query timed out");
     }
 }


### PR DESCRIPTION
## Summary

Implements Issue #67: adds a configurable per-query execution timeout. When a timeout is set and exceeded, the in-flight query is cancelled via `CancellationToken` and a localized "Query timed out" error is shown. The timeout can be set through the new Editor Preferences dialog (Off / 10s / 30s / 60s) and persists to `config.toml`. Timeout is applied per-statement in `run_all` mode.

## Changes

- `wf-db`: added `DbError::Timeout` error variant
- `wf-config`: added `query_timeout_secs: u64` field to `EditorConfig` (default 0 = disabled)
- `wf-config`: fixed `manager.rs` test struct literal to include new field
- `app/state`: added `query_timeout_secs` getter/setter to `UiData` / `UiState`
- `app/session`: added `save_query_timeout` to persist setting to `config.toml`
- `app/command`: added `ConfigUpdate::QueryTimeout(u64)` variant
- `app/controller/config`: handle `QueryTimeout` — update runtime state and persist
- `app/controller/query`: wrap `execute_with_cancel` with `tokio::time::timeout` in both `handle_run_query` and `handle_run_all`; cancel token on elapsed
- `app/localized_message`: map `DbError::Timeout` to localized error string
- `app/locales`: added `error.query_timeout` key in EN/JA
- `editor_prefs_dialog.slint`: added Query Timeout row with segmented buttons; `apply-clicked` now carries `(tab_width, timeout_secs)`
- `app.slint`: added `query-timeout-secs` property and `set-query-timeout-secs` callback to `UiState`; wired dialog `apply-clicked`
- `appearance.rs`: registered `on_set_query_timeout_secs` callback
- `mod.rs`: initialize `query_timeout_secs` from loaded config on startup
- `lang/en` + `lang/ja` PO files: added `EditorPrefsDialog` entries and `MenuBar` "Editor Preferences…" entry for full i18n coverage

## Related Issues

Closes #67

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes