### PR TITLE
feat(ui): expand EditorPrefsDialog into unified settings panel

### DIFF
--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -77,14 +77,6 @@ msgid "Cancel (Esc)"
 msgstr "Cancel (Esc)"
 
 msgctxt "MenuBar"
-msgid "Settings"
-msgstr "Settings"
-
-msgctxt "MenuBar"
-msgid "Font Settings (coming soon)"
-msgstr "Font Settings (coming soon)"
-
-msgctxt "MenuBar"
 msgid "Database"
 msgstr "Database"
 
@@ -95,14 +87,6 @@ msgstr "Manage Connections…"
 msgctxt "MenuBar"
 msgid "Disconnect"
 msgstr "Disconnect"
-
-msgctxt "MenuBar"
-msgid "English"
-msgstr "English"
-
-msgctxt "MenuBar"
-msgid "Japanese"
-msgstr "Japanese"
 
 msgctxt "Sidebar"
 msgid "Schema"
@@ -373,10 +357,6 @@ msgid "Execute"
 msgstr "Execute"
 
 
-msgctxt "MenuBar"
-msgid "Reduce Motion"
-msgstr "Reduce Motion"
-
 msgctxt "FindReplaceBar"
 msgid "No results"
 msgstr "No results"
@@ -450,6 +430,62 @@ msgid "Editor Preferences"
 msgstr "Editor Preferences"
 
 msgctxt "EditorPrefsDialog"
+msgid "Appearance"
+msgstr "Appearance"
+
+msgctxt "EditorPrefsDialog"
+msgid "Font Family"
+msgstr "Font Family"
+
+msgctxt "EditorPrefsDialog"
+msgid "Font Size"
+msgstr "Font Size"
+
+msgctxt "EditorPrefsDialog"
+msgid "12"
+msgstr "12"
+
+msgctxt "EditorPrefsDialog"
+msgid "14"
+msgstr "14"
+
+msgctxt "EditorPrefsDialog"
+msgid "16"
+msgstr "16"
+
+msgctxt "EditorPrefsDialog"
+msgid "18"
+msgstr "18"
+
+msgctxt "EditorPrefsDialog"
+msgid "20"
+msgstr "20"
+
+msgctxt "EditorPrefsDialog"
+msgid "Theme"
+msgstr "Theme"
+
+msgctxt "EditorPrefsDialog"
+msgid "Dark"
+msgstr "Dark"
+
+msgctxt "EditorPrefsDialog"
+msgid "Light"
+msgstr "Light"
+
+msgctxt "EditorPrefsDialog"
+msgid "Reduce Motion"
+msgstr "Reduce Motion"
+
+msgctxt "EditorPrefsDialog"
+msgid "On"
+msgstr "On"
+
+msgctxt "EditorPrefsDialog"
+msgid "Editor"
+msgstr "Editor"
+
+msgctxt "EditorPrefsDialog"
 msgid "Tab Width"
 msgstr "Tab Width"
 
@@ -476,6 +512,38 @@ msgstr "Query Timeout"
 msgctxt "EditorPrefsDialog"
 msgid "Off"
 msgstr "Off"
+
+msgctxt "EditorPrefsDialog"
+msgid "10s"
+msgstr "10s"
+
+msgctxt "EditorPrefsDialog"
+msgid "30s"
+msgstr "30s"
+
+msgctxt "EditorPrefsDialog"
+msgid "60s"
+msgstr "60s"
+
+msgctxt "EditorPrefsDialog"
+msgid "General"
+msgstr "General"
+
+msgctxt "EditorPrefsDialog"
+msgid "Language"
+msgstr "Language"
+
+msgctxt "EditorPrefsDialog"
+msgid "EN"
+msgstr "EN"
+
+msgctxt "EditorPrefsDialog"
+msgid "JA"
+msgstr "JA"
+
+msgctxt "EditorPrefsDialog"
+msgid "Language change takes effect immediately"
+msgstr "Language change takes effect immediately"
 
 msgctxt "EditorPrefsDialog"
 msgid "Cancel"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -77,14 +77,6 @@ msgid "Cancel (Esc)"
 msgstr "キャンセル (Esc)"
 
 msgctxt "MenuBar"
-msgid "Settings"
-msgstr "設定"
-
-msgctxt "MenuBar"
-msgid "Font Settings (coming soon)"
-msgstr "フォント設定（近日公開）"
-
-msgctxt "MenuBar"
 msgid "Database"
 msgstr "データベース"
 
@@ -95,14 +87,6 @@ msgstr "接続の管理…"
 msgctxt "MenuBar"
 msgid "Disconnect"
 msgstr "切断"
-
-msgctxt "MenuBar"
-msgid "English"
-msgstr "English"
-
-msgctxt "MenuBar"
-msgid "Japanese"
-msgstr "日本語"
 
 msgctxt "Sidebar"
 msgid "Schema"
@@ -373,10 +357,6 @@ msgid "Execute"
 msgstr "実行"
 
 
-msgctxt "MenuBar"
-msgid "Reduce Motion"
-msgstr "モーション軽減"
-
 msgctxt "FindReplaceBar"
 msgid "No results"
 msgstr "一致なし"
@@ -450,6 +430,62 @@ msgid "Editor Preferences"
 msgstr "エディター設定"
 
 msgctxt "EditorPrefsDialog"
+msgid "Appearance"
+msgstr "外観"
+
+msgctxt "EditorPrefsDialog"
+msgid "Font Family"
+msgstr "フォント"
+
+msgctxt "EditorPrefsDialog"
+msgid "Font Size"
+msgstr "フォントサイズ"
+
+msgctxt "EditorPrefsDialog"
+msgid "12"
+msgstr "12"
+
+msgctxt "EditorPrefsDialog"
+msgid "14"
+msgstr "14"
+
+msgctxt "EditorPrefsDialog"
+msgid "16"
+msgstr "16"
+
+msgctxt "EditorPrefsDialog"
+msgid "18"
+msgstr "18"
+
+msgctxt "EditorPrefsDialog"
+msgid "20"
+msgstr "20"
+
+msgctxt "EditorPrefsDialog"
+msgid "Theme"
+msgstr "テーマ"
+
+msgctxt "EditorPrefsDialog"
+msgid "Dark"
+msgstr "ダーク"
+
+msgctxt "EditorPrefsDialog"
+msgid "Light"
+msgstr "ライト"
+
+msgctxt "EditorPrefsDialog"
+msgid "Reduce Motion"
+msgstr "モーション軽減"
+
+msgctxt "EditorPrefsDialog"
+msgid "On"
+msgstr "オン"
+
+msgctxt "EditorPrefsDialog"
+msgid "Editor"
+msgstr "エディター"
+
+msgctxt "EditorPrefsDialog"
 msgid "Tab Width"
 msgstr "タブ幅"
 
@@ -476,6 +512,38 @@ msgstr "クエリタイムアウト"
 msgctxt "EditorPrefsDialog"
 msgid "Off"
 msgstr "オフ"
+
+msgctxt "EditorPrefsDialog"
+msgid "10s"
+msgstr "10秒"
+
+msgctxt "EditorPrefsDialog"
+msgid "30s"
+msgstr "30秒"
+
+msgctxt "EditorPrefsDialog"
+msgid "60s"
+msgstr "60秒"
+
+msgctxt "EditorPrefsDialog"
+msgid "General"
+msgstr "一般"
+
+msgctxt "EditorPrefsDialog"
+msgid "Language"
+msgstr "言語"
+
+msgctxt "EditorPrefsDialog"
+msgid "EN"
+msgstr "英語"
+
+msgctxt "EditorPrefsDialog"
+msgid "JA"
+msgstr "日本語"
+
+msgctxt "EditorPrefsDialog"
+msgid "Language change takes effect immediately"
+msgstr "言語の変更はすぐに反映されます"
 
 msgctxt "EditorPrefsDialog"
 msgid "Cancel"

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -20,6 +20,10 @@ pub enum ConfigUpdate {
     QueryTimeout(u64),
     /// Set the slow query warning threshold (milliseconds; 0 = disabled).
     SlowQueryThreshold(u64),
+    /// Set the editor font family name.
+    FontFamily(String),
+    /// Set the editor font size in logical pixels.
+    FontSize(u32),
 }
 
 /// UI → Controller channel messages.

--- a/app/src/app/controller/config.rs
+++ b/app/src/app/controller/config.rs
@@ -75,6 +75,16 @@ impl AppController {
                     warn!(error = %e, "failed to persist slow_query_threshold_ms to config");
                 }
             }
+            ConfigUpdate::FontFamily(family) => {
+                if let Err(e) = self.session.save_font_family(&family) {
+                    warn!(error = %e, "failed to persist font_family to config");
+                }
+            }
+            ConfigUpdate::FontSize(size) => {
+                if let Err(e) = self.session.save_font_size(size) {
+                    warn!(error = %e, "failed to persist font_size to config");
+                }
+            }
         }
     }
 }

--- a/app/src/app/session.rs
+++ b/app/src/app/session.rs
@@ -153,6 +153,32 @@ impl SessionManager {
         Ok(())
     }
 
+    pub fn save_font_family(&self, family: &str) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for font_family save")?;
+        config.appearance.font_family = family.to_string();
+        self.config_manager
+            .save(&config)
+            .context("failed to save font_family")?;
+        info!(%family, "font_family saved");
+        Ok(())
+    }
+
+    pub fn save_font_size(&self, size: u32) -> anyhow::Result<()> {
+        let mut config = self
+            .config_manager
+            .load()
+            .context("failed to load config for font_size save")?;
+        config.appearance.font_size = size;
+        self.config_manager
+            .save(&config)
+            .context("failed to save font_size")?;
+        info!(font_size = size, "font_size saved");
+        Ok(())
+    }
+
     /// Persist `ms` as `[editor].slow_query_threshold_ms` in `config.toml`.
     pub fn save_slow_query_threshold(&self, ms: u64) -> anyhow::Result<()> {
         let mut config = self
@@ -331,6 +357,34 @@ mod tests {
 
     use super::{SessionManager, config_to_db_conn, db_to_config_conn};
     use wf_config::models::{ConnectionConfig, DbTypeName};
+
+    #[test]
+    fn save_font_family_should_persist_to_config() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_font_family("Fira Code").unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        assert_eq!(cfg.appearance.font_family, "Fira Code");
+    }
+
+    #[test]
+    fn save_font_size_should_persist_to_config() {
+        let dir = tempdir().unwrap();
+        let sm = SessionManager::with_config_manager(ConfigManager::with_path(
+            dir.path().join("config.toml"),
+        ));
+        sm.save_font_size(18).unwrap();
+
+        let cfg = ConfigManager::with_path(dir.path().join("config.toml"))
+            .load()
+            .unwrap();
+        assert_eq!(cfg.appearance.font_size, 18);
+    }
 
     #[test]
     fn save_tab_width_should_persist_to_config() {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -54,6 +54,10 @@ export global UiState {
     in-out property <string> font-family: "JetBrains Mono";
     in-out property <int>    font-size:   14;  // logical pixels
     in-out property <string> ui-font:     "Segoe UI"; // platform system UI font, set at startup
+    /// Persist a new font family; Rust sends Command::UpdateConfig.
+    callback set-font-family(string);
+    /// Persist a new font size; Rust sends Command::UpdateConfig.
+    callback set-font-size(int);
 
     // ── Editor state ──────────────────────────────────────────────────────────
     in-out property <string> editor-text: "";
@@ -773,23 +777,19 @@ export component AppWindow inherits Window {
             y: 0;
             width:        root.width;
             editor-text:  UiState.editor-text;
-            language:     UiState.language;
             has-active-connection: UiState.active-connection-id != "";
-            reduce-motion: UiState.reduce-motion;
             export-csv        => { UiState.export-csv(); }
             export-json       => { UiState.export-json(); }
             export-insert-sql => { UiState.export-insert-sql(); }
-            quit         => { UiState.quit(); }
-            toggle-theme          => { UiState.toggle-theme(); }
-            toggle-reduce-motion  => { UiState.toggle-reduce-motion(); }
-            open-db-manager  => { UiState.open-db-manager(); }
-            disconnect       => { UiState.disconnect(UiState.active-connection-id); }
-            run-query(sql) => { UiState.run-query(sql); }
-            run-all(sql)   => { UiState.run-all(sql); }
-            cancel-query   => { UiState.cancel-query(); }
-            set-language(lang) => { UiState.set-language(lang); }
-            add-snippet      => { UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos); }
-            show-snippets    => { UiState.show-snippet-list = true; }
+            quit              => { UiState.quit(); }
+            toggle-theme      => { UiState.toggle-theme(); }
+            open-db-manager   => { UiState.open-db-manager(); }
+            disconnect        => { UiState.disconnect(UiState.active-connection-id); }
+            run-query(sql)    => { UiState.run-query(sql); }
+            run-all(sql)      => { UiState.run-all(sql); }
+            cancel-query      => { UiState.cancel-query(); }
+            add-snippet       => { UiState.open-snippet-save(editor-inst.anchor-pos, editor-inst.cursor-pos); }
+            show-snippets     => { UiState.show-snippet-list = true; }
             open-editor-prefs => { UiState.show-editor-prefs = true; }
         }
 
@@ -1441,14 +1441,26 @@ export component AppWindow inherits Window {
             tab-width:               UiState.tab-width;
             query-timeout-secs:      UiState.query-timeout-secs;
             slow-query-threshold-ms: UiState.slow-query-threshold-ms;
+            font-family:             UiState.font-family;
+            font-size:               UiState.font-size;
+            is-dark:                 UiState.is-dark;
+            reduce-motion:           UiState.reduce-motion;
+            language:                UiState.language;
             cancel-clicked => { UiState.show-editor-prefs = false; }
-            apply-clicked(w, t, s) => {
+            toggle-theme => { UiState.toggle-theme(); }
+            toggle-reduce-motion => { UiState.toggle-reduce-motion(); }
+            apply-clicked(w, t, s, fam, sz, lang) => {
                 UiState.tab-width = w;
                 UiState.set-tab-width(w);
                 UiState.query-timeout-secs = t;
                 UiState.set-query-timeout-secs(t);
                 UiState.slow-query-threshold-ms = s;
                 UiState.set-slow-query-threshold-ms(s);
+                UiState.font-family = fam;
+                UiState.set-font-family(fam);
+                UiState.font-size = sz;
+                UiState.set-font-size(sz);
+                UiState.set-language(lang);
                 UiState.show-editor-prefs = false;
             }
             exited => { _editor-prefs-alive = false; }

--- a/app/src/ui/appearance.rs
+++ b/app/src/ui/appearance.rs
@@ -234,10 +234,30 @@ pub(super) fn register_editor_prefs_callbacks(
         });
     }
 
-    ui.on_set_slow_query_threshold_ms(move |ms| {
+    {
+        let tx_cmd = tx_cmd.clone(); // clone required: on_set_slow_query_threshold_ms closure
+        ui.on_set_slow_query_threshold_ms(move |ms| {
+            send_cmd(
+                &tx_cmd,
+                Command::UpdateConfig(ConfigUpdate::SlowQueryThreshold(ms.max(0) as u64)),
+            );
+        });
+    }
+
+    {
+        let tx_cmd = tx_cmd.clone(); // clone required: on_set_font_family closure
+        ui.on_set_font_family(move |family| {
+            send_cmd(
+                &tx_cmd,
+                Command::UpdateConfig(ConfigUpdate::FontFamily(family.to_string())),
+            );
+        });
+    }
+
+    ui.on_set_font_size(move |size| {
         send_cmd(
             &tx_cmd,
-            Command::UpdateConfig(ConfigUpdate::SlowQueryThreshold(ms.max(0) as u64)),
+            Command::UpdateConfig(ConfigUpdate::FontSize(size.max(1) as u32)),
         );
     });
 }

--- a/app/src/ui/components/dialogs/editor_prefs_dialog.slint
+++ b/app/src/ui/components/dialogs/editor_prefs_dialog.slint
@@ -3,12 +3,19 @@ import { ActionButton, ModalOverlay } from "../common.slint";
 
 export component EditorPrefsDialog inherits ModalOverlay {
     callback cancel-clicked;
-    // tab-width, query-timeout-secs, slow-query-threshold-ms
-    callback apply-clicked(int, int, int);
+    callback toggle-theme();
+    callback toggle-reduce-motion();
+    // tab-width, query-timeout-secs, slow-query-threshold-ms, font-family, font-size, language
+    callback apply-clicked(int, int, int, string, int, string);
 
-    in-out property <int> tab-width: 2;
-    in-out property <int> query-timeout-secs: 0;
-    in-out property <int> slow-query-threshold-ms: 0;
+    in-out property <int>    tab-width: 2;
+    in-out property <int>    query-timeout-secs: 0;
+    in-out property <int>    slow-query-threshold-ms: 0;
+    in-out property <string> font-family: "JetBrains Mono";
+    in-out property <int>    font-size: 14;
+    in property <bool>       is-dark: false;
+    in property <bool>       reduce-motion: false;
+    in-out property <string> language: "en";
 
     VerticalLayout {
         padding: Layout.padding-2xl;
@@ -20,6 +27,262 @@ export component EditorPrefsDialog inherits ModalOverlay {
             color: Colors.text;
             font-size: Typography.size-xl;
             font-weight: 700;
+        }
+
+        // ── Appearance ────────────────────────────────────────────────────────
+        Text {
+            text: @tr("Appearance");
+            color: Colors.subtext1;
+            font-size: Typography.size-base;
+            font-weight: 600;
+        }
+
+        // Font Family row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Font Family");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            Rectangle {
+                width: 130px;
+                height: 28px;
+                border-radius: 4px;
+                border-width: 1px;
+                border-color: Colors.surface2;
+                background: Colors.surface1;
+
+                TextInput {
+                    x: 6px;
+                    width: parent.width - 12px;
+                    height: parent.height;
+                    text <=> root.font-family;
+                    color: Colors.text;
+                    font-size: Typography.size-sm;
+                    vertical-alignment: center;
+                }
+            }
+        }
+
+        // Font Size row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Font Size");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                fs12 := Rectangle {
+                    width: 36px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.font-size == 12 ? Colors.blue : Colors.surface2;
+                    background: root.font-size == 12 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("12");
+                        color: root.font-size == 12 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.font-size = 12; } }
+                }
+
+                fs14 := Rectangle {
+                    width: 36px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.font-size == 14 ? Colors.blue : Colors.surface2;
+                    background: root.font-size == 14 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("14");
+                        color: root.font-size == 14 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.font-size = 14; } }
+                }
+
+                fs16 := Rectangle {
+                    width: 36px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.font-size == 16 ? Colors.blue : Colors.surface2;
+                    background: root.font-size == 16 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("16");
+                        color: root.font-size == 16 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.font-size = 16; } }
+                }
+
+                fs18 := Rectangle {
+                    width: 36px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.font-size == 18 ? Colors.blue : Colors.surface2;
+                    background: root.font-size == 18 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("18");
+                        color: root.font-size == 18 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.font-size = 18; } }
+                }
+
+                fs20 := Rectangle {
+                    width: 36px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.font-size == 20 ? Colors.blue : Colors.surface2;
+                    background: root.font-size == 20 ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("20");
+                        color: root.font-size == 20 ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.font-size = 20; } }
+                }
+            }
+        }
+
+        // Theme row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Theme");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                th-dark := Rectangle {
+                    width: 52px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.is-dark ? Colors.blue : Colors.surface2;
+                    background: root.is-dark ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("Dark");
+                        color: root.is-dark ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { if (!root.is-dark) { root.toggle-theme(); } } }
+                }
+
+                th-light := Rectangle {
+                    width: 52px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: !root.is-dark ? Colors.blue : Colors.surface2;
+                    background: !root.is-dark ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("Light");
+                        color: !root.is-dark ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { if (root.is-dark) { root.toggle-theme(); } } }
+                }
+            }
+        }
+
+        // Reduce Motion row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Reduce Motion");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                rm-on := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.reduce-motion ? Colors.blue : Colors.surface2;
+                    background: root.reduce-motion ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("On");
+                        color: root.reduce-motion ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { if (!root.reduce-motion) { root.toggle-reduce-motion(); } } }
+                }
+
+                rm-off := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: !root.reduce-motion ? Colors.blue : Colors.surface2;
+                    background: !root.reduce-motion ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("Off");
+                        color: !root.reduce-motion ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { if (root.reduce-motion) { root.toggle-reduce-motion(); } } }
+                }
+            }
+        }
+
+        // ── Editor ────────────────────────────────────────────────────────────
+        Text {
+            text: @tr("Editor");
+            color: Colors.subtext1;
+            font-size: Typography.size-base;
+            font-weight: 600;
         }
 
         // Tab-width selector row
@@ -35,7 +298,6 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 width: 90px;
             }
 
-            // Three segmented buttons: 2 / 4 / 8
             HorizontalLayout {
                 spacing: Layout.spacing-sm;
 
@@ -105,7 +367,6 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 width: 90px;
             }
 
-            // Four segmented buttons: Off / 500ms / 1s / 5s
             HorizontalLayout {
                 spacing: Layout.spacing-sm;
 
@@ -192,7 +453,6 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 width: 90px;
             }
 
-            // Four segmented buttons: Off / 10s / 30s / 60s
             HorizontalLayout {
                 spacing: Layout.spacing-sm;
 
@@ -221,7 +481,7 @@ export component EditorPrefsDialog inherits ModalOverlay {
                     border-color: root.query-timeout-secs == 10 ? Colors.blue : Colors.surface2;
                     background: root.query-timeout-secs == 10 ? Colors.blue : Colors.surface1;
                     Text {
-                        text: "10s";
+                        text: @tr("10s");
                         color: root.query-timeout-secs == 10 ? Colors.base : Colors.text;
                         font-size: Typography.size-sm;
                         horizontal-alignment: center;
@@ -238,7 +498,7 @@ export component EditorPrefsDialog inherits ModalOverlay {
                     border-color: root.query-timeout-secs == 30 ? Colors.blue : Colors.surface2;
                     background: root.query-timeout-secs == 30 ? Colors.blue : Colors.surface1;
                     Text {
-                        text: "30s";
+                        text: @tr("30s");
                         color: root.query-timeout-secs == 30 ? Colors.base : Colors.text;
                         font-size: Typography.size-sm;
                         horizontal-alignment: center;
@@ -255,7 +515,7 @@ export component EditorPrefsDialog inherits ModalOverlay {
                     border-color: root.query-timeout-secs == 60 ? Colors.blue : Colors.surface2;
                     background: root.query-timeout-secs == 60 ? Colors.blue : Colors.surface1;
                     Text {
-                        text: "60s";
+                        text: @tr("60s");
                         color: root.query-timeout-secs == 60 ? Colors.base : Colors.text;
                         font-size: Typography.size-sm;
                         horizontal-alignment: center;
@@ -264,6 +524,72 @@ export component EditorPrefsDialog inherits ModalOverlay {
                     TouchArea { clicked => { root.query-timeout-secs = 60; } }
                 }
             }
+        }
+
+        // ── General ───────────────────────────────────────────────────────────
+        Text {
+            text: @tr("General");
+            color: Colors.subtext1;
+            font-size: Typography.size-base;
+            font-weight: 600;
+        }
+
+        // Language row
+        HorizontalLayout {
+            spacing: Layout.spacing-lg;
+            alignment: start;
+
+            Text {
+                text: @tr("Language");
+                color: Colors.subtext1;
+                font-size: Typography.size-base;
+                vertical-alignment: center;
+                width: 90px;
+            }
+
+            HorizontalLayout {
+                spacing: Layout.spacing-sm;
+
+                lang-en := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.language == "en" ? Colors.blue : Colors.surface2;
+                    background: root.language == "en" ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("EN");
+                        color: root.language == "en" ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.language = "en"; } }
+                }
+
+                lang-ja := Rectangle {
+                    width: 44px;
+                    height: 28px;
+                    border-radius: 4px;
+                    border-width: 1px;
+                    border-color: root.language == "ja" ? Colors.blue : Colors.surface2;
+                    background: root.language == "ja" ? Colors.blue : Colors.surface1;
+                    Text {
+                        text: @tr("JA");
+                        color: root.language == "ja" ? Colors.base : Colors.text;
+                        font-size: Typography.size-sm;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    TouchArea { clicked => { root.language = "ja"; } }
+                }
+            }
+        }
+
+        Text {
+            text: @tr("Language change takes effect immediately");
+            color: Colors.subtext1;
+            font-size: Typography.size-sm;
         }
 
         HorizontalLayout {
@@ -279,7 +605,16 @@ export component EditorPrefsDialog inherits ModalOverlay {
                 text: @tr("Apply");
                 bg: Colors.blue;
                 fg: Colors.base;
-                clicked => { root.apply-clicked(root.tab-width, root.query-timeout-secs, root.slow-query-threshold-ms); }
+                clicked => {
+                    root.apply-clicked(
+                        root.tab-width,
+                        root.query-timeout-secs,
+                        root.slow-query-threshold-ms,
+                        root.font-family,
+                        root.font-size,
+                        root.language,
+                    );
+                }
             }
         }
     }

--- a/app/src/ui/components/menu_bar.slint
+++ b/app/src/ui/components/menu_bar.slint
@@ -1,4 +1,4 @@
-// Custom menu bar — horizontal strip of top-level menus (File / Edit / Query / Settings).
+// Custom menu bar — horizontal strip of top-level menus (File / Edit / Database / Snippets / Query).
 // Each top-level label shows a PopupWindow dropdown on click.
 // Items reuse MenuItem from common.slint.
 
@@ -14,20 +14,16 @@ export component MenuBar inherits Rectangle {
     callback export-insert-sql();
     callback quit();
     callback toggle-theme();
-    callback toggle-reduce-motion();
     callback open-db-manager();
     callback disconnect();
     callback run-query(string);
     callback run-all(string);
     callback cancel-query();
-    callback set-language(string);
     callback add-snippet();
     callback show-snippets();
     callback open-editor-prefs();
     in property <string> editor-text;
-    in property <string> language: "en";
     in property <bool>   has-active-connection: false;
-    in property <bool>   reduce-motion: false;
 
     // Bottom border separating menu bar from content area
     Rectangle {
@@ -297,63 +293,5 @@ export component MenuBar inherits Rectangle {
             }
         }
 
-        // ── Settings ──────────────────────────────────────────────────────────
-        Rectangle {
-            width: 80px;
-            background: settings-ta.has-hover ? Colors.surface1 : transparent;
-            border-radius: Layout.radius-sm;
-
-            Text {
-                text: @tr("Settings");
-                color: Colors.text;
-                font-size:   Typography.size-base;
-                horizontal-alignment: center;
-                vertical-alignment:   center;
-            }
-            settings-ta := TouchArea {
-                clicked => { settings-popup.show(); }
-            }
-            settings-popup := PopupWindow {
-                x: 0;
-                y: root.height;
-                width:  220px;
-                height: 5 * Layout.height-menu-item + 2px;
-                close-policy: PopupClosePolicy.close-on-click;
-
-                Rectangle {
-                    width:  220px;
-                    height: 5 * Layout.height-menu-item + 2px;
-                    background:    Colors.surface0;
-                    border-radius: Layout.radius-md;
-                    border-width:  1px;
-                    border-color:  Colors.surface2;
-                    drop-shadow-blur:  8px;
-                    drop-shadow-color: Colors.shadow;
-                    clip: true;
-
-                    VerticalLayout {
-                        spacing: 0;
-                        MenuItem { text: @tr("Font Settings (coming soon)"); }
-                        Rectangle { height: 1px; background: Colors.surface1; }
-                        MenuItem {
-                            text: @tr("Reduce Motion");
-                            selected: root.reduce-motion;
-                            clicked => { root.toggle-reduce-motion(); }
-                        }
-                        Rectangle { height: 1px; background: Colors.surface1; }
-                        MenuItem {
-                            text: @tr("English");
-                            selected: root.language == "en";
-                            clicked => { root.set-language("en"); }
-                        }
-                        MenuItem {
-                            text: @tr("Japanese");
-                            selected: root.language == "ja";
-                            clicked => { root.set-language("ja"); }
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary

Expands the Editor Preferences dialog into a full settings panel with three sections — Appearance, Editor, and General — eliminating the need for users to manually edit `config.toml` to change font or theme settings. The standalone Settings menu entry is removed from the menu bar; all settings now live in one place.

## Changes

- **Editor Preferences dialog** (`editor_prefs_dialog.slint`): added Appearance section (font family free-text input, font size segmented buttons 12–20, theme Dark/Light toggle, Reduce Motion toggle), section header labels, General section (language EN/JA segmented buttons with immediate-effect note); `apply-clicked` callback expanded from 3 to 6 params
- **`app.slint`**: wired new `font-family`, `font-size`, `is-dark`, `reduce-motion`, `language` property bindings and `toggle-theme`/`toggle-reduce-motion`/`set-font-family`/`set-font-size` callbacks on the dialog instance
- **`menu_bar.slint`**: removed the Settings top-level menu (font settings, reduce motion, language items); kept Edit → Editor Preferences…
- **`command.rs`**: added `ConfigUpdate::FontFamily(String)` and `ConfigUpdate::FontSize(u32)` variants
- **`session.rs`**: added `save_font_family` and `save_font_size` with unit tests
- **`controller/config.rs`**: added match arms for the two new `ConfigUpdate` variants
- **`appearance.rs`**: registered `on_set_font_family` and `on_set_font_size` callbacks
- **PO files** (en + ja): added all new i18n keys; removed dead MenuBar-context entries that belonged to the deleted Settings menu; fixed missing `@tr()` wrapping for `10s`/`30s`/`60s`

## Related Issues

Closes #85

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes