### PR TITLE
perf(app): move QueryResult.rows into Arc to eliminate double clone

### DIFF
--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -125,7 +125,7 @@ fn check_safe_dml(weak: &slint::Weak<crate::AppWindow>, sql: &str, kind: &str) -
 struct OriginalQueryData {
     columns: Vec<slint::SharedString>,
     // None = SQL NULL; Some(s) = value (including empty string)
-    rows: Vec<Vec<Option<String>>>,
+    rows: Arc<Vec<Vec<Option<String>>>>,
     /// None = unsorted; Some(i) = sort column index.
     sort_col: Option<usize>,
     sort_asc: bool,

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -329,7 +329,7 @@ pub(super) fn register_export_callbacks(
                 let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
                 orig.as_ref().map(|d| {
                     let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
-                    (cols, d.rows.clone())
+                    (cols, Arc::clone(&d.rows)) // clone required: tokio::spawn needs 'static
                 })
             };
             let Some((columns, rows)) = snapshot else {
@@ -366,7 +366,7 @@ pub(super) fn register_export_callbacks(
                 let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
                 orig.as_ref().map(|d| {
                     let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
-                    (cols, d.rows.clone())
+                    (cols, Arc::clone(&d.rows)) // clone required: tokio::spawn needs 'static
                 })
             };
             let Some((columns, rows)) = snapshot else {
@@ -403,7 +403,7 @@ pub(super) fn register_export_callbacks(
                 let orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
                 orig.as_ref().map(|d| {
                     let cols: Vec<String> = d.columns.iter().map(|s| s.to_string()).collect();
-                    (cols, d.rows.clone())
+                    (cols, Arc::clone(&d.rows)) // clone required: tokio::spawn needs 'static
                 })
             };
             let Some((columns, rows)) = snapshot else {
@@ -741,14 +741,14 @@ pub(super) fn handle_query_finished(
     let col_count = result.columns.len();
     let columns: Vec<slint::SharedString> =
         result.columns.iter().map(|c| c.clone().into()).collect();
-    let raw_rows: Vec<Vec<Option<String>>> = result.rows.iter().map(|r| r.to_vec()).collect();
+    let raw_rows = Arc::new(result.rows);
     let row_count = result.row_count as i32;
     let exec_ms = result.execution_time_ms;
     {
         let mut orig = original_data.lock().unwrap_or_else(|p| p.into_inner());
         *orig = Some(OriginalQueryData {
             columns: columns.clone(),
-            rows: raw_rows.clone(),
+            rows: Arc::clone(&raw_rows),
             sort_col: None,
             sort_asc: true,
         });
@@ -788,7 +788,7 @@ pub(super) fn handle_table_data_loaded(
     let col_count = result.columns.len();
     let columns: Vec<slint::SharedString> =
         result.columns.iter().map(|c| c.clone().into()).collect();
-    let raw_rows: Vec<Vec<Option<String>>> = result.rows.iter().map(|r| r.to_vec()).collect();
+    let raw_rows = result.rows;
     let row_count = result.row_count as i32;
     // clone required: invoke_from_event_loop closure must be 'static
     let _ = slint::invoke_from_event_loop(move || {


### PR DESCRIPTION
## Summary

`handle_query_finished` cloned `QueryResult.rows` twice before the data reached the Slint model: once into a local `raw_rows` variable and again into `OriginalQueryData`. Since `QueryResult` is passed by value, `result.rows` is already owned and can be moved directly into an `Arc` with zero copying. `Arc::clone` (pointer copy) then replaces the second full deep clone. `handle_table_data_loaded` had the same unnecessary copy and is fixed with a plain move. Export callbacks (CSV, JSON, INSERT SQL) each performed a full `Vec` clone before spawning a file-write task; these are replaced with `Arc::clone`.

## Changes

- `app/src/ui/mod.rs`: `OriginalQueryData.rows` type changed from `Vec<Vec<Option<String>>>` to `Arc<Vec<Vec<Option<String>>>>`
- `app/src/ui/query.rs`: `handle_query_finished` — `Arc::new(result.rows)` replaces clone #1; `Arc::clone(&raw_rows)` replaces clone #2
- `app/src/ui/query.rs`: `handle_table_data_loaded` — `let raw_rows = result.rows` (move) replaces the full row-by-row copy
- `app/src/ui/query.rs`: three export callbacks — `Arc::clone(&d.rows)` replaces `d.rows.clone()` (Vec deep copy); `&rows` auto-derefs through `Arc` to satisfy `&[Vec<Option<String>>]`

## Related Issues

Closes #282

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes