### PR TITLE
fix(app): suppress ICU4X segmentation warning in Japanese mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,7 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "log",
  "serde",
  "stable_deref_trait",
  "writeable",
@@ -6288,6 +6289,7 @@ dependencies = [
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
  "i-slint-renderer-software",
+ "log",
  "num-traits",
  "once_cell",
  "pin-weak",
@@ -7978,6 +7980,7 @@ dependencies = [
  "chrono",
  "directories",
  "fuzzy-matcher",
+ "icu_provider",
  "regex",
  "rfd",
  "rust-i18n",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace  = true
 license.workspace  = true
 
 [dependencies]
-slint              = "1.15.1"
+slint              = { version = "1.15.1", features = ["log"] }
+icu_provider       = { version = "2.2", features = ["logging"] }
 wf-db              = { path = "../crates/wf-db" }
 wf-config          = { path = "../crates/wf-config" }
 wf-query           = { path = "../crates/wf-query" }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -47,8 +47,16 @@ use wf_history::{
 /// Entry point. Runs on the main OS thread; the Slint event loop must stay here.
 fn main() -> anyhow::Result<()> {
     // Initialise tracing first so that enable_dpi_awareness() can log warnings.
+    // tracing-subscriber's fmt().init() installs the log→tracing bridge internally;
+    // suppress noisy ICU4X locale-data warnings from Slint internals with explicit
+    // directives (override with RUST_LOG=i_slint_core=warn if you need them).
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("i_slint_core=error".parse().unwrap())
+                .add_directive("icu_segmenter=error".parse().unwrap())
+                .add_directive("icu_provider=error".parse().unwrap()),
+        )
         .init();
 
     // Enable per-monitor DPI awareness before any window is created (Windows only;


### PR DESCRIPTION
## Summary

In debug builds, `icu_provider` routes `log::warn!()` to `std::eprintln` when its
`logging` Cargo feature is disabled, bypassing the tracing/EnvFilter pipeline
entirely. This caused "ICU4X data error: No segmentation model for language: ja"
to flood stderr on every mouse-move over a TextInput when the app language is
set to Japanese.

## Changes

- `app/Cargo.toml`: enable `logging` feature on `icu_provider` so its internal
  warnings flow through the `log` crate instead of `eprintln`; enable `log`
  feature on `slint` for the same reason
- `app/src/main.rs`: add `EnvFilter` directives `icu_provider=error`,
  `i_slint_core=error`, and `icu_segmenter=error` to suppress warn-level noise
  from Slint/ICU4X internals; the messages remain visible via `RUST_LOG=icu_provider=warn`

## Related Issues

Fixes #333

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes