### PR TITLE
perf(history): add indexes to eliminate full table scans on history and connections

### DIFF
--- a/crates/wf-config/src/repository.rs
+++ b/crates/wf-config/src/repository.rs
@@ -48,6 +48,10 @@ const CREATE_TABLE_GROUPS: &str = "
     )
 ";
 
+const CREATE_INDEX_CONN_LAST_USED: &str = "
+    CREATE INDEX IF NOT EXISTS idx_conn_last_used
+        ON connections(last_used_at DESC)";
+
 /// Migrations for existing databases created before group columns were added.
 const MIGRATE_GROUP_COLUMNS: &[&str] = &[
     "ALTER TABLE connections ADD COLUMN group_id TEXT",
@@ -101,7 +105,16 @@ impl ConnectionRepository {
         for stmt in MIGRATE_GROUP_COLUMNS {
             let _ = sqlx::query(stmt).execute(&pool).await;
         }
+        sqlx::query(CREATE_INDEX_CONN_LAST_USED)
+            .execute(&pool)
+            .await
+            .context("failed to create idx_conn_last_used")?;
         Ok(Self { pool })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
     }
 
     /// In-memory database (for tests only).
@@ -489,6 +502,19 @@ mod tests {
             group_id: None,
             color: None,
         }
+    }
+
+    #[tokio::test]
+    async fn new_should_create_last_used_index() {
+        let repo = ConnectionRepository::open_memory().await.unwrap();
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE type='index' AND name='idx_conn_last_used'",
+        )
+        .fetch_one(repo.pool())
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[tokio::test]

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -28,6 +28,10 @@ const CREATE_TABLE: &str = "
         connection_id TEXT    NOT NULL
     )";
 
+const CREATE_INDEX: &str = "
+    CREATE INDEX IF NOT EXISTS idx_qe_timestamp
+        ON query_executions(timestamp DESC)";
+
 impl HistoryService {
     /// Accept an already-open [`SqlitePool`] and ensure the schema exists.
     pub async fn new(pool: SqlitePool) -> Result<Self> {
@@ -37,7 +41,13 @@ impl HistoryService {
 
     async fn migrate(pool: &SqlitePool) -> Result<()> {
         sqlx::query(CREATE_TABLE).execute(pool).await?;
+        sqlx::query(CREATE_INDEX).execute(pool).await?;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
     }
 
     /// Persist one [`QueryExecution`] record.
@@ -164,6 +174,19 @@ mod tests {
             timestamp: ts,
             connection_id: conn_id.to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn migrate_should_create_timestamp_index() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE type='index' AND name='idx_qe_timestamp'",
+        )
+        .fetch_one(svc.pool())
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds `CREATE INDEX IF NOT EXISTS` statements to two SQLite tables that were missing indexes on their sort columns. The `query_executions` table had no index on `timestamp`, so every `recent()` call (opening the history panel) performed a full table scan plus in-memory sort — O(n log n) cost that grows with query count. Similarly, `connections` had no index on `last_used_at`, causing an O(n) scan at every app startup. Both indexes reduce these operations to O(log n + limit). The `CREATE INDEX IF NOT EXISTS` form is idempotent and applies safely to existing user databases.

## Changes

- `crates/wf-history/src/service.rs`: add `CREATE_INDEX` constant and execute it in `migrate()` after `CREATE TABLE`; add `#[cfg(test)]` pool accessor; add `migrate_should_create_timestamp_index` test that queries `sqlite_schema` to confirm the index exists
- `crates/wf-config/src/repository.rs`: add `CREATE_INDEX_CONN_LAST_USED` constant and execute it in `ConnectionRepository::new()` after the column-migration loop; add `#[cfg(test)]` pool accessor; add `new_should_create_last_used_index` test

## Related Issues

Closes #280

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes