### PR TITLE
perf(app): add SQLite performance pragmas and aggregate next_query_number

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -120,7 +120,12 @@ fn main() -> anyhow::Result<()> {
                 sqlx::sqlite::SqliteConnectOptions::new()
                     .filename(config_dir.join("wellfeather.db"))
                     .create_if_missing(true)
-                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal),
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .pragma("synchronous", "normal")
+                    .pragma("cache_size", "-20000")
+                    .pragma("mmap_size", "30000000")
+                    .pragma("busy_timeout", "5000")
+                    .pragma("temp_store", "memory"),
             )
             .await
     })?;

--- a/crates/wf-config/src/snippet.rs
+++ b/crates/wf-config/src/snippet.rs
@@ -171,16 +171,13 @@ impl SnippetRepository {
     /// Finds the highest N already used and returns N+1, so numbers never repeat
     /// even after deletion.
     pub async fn next_query_number(&self) -> anyhow::Result<u64> {
-        let names: Vec<String> =
-            sqlx::query_scalar("SELECT name FROM snippets WHERE name LIKE 'Query %'")
-                .fetch_all(&self.pool)
-                .await?;
-        let max = names
-            .iter()
-            .filter_map(|n| n.strip_prefix("Query ").and_then(|s| s.parse::<u64>().ok()))
-            .max()
-            .unwrap_or(0);
-        Ok(max + 1)
+        let max: Option<i64> = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(CAST(SUBSTR(name, 7) AS INTEGER)), 0)
+             FROM snippets WHERE name GLOB 'Query [0-9]*'",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(max.unwrap_or(0) as u64 + 1)
     }
 
     async fn next_sort_order(&self) -> anyhow::Result<i64> {
@@ -355,5 +352,26 @@ mod tests {
         let (x, y) = repo.get_bar_position().await.unwrap();
         assert!((x - 400.0).abs() < 0.001);
         assert!((y - 300.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn next_query_number_should_return_one_when_no_snippets() {
+        let repo = open_memory().await;
+        assert_eq!(repo.next_query_number().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn next_query_number_should_return_max_plus_one() {
+        let repo = open_memory().await;
+        repo.add(&make_entry("b1", "Query 3", "SELECT 1"))
+            .await
+            .unwrap();
+        repo.add(&make_entry("b2", "Query 7", "SELECT 2"))
+            .await
+            .unwrap();
+        repo.add(&make_entry("b3", "Custom Name", "SELECT 3"))
+            .await
+            .unwrap();
+        assert_eq!(repo.next_query_number().await.unwrap(), 8);
     }
 }


### PR DESCRIPTION
## Summary

The shared SQLite pool in `app/src/main.rs` was opened with only `journal_mode=WAL` set, leaving five performance pragmas unset. This adds `synchronous=NORMAL`, a 20 MB page cache, 30 MB memory-mapped I/O, a 5 s busy timeout, and in-memory temporary tables. Additionally, `SnippetRepository::next_query_number()` was loading all matching snippet names into Rust memory to find the maximum; it now uses a single SQL `MAX` aggregation that transfers one integer.

## Changes

- `app/src/main.rs`: add five `.pragma()` calls to `SqliteConnectOptions` — `synchronous`, `cache_size`, `mmap_size`, `busy_timeout`, `temp_store`
- `crates/wf-config/src/snippet.rs`: replace `fetch_all` + Rust-side parse in `next_query_number()` with `COALESCE(MAX(CAST(SUBSTR(name, 7) AS INTEGER)), 0)` aggregation; add `next_query_number_should_return_one_when_no_snippets` and `next_query_number_should_return_max_plus_one` tests

## Related Issues

Closes #281

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes