### PR TITLE
feat(app): slow query detection with configurable threshold and status bar warning

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -454,6 +454,22 @@ msgid "Tab Width"
 msgstr "Tab Width"
 
 msgctxt "EditorPrefsDialog"
+msgid "Slow Query"
+msgstr "Slow Query"
+
+msgctxt "EditorPrefsDialog"
+msgid "500ms"
+msgstr "500ms"
+
+msgctxt "EditorPrefsDialog"
+msgid "1s"
+msgstr "1s"
+
+msgctxt "EditorPrefsDialog"
+msgid "5s"
+msgstr "5s"
+
+msgctxt "EditorPrefsDialog"
 msgid "Query Timeout"
 msgstr "Query Timeout"
 

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -454,6 +454,22 @@ msgid "Tab Width"
 msgstr "タブ幅"
 
 msgctxt "EditorPrefsDialog"
+msgid "Slow Query"
+msgstr "低速クエリ"
+
+msgctxt "EditorPrefsDialog"
+msgid "500ms"
+msgstr "500ms"
+
+msgctxt "EditorPrefsDialog"
+msgid "1s"
+msgstr "1秒"
+
+msgctxt "EditorPrefsDialog"
+msgid "5s"
+msgstr "5秒"
+
+msgctxt "EditorPrefsDialog"
 msgid "Query Timeout"
 msgstr "クエリタイムアウト"
 

--- a/app/locales/en.yml
+++ b/app/locales/en.yml
@@ -1,6 +1,7 @@
 status:
   running: "Running…"
   query_finished: "%{ms} ms  ·  %{rows} rows"
+  slow_query: "⚠ Slow query: %{ms}ms"
   cancelled: "Cancelled"
   error: "Error: %{msg}"
   disconnected: "Disconnected: %{id}"

--- a/app/locales/ja.yml
+++ b/app/locales/ja.yml
@@ -1,6 +1,7 @@
 status:
   running: "実行中…"
   query_finished: "%{ms} ms  ·  %{rows} 行"
+  slow_query: "⚠ 低速クエリ: %{ms}ms"
   cancelled: "キャンセルしました"
   error: "エラー: %{msg}"
   disconnected: "切断しました: %{id}"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -18,6 +18,8 @@ pub enum ConfigUpdate {
     TabWidth(u32),
     /// Set the query execution timeout (seconds; 0 = disabled).
     QueryTimeout(u64),
+    /// Set the slow query warning threshold (milliseconds; 0 = disabled).
+    SlowQueryThreshold(u64),
 }
 
 /// UI → Controller channel messages.

--- a/app/src/app/controller/config.rs
+++ b/app/src/app/controller/config.rs
@@ -70,6 +70,11 @@ impl AppController {
                     warn!(error = %e, "failed to persist query_timeout_secs to config");
                 }
             }
+            ConfigUpdate::SlowQueryThreshold(ms) => {
+                if let Err(e) = self.session.save_slow_query_threshold(ms) {
+                    warn!(error = %e, "failed to persist slow_query_threshold_ms to config");
+                }
+            }
         }
     }
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -152,6 +152,23 @@ impl SessionManager {
         info!(query_timeout_secs = secs, "query_timeout_secs saved");
         Ok(())
     }
+
+    /// Persist `ms` as `[editor].slow_query_threshold_ms` in `config.toml`.
+    pub fn save_slow_query_threshold(&self, ms: u64) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for slow_query_threshold_ms save")?;
+        config.editor.slow_query_threshold_ms = ms;
+        self.config_manager
+            .save(&config)
+            .context("failed to save slow_query_threshold_ms")?;
+        info!(
+            slow_query_threshold_ms = ms,
+            "slow_query_threshold_ms saved"
+        );
+        Ok(())
+    }
 }
 
 impl Default for SessionManager {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -40,6 +40,12 @@ export global UiState {
     // ── Core UI state ─────────────────────────────────────────────────────────
     in-out property <bool>   is-loading:        false;
     in-out property <string> status-message:    "";
+    /// Yellow warning displayed when a query exceeds slow-query-threshold-ms. Empty = no warning.
+    in-out property <string> slow-query-warning: "";
+    /// Slow query detection threshold in milliseconds (0 = disabled). Persisted in config.toml.
+    in-out property <int> slow-query-threshold-ms: 0;
+    /// Persist a new slow-query-threshold-ms; Rust sends Command::UpdateConfig.
+    callback set-slow-query-threshold-ms(int);
     in-out property <string> error-message:     "";
     in-out property <string> status-connection: @tr("Not connected");
     in-out property <bool>   sidebar-loading:   false;
@@ -1166,9 +1172,10 @@ export component AppWindow inherits Window {
             y: menu-bar-height + tab-bar-height + content-height;
             width:  root.width;
             height: 24px;
-            connection-text: UiState.status-connection;
-            query-status:    UiState.status-message;
-            ssh-active:      UiState.ssh-active;
+            connection-text:    UiState.status-connection;
+            query-status:       UiState.status-message;
+            slow-query-warning: UiState.slow-query-warning;
+            ssh-active:         UiState.ssh-active;
         }
 
         // ── Inner edge lines ──────────────────────────────────────────────────
@@ -1430,15 +1437,18 @@ export component AppWindow inherits Window {
         if _editor-prefs-alive: EditorPrefsDialog {
             x: 0; y: 0;
             width: root.width; height: root.height;
-            show:               UiState.show-editor-prefs;
-            tab-width:          UiState.tab-width;
-            query-timeout-secs: UiState.query-timeout-secs;
+            show:                    UiState.show-editor-prefs;
+            tab-width:               UiState.tab-width;
+            query-timeout-secs:      UiState.query-timeout-secs;
+            slow-query-threshold-ms: UiState.slow-query-threshold-ms;
             cancel-clicked => { UiState.show-editor-prefs = false; }
-            apply-clicked(w, t) => {
+            apply-clicked(w, t, s) => {
                 UiState.tab-width = w;
                 UiState.set-tab-width(w);
                 UiState.query-timeout-secs = t;
                 UiState.set-query-timeout-secs(t);
+                UiState.slow-query-threshold-ms = s;
+                UiState.set-slow-query-threshold-ms(s);
                 UiState.show-editor-prefs = false;
             }
             exited => { _editor-prefs-alive = false; }

--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -224,10 +224,20 @@ pub(super) fn register_editor_prefs_callbacks(
         });
     }
 
-    ui.on_set_query_timeout_secs(move |secs| {
+    {
+        let tx_cmd = tx_cmd.clone(); // clone required: on_set_query_timeout_secs closure
+        ui.on_set_query_timeout_secs(move |secs| {
+            send_cmd(
+                &tx_cmd,
+                Command::UpdateConfig(ConfigUpdate::QueryTimeout(secs.max(0) as u64)),
+            );
+        });
+    }
+
+    ui.on_set_slow_query_threshold_ms(move |ms| {
         send_cmd(
             &tx_cmd,
-            Command::UpdateConfig(ConfigUpdate::QueryTimeout(secs.max(0) as u64)),
+            Command::UpdateConfig(ConfigUpdate::SlowQueryThreshold(ms.max(0) as u64)),
         );
     });
 }

--- a/app/src/ui/components/dialogs/editor_prefs_dialog.slint
+++ b/app/src/ui/components/dialogs/editor_prefs_dialog.slint
@@ -3,11 +3,12 @@ import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component EditorPrefsDialog inherits ModalOverlay {
     callback cancel-clicked;
-    // tab-width, query-timeout-secs
-    callback apply-clicked(int, int);
+    // tab-width, query-timeout-secs, slow-query-threshold-ms
+    callback apply-clicked(int, int, int);
 
     in-out property <int> tab-width: 2;
     in-out property <int> query-timeout-secs: 0;
+    in-out property <int> slow-query-threshold-ms: 0;
 
     VerticalLayout {
         padding: Layout.padding-2xl;
@@ -87,6 +88,93 @@ export component EditorPrefsDialog inherits ModalOverlay {
                         vertical-alignment: center;
                     }
                     TouchArea { clicked => { root.tab-width = 8; } }
+                }
+            }
+        }
+
+        // Slow-query-threshold selector row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Slow Query");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            // Four segmented buttons: Off / 500ms / 1s / 5s
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                sq0 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.slow-query-threshold-ms == 0 ? Colors.blue : Colors.surface2;
+                    background: root.slow-query-threshold-ms == 0 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("Off");
+                        color: root.slow-query-threshold-ms == 0 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.slow-query-threshold-ms = 0; } }
+                }
+
+                sq500 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.slow-query-threshold-ms == 500 ? Colors.blue : Colors.surface2;
+                    background: root.slow-query-threshold-ms == 500 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("500ms");
+                        color: root.slow-query-threshold-ms == 500 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.slow-query-threshold-ms = 500; } }
+                }
+
+                sq1000 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.slow-query-threshold-ms == 1000 ? Colors.blue : Colors.surface2;
+                    background: root.slow-query-threshold-ms == 1000 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("1s");
+                        color: root.slow-query-threshold-ms == 1000 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.slow-query-threshold-ms = 1000; } }
+                }
+
+                sq5000 := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.slow-query-threshold-ms == 5000 ? Colors.blue : Colors.surface2;
+                    background: root.slow-query-threshold-ms == 5000 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("5s");
+                        color: root.slow-query-threshold-ms == 5000 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.slow-query-threshold-ms = 5000; } }
                 }
             }
         }
@@ -191,7 +279,7 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 text: @tr("Apply");
                 bg: Colors.blue;
                 fg: Colors.base;
-                clicked => { root.apply-clicked(root.tab-width, root.query-timeout-secs); }
+                clicked => { root.apply-clicked(root.tab-width, root.query-timeout-secs, root.slow-query-threshold-ms); }
             }
         }
     }

--- a/app/src/ui/components/status_bar.slint
+++ b/app/src/ui/components/status_bar.slint
@@ -13,6 +13,9 @@ export component StatusBar inherits Rectangle {
     /// Query lifecycle status string pushed from Rust (status-message in UiState).
     /// Examples: "Running…"  |  "42 ms  ·  128 rows"  |  "Cancelled"  |  "Error: …"
     in property <string> query-status;
+    /// Slow query warning set by Rust when execution_time_ms exceeds the threshold.
+    /// Empty string means no warning is shown.
+    in property <string> slow-query-warning: "";
     /// When true, a green "SSH" badge is shown next to the connection text.
     in property <bool> ssh-active: false;
 
@@ -42,6 +45,13 @@ export component StatusBar inherits Rectangle {
                 horizontal-alignment: center;
                 vertical-alignment: center;
             }
+        }
+
+        if root.slow-query-warning != "": Text {
+            text: root.slow-query-warning;
+            color: Colors.yellow;
+            font-size: Typography.size-base;
+            vertical-alignment: center;
         }
 
         Text {

--- a/app/src/ui/event.rs
+++ b/app/src/ui/event.rs
@@ -419,6 +419,7 @@ fn handle_query_started(ww: slint::Weak<crate::AppWindow>) {
             ui.set_is_loading(true);
             ui.set_error_message("".into());
             ui.set_status_message(t!("status.running").to_string().into());
+            ui.set_slow_query_warning("".into());
             ui.set_result_panel_open(true);
         });
     });

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -602,6 +602,7 @@ impl UI {
         ui_global.set_reduce_motion(config.appearance.reduce_motion);
         ui_global.set_tab_width(config.editor.tab_width as i32);
         ui_global.set_query_timeout_secs(config.editor.query_timeout_secs as i32);
+        ui_global.set_slow_query_threshold_ms(config.editor.slow_query_threshold_ms as i32);
         // Apply locale after the Slint component exists — select_bundled_translation
         // requires a live component and is a no-op if called before one is created.
         let lang = &config.ui.language;

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -775,6 +775,16 @@ pub(super) fn handle_query_finished(
                     .to_string()
                     .into(),
             );
+            let threshold = ui.get_slow_query_threshold_ms();
+            if threshold > 0 && exec_ms >= threshold as u128 {
+                ui.set_slow_query_warning(
+                    rust_i18n::t!("status.slow_query", ms = exec_ms)
+                        .to_string()
+                        .into(),
+                );
+            } else {
+                ui.set_slow_query_warning("".into());
+            }
             ui.set_result_panel_open(true);
         });
     });

--- a/crates/wf-config/src/manager.rs
+++ b/crates/wf-config/src/manager.rs
@@ -160,6 +160,7 @@ mod tests {
                 page_size: PageSize::Rows100,
                 tab_width: 2,
                 query_timeout_secs: 0,
+                slow_query_threshold_ms: 0,
             },
             ..Config::default()
         };

--- a/crates/wf-config/src/models.rs
+++ b/crates/wf-config/src/models.rs
@@ -103,6 +103,8 @@ pub struct EditorConfig {
     pub tab_width: u32,
     /// Query timeout in seconds. `0` means no timeout.
     pub query_timeout_secs: u64,
+    /// Slow query warning threshold in milliseconds. `0` means disabled.
+    pub slow_query_threshold_ms: u64,
 }
 
 impl Default for EditorConfig {
@@ -111,6 +113,7 @@ impl Default for EditorConfig {
             page_size: PageSize::default(),
             tab_width: 2,
             query_timeout_secs: 0,
+            slow_query_threshold_ms: 0,
         }
     }
 }
@@ -531,6 +534,7 @@ language = "ja"
                 page_size: PageSize::Rows100,
                 tab_width: 4,
                 query_timeout_secs: 30,
+                slow_query_threshold_ms: 0,
             },
             session: SessionConfig {
                 last_query: Some("SELECT 1".to_string()),


### PR DESCRIPTION
## Summary

Implements Issue #68 (T134): detects slow queries by comparing `execution_time_ms` against a configurable threshold and displays a yellow `⚠ Slow query: Nms` warning in the status bar alongside the normal row count / execution time status. The threshold is configurable from the Editor Preferences dialog (Off / 500ms / 1s / 5s) and persisted to `config.toml`.

## Changes

- `crates/wf-config/src/models.rs`: add `slow_query_threshold_ms: u64` field to `EditorConfig` (default `0` = disabled, `serde(default)` ensures backwards-compatible deserialization)
- `app/src/app/command.rs`: add `ConfigUpdate::SlowQueryThreshold(u64)` variant
- `app/src/app/controller/config.rs`: handle `SlowQueryThreshold` by persisting to config
- `app/src/app/session.rs`: add `save_slow_query_threshold()` method
- `app/src/ui/query.rs`: compare `exec_ms` against threshold in `handle_query_finished`; set or clear `slow-query-warning` on `UiState`
- `app/src/ui/event.rs`: clear `slow-query-warning` when a new query starts
- `app/src/ui/app.slint`: add `in-out property slow-query-warning`, `in-out property slow-query-threshold-ms`, and `callback set-slow-query-threshold-ms` to `UiState`; wire `StatusBar` and `EditorPrefsDialog`
- `app/src/ui/components/status_bar.slint`: add conditional yellow `Text` element for the warning
- `app/src/ui/components/dialogs/editor_prefs_dialog.slint`: add Slow Query segmented-button row (Off / 500ms / 1s / 5s); extend `apply-clicked` callback signature to carry the new value
- `app/src/ui/appearance.rs`: register `on_set_slow_query_threshold_ms` callback
- `app/src/ui/mod.rs`: initialize `slow-query-threshold-ms` from config on startup
- `app/locales/en.yml`, `app/locales/ja.yml`: add `status.slow_query` i18n key
- `app/lang/*/LC_MESSAGES/wellfeather.po`: add translations for `"Slow Query"`, `"500ms"`, `"1s"`, `"5s"` in `EditorPrefsDialog` context

## Related Issues

Closes #68

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes