### PR TITLE
perf(app): await snippet refresh instead of spawning unbounded tasks

### DIFF
--- a/app/src/ui/event.rs
+++ b/app/src/ui/event.rs
@@ -54,11 +54,7 @@ pub(super) fn spawn_event_handler(
                         Arc::clone(&sidebar_state),
                     );
                     // Refresh snippets to include per-connection entries.
-                    let bk_repo = Arc::clone(&snippet_repo);
-                    let bk_ww = window_weak.clone();
-                    tokio::spawn(async move {
-                        do_refresh_snippets(&bk_ww, &bk_repo, Some(&conn_id)).await;
-                    });
+                    do_refresh_snippets(&window_weak, &snippet_repo, Some(&conn_id)).await;
                 }
                 Event::TestConnectionOk => handle_test_ok(window_weak.clone()),
                 Event::TestConnectionFailed(msg) => handle_test_failed(msg, window_weak.clone()),
@@ -72,11 +68,7 @@ pub(super) fn spawn_event_handler(
                 Event::Disconnected(id) => {
                     handle_disconnected(id, window_weak.clone());
                     // Drop per-connection snippets; show global only.
-                    let bk_repo = Arc::clone(&snippet_repo);
-                    let bk_ww = window_weak.clone();
-                    tokio::spawn(async move {
-                        do_refresh_snippets(&bk_ww, &bk_repo, None).await;
-                    });
+                    do_refresh_snippets(&window_weak, &snippet_repo, None).await;
                 }
                 Event::ConnectionRemoved(id) => {
                     handle_connection_removed(id, window_weak.clone(), Arc::clone(&sidebar_state))


### PR DESCRIPTION
## Summary

Each `Event::Connected` and `Event::Disconnected` was spawning a new `tokio::spawn` task to call `do_refresh_snippets`, with no bound or cancellation mechanism. Rapid connect/disconnect (flaky network, quick connection switching) accumulated unbounded tasks in the tokio runtime. This PR replaces the inner spawns with a direct `.await`, serialising snippet refresh and preventing task accumulation entirely.

## Changes

- `app/src/ui/event.rs`: replace `tokio::spawn(async move { do_refresh_snippets(...).await })` with `do_refresh_snippets(...).await` for both `Event::Connected` and `Event::Disconnected` arms
- Root cause: fire-and-forget inner spawns with no cancellation or bound
- Fix: direct `.await` inside the outer event-handler task; `SnippetRepository::list()` reads from a TOML file so the blocking time is negligible

## Related Issues

Fixes #279

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes