### PR TITLE
feat(query): parameterized query :name placeholder detection and input dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6011,9 +6011,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -7985,6 +7985,7 @@ dependencies = [
  "rfd",
  "rust-i18n",
  "serde",
+ "serde_json",
  "slint",
  "slint-build",
  "sqlx",
@@ -8068,6 +8069,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8073,6 +8073,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
  "wf-db",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ authors = ["itsakeyfut"]
 tokio         = { version = "1.50.0", features = ["full"] }
 tokio-util    = "0.7.18"
 serde         = { version = "1.0.228", features = ["derive"] }
+serde_json    = "1.0.150"
 anyhow        = "1.0.102"
 thiserror     = "2.0.18"
 tracing       = "0.1.44"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,6 +30,7 @@ zeroize            = "1"
 fuzzy-matcher      = "0.3.7"
 directories        = "6.0.0"
 thiserror          = { workspace = true }
+serde_json         = "1.0.150"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_UI_HiDpi"] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,7 +30,7 @@ zeroize            = "1"
 fuzzy-matcher      = "0.3.7"
 directories        = "6.0.0"
 thiserror          = { workspace = true }
-serde_json         = "1.0.150"
+serde_json         = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_UI_HiDpi"] }

--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -26,6 +26,16 @@ pub enum ConfigUpdate {
     FontSize(u32),
 }
 
+/// A single parameter value submitted from the param-input dialog.
+#[derive(Debug)]
+pub struct ParamValue {
+    pub name: String,
+    /// 0=String, 1=Number, 2=Date, 3=Bool
+    pub type_idx: i32,
+    /// Raw user input (not yet formatted for SQL).
+    pub value: String,
+}
+
 /// UI → Controller channel messages.
 #[derive(Debug)]
 pub enum Command {
@@ -41,6 +51,12 @@ pub enum Command {
     RemoveConnection(String), // connection_id — disconnect + delete from config
     RunQuery(String),         // sql
     RunAll(String),           // sql (entire editor)
+    /// Run a parameterized query after the user has supplied values in the dialog.
+    RunQueryWithParams {
+        /// Original SQL with `:name` placeholders.
+        sql: String,
+        params: Vec<ParamValue>,
+    },
     CancelQuery,
     FetchCompletion(String, usize), // sql, cursor_pos
     UpdateConfig(ConfigUpdate),
@@ -109,6 +125,7 @@ impl Command {
             Self::RemoveConnection(..) => "RemoveConnection",
             Self::RunQuery(..) => "RunQuery",
             Self::RunAll(..) => "RunAll",
+            Self::RunQueryWithParams { .. } => "RunQueryWithParams",
             Self::CancelQuery => "CancelQuery",
             Self::FetchCompletion(..) => "FetchCompletion",
             Self::UpdateConfig(..) => "UpdateConfig",

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -120,6 +120,9 @@ impl AppController {
                 Command::RemoveConnection(id) => this.handle_remove_connection(id).await,
                 Command::RunQuery(sql) => this.handle_run_query(sql).await,
                 Command::RunAll(sql) => this.handle_run_all(sql).await,
+                Command::RunQueryWithParams { sql, params } => {
+                    this.handle_run_query_with_params(sql, params).await
+                }
                 Command::CancelQuery => this.handle_cancel_query().await,
                 Command::UpdateConfig(update) => this.handle_update_config(update).await,
                 Command::FetchCompletion(sql, cursor_pos) => {

--- a/app/src/app/controller/history.rs
+++ b/app/src/app/controller/history.rs
@@ -77,6 +77,7 @@ mod tests {
             error_message: None,
             timestamp: ts,
             connection_id: "c1".to_string(),
+            params_json: None,
         }
     }
 

--- a/app/src/app/controller/query.rs
+++ b/app/src/app/controller/query.rs
@@ -261,6 +261,10 @@ impl AppController {
     /// Splits the SQL on semicolons and executes each non-empty statement
     /// sequentially using a single cancellation token.  Only the result of the
     /// last statement is surfaced to the UI so the result panel is not spammed.
+    ///
+    /// `:name` placeholder detection is intentionally skipped here — RunAll is
+    /// a bulk-execution path and mixing parameterized dialogs with multi-statement
+    /// runs would be ambiguous (each statement could reference different params).
     pub(super) async fn handle_run_all(&self, sql: String) {
         self.state.query.cancel();
 
@@ -405,15 +409,16 @@ impl AppController {
 
 fn format_param_value(type_idx: i32, value: &str) -> String {
     match type_idx {
-        1 => value.to_string(),
-        2 => format!("'{value}'"),
+        1 => value.to_string(),    // Number — validated f64, safe to emit as-is
+        2 => format!("'{value}'"), // Date   — validated YYYY-MM-DD, no injection risk
         3 => {
+            // Bool — normalize to SQL literal regardless of input casing
             if value.eq_ignore_ascii_case("true") {
                 "TRUE".to_string()
             } else {
                 "FALSE".to_string()
             }
         }
-        _ => format!("'{}'", value.replace('\'', "''")),
+        _ => format!("'{}'", value.replace('\'', "''")), // String — escape embedded single quotes
     }
 }

--- a/app/src/app/controller/query.rs
+++ b/app/src/app/controller/query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -6,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use wf_db::error::DbError;
 
-use crate::app::{LocalizedMessage, event::Event};
+use crate::app::{LocalizedMessage, command::ParamValue, event::Event};
 
 use super::AppController;
 
@@ -40,6 +41,26 @@ impl AppController {
         };
 
         if self.is_read_only_blocked(&conn_id, &sql).await {
+            return;
+        }
+
+        // If the SQL contains :name placeholders, show the param dialog instead.
+        let raw_params = wf_query::params::extract_params(&sql);
+        if !raw_params.is_empty() {
+            let defaults = self
+                .history
+                .find_last_params(&sql)
+                .await
+                .unwrap_or_default()
+                .unwrap_or_default();
+            let _ = self
+                .tx_event
+                .send(Event::ParamDialogRequired {
+                    sql,
+                    params: raw_params,
+                    defaults,
+                })
+                .await;
             return;
         }
 
@@ -87,6 +108,7 @@ impl AppController {
                         error_message: None,
                         timestamp: now,
                         connection_id: conn_id_hist,
+                        params_json: None,
                     };
                     if let Err(e) = history.insert(&exec).await {
                         warn!("failed to save history: {e}");
@@ -108,11 +130,126 @@ impl AppController {
                         error_message: Some(e.to_string()),
                         timestamp: now,
                         connection_id: conn_id_hist,
+                        params_json: None,
                     };
                     if let Err(he) = history.insert(&exec).await {
                         warn!("failed to save history: {he}");
                     }
                     debug!("sending event: QueryError");
+                    let _ = tx.send(Event::QueryError(e.localized_message())).await;
+                }
+            }
+        });
+    }
+
+    /// Handle a `RunQueryWithParams` command.
+    ///
+    /// Formats each parameter value according to its type, substitutes them into
+    /// the SQL template, and executes the resulting query. The original SQL (with
+    /// placeholders) and raw parameter values are stored in history.
+    pub(super) async fn handle_run_query_with_params(&self, sql: String, params: Vec<ParamValue>) {
+        info!("handling RunQueryWithParams command");
+        self.state.query.cancel();
+
+        let conn_id = match self.state.conn.active() {
+            Some(c) => c.id.clone(),
+            None => {
+                warn!("RunQueryWithParams: no active connection");
+                let _ = self
+                    .tx_event
+                    .send(Event::QueryError(
+                        t!("error.no_active_connection").to_string(),
+                    ))
+                    .await;
+                return;
+            }
+        };
+
+        if self.is_read_only_blocked(&conn_id, &sql).await {
+            return;
+        }
+
+        // Build raw-value map (for history) and formatted-value map (for substitution).
+        let mut raw_map: HashMap<String, String> = HashMap::new();
+        let mut formatted_map: HashMap<String, String> = HashMap::new();
+        for p in &params {
+            raw_map.insert(p.name.clone(), p.value.clone());
+            let formatted = format_param_value(p.type_idx, &p.value);
+            formatted_map.insert(p.name.clone(), formatted);
+        }
+
+        let substituted = wf_query::params::substitute_params(&sql, &formatted_map);
+        self.state.query.set_last_sql(sql.clone());
+
+        let token = CancellationToken::new();
+        self.state.query.set_cancel_token(token.clone());
+        debug!("sending event: QueryStarted");
+        let _ = self.tx_event.send(Event::QueryStarted).await;
+
+        let page_size = self.state.ui.page_size();
+        let timeout_secs = self.state.ui.query_timeout_secs();
+        let sql_to_run = super::apply_limit(&substituted, page_size);
+        let params_json = serde_json::to_string(&raw_map).ok();
+
+        let db = self.db.clone(); // clone required: tokio::spawn needs 'static
+        let tx = self.tx_event.clone(); // clone required: tokio::spawn needs 'static
+        let history = self.history.clone(); // clone required: tokio::spawn needs 'static
+        let sql_hist = sql.clone(); // clone required: history record needs original sql
+
+        tokio::spawn(async move {
+            let now = Utc::now().timestamp();
+            let result = if timeout_secs > 0 {
+                match tokio::time::timeout(
+                    Duration::from_secs(timeout_secs),
+                    db.execute_with_cancel(&conn_id, &sql_to_run, token.clone()),
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(_elapsed) => {
+                        token.cancel();
+                        Err(DbError::Timeout)
+                    }
+                }
+            } else {
+                db.execute_with_cancel(&conn_id, &sql_to_run, token).await
+            };
+            match result {
+                Ok(result) => {
+                    let exec = wf_db::models::QueryExecution {
+                        id: 0,
+                        sql: sql_hist,
+                        duration_ms: result.execution_time_ms,
+                        success: true,
+                        error_message: None,
+                        timestamp: now,
+                        connection_id: conn_id.clone(),
+                        params_json,
+                    };
+                    if let Err(e) = history.insert(&exec).await {
+                        warn!("failed to save history: {e}");
+                    }
+                    debug!("sending event: QueryFinished (parameterized)");
+                    let _ = tx.send(Event::QueryFinished(result)).await;
+                }
+                Err(DbError::Cancelled) => {
+                    let _ = tx.send(Event::QueryCancelled).await;
+                }
+                Err(e) => {
+                    error!(error = %e, "parameterized query execution failed");
+                    let exec = wf_db::models::QueryExecution {
+                        id: 0,
+                        sql: sql_hist,
+                        duration_ms: 0,
+                        success: false,
+                        error_message: Some(e.to_string()),
+                        timestamp: now,
+                        connection_id: conn_id.clone(),
+                        params_json: None,
+                    };
+                    if let Err(he) = history.insert(&exec).await {
+                        warn!("failed to save history: {he}");
+                    }
                     let _ = tx.send(Event::QueryError(e.localized_message())).await;
                 }
             }
@@ -203,6 +340,7 @@ impl AppController {
                                 error_message: None,
                                 timestamp: now,
                                 connection_id: conn_id_hist.clone(),
+                                params_json: None,
                             };
                             if let Err(e) = history.insert(&exec).await {
                                 warn!("failed to save history: {e}");
@@ -226,6 +364,7 @@ impl AppController {
                             error_message: Some(e.to_string()),
                             timestamp: now,
                             connection_id: conn_id_hist.clone(),
+                            params_json: None,
                         };
                         if let Err(he) = history.insert(&exec).await {
                             warn!("failed to save history: {he}");
@@ -261,5 +400,20 @@ impl AppController {
             return true;
         }
         false
+    }
+}
+
+fn format_param_value(type_idx: i32, value: &str) -> String {
+    match type_idx {
+        1 => value.to_string(),
+        2 => format!("'{value}'"),
+        3 => {
+            if value.eq_ignore_ascii_case("true") {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        _ => format!("'{}'", value.replace('\'', "''")),
     }
 }

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use tokio::sync::oneshot;
 use wf_completion::CompletionItem;
 use wf_config::models::{ConnectionConfig, GroupConfig, Theme};
@@ -67,6 +69,15 @@ pub enum Event {
     TableDataFailed {
         tab_id: String,
         msg: String,
+    },
+    /// Controller detected `:name` placeholders and needs the user to supply values.
+    /// The UI shows the param dialog; on confirm it sends `Command::RunQueryWithParams`.
+    ParamDialogRequired {
+        sql: String,
+        /// Deduplicated param names in order of first appearance.
+        params: Vec<String>,
+        /// Previously used raw values for the same SQL, keyed by name.
+        defaults: HashMap<String, String>,
     },
     // ── History panel ────────────────────────────────────────────────────────
     HistoryLoaded(Vec<QueryExecution>),

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem, HistoryEntry } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem, HistoryEntry, ParamRow } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -34,6 +34,7 @@ import { HistoryPanel }          from "components/history_panel.slint";
 import { SnippetPalette }        from "components/snippet_palette.slint";
 import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.slint";
 import { FingerprintDialog }    from "components/dialogs/fingerprint_dialog.slint";
+import { ParamDialog }          from "components/dialogs/param_dialog.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -171,6 +172,17 @@ export global UiState {
     in-out property <string> ssh-fingerprint-text:        "";
     callback approve-ssh-fingerprint();
     callback reject-ssh-fingerprint();
+    // ── Parameterized query dialog ────────────────────────────────────────────
+    in-out property <bool>        show-param-dialog: false;
+    in-out property <[ParamRow]>  param-dialog-rows: [];
+    in-out property <bool>        params-all-valid:  true;
+    callback param-value-changed(int, string);
+    callback param-type-changed(int, int);
+    callback confirm-param-dialog();
+    callback cancel-param-dialog();
+    pure callback validate-param-number(string) -> bool;
+    pure callback validate-param-date(string) -> bool;
+    pure callback validate-param-bool(string) -> bool;
     // ── SSH active status ─────────────────────────────────────────────────────
     in-out property <bool>   ssh-active: false;
     // ── SSL/TLS form ──────────────────────────────────────────────────────────
@@ -601,6 +613,10 @@ export component AppWindow inherits Window {
     private property <bool> _fp-dialog-open:  UiState.show-ssh-fingerprint-dialog;
     changed _fp-dialog-open => { if (_fp-dialog-open) { _fp-dialog-alive = true; } }
 
+    private property <bool> _param-dialog-alive: false;
+    private property <bool> _param-dialog-open:  UiState.show-param-dialog;
+    changed _param-dialog-open => { if (_param-dialog-open) { _param-dialog-alive = true; } }
+
     // ── Root key-intercept FocusScope ─────────────────────────────────────────
     // Global shortcuts live in key-pressed (bubble phase) so they fire regardless
     // of which inner FocusScope — editor, table-view, sidebar, result — has focus.
@@ -629,7 +645,8 @@ export component AppWindow inherits Window {
                     || UiState.show-history
                     || UiState.show-editor-prefs
                     || UiState.show-ssh-fingerprint-dialog
-                    || UiState.show-snippet-palette) {
+                    || UiState.show-snippet-palette
+                    || UiState.show-param-dialog) {
                 EventResult.reject
             } else if (event.modifiers.control
                     && !event.modifiers.shift
@@ -1501,6 +1518,20 @@ export component AppWindow inherits Window {
             approve => { UiState.approve-ssh-fingerprint(); }
             reject  => { UiState.reject-ssh-fingerprint(); }
             exited  => { _fp-dialog-alive = false; }
+        }
+
+        // ── Parameterized query dialog ────────────────────────────────────────
+        if _param-dialog-alive: ParamDialog {
+            x: 0; y: 0;
+            width: root.width; height: root.height;
+            show:      UiState.show-param-dialog;
+            rows:      UiState.param-dialog-rows;
+            all-valid: UiState.params-all-valid;
+            value-changed(i, v) => { UiState.param-value-changed(i, v); }
+            type-changed(i, t)  => { UiState.param-type-changed(i, t); }
+            confirm => { UiState.confirm-param-dialog(); }
+            cancel  => { UiState.cancel-param-dialog(); }
+            exited  => { _param-dialog-alive = false; }
         }
 
         // ── Metadata search palette (Ctrl+P) ──────────────────────────────────

--- a/app/src/ui/components/dialogs/param_dialog.slint
+++ b/app/src/ui/components/dialogs/param_dialog.slint
@@ -1,0 +1,166 @@
+import { Colors, Typography, Layout, Animation } from "../../theme.slint";
+import { ActionButton } from "../common.slint";
+import { ParamRow } from "../../globals.slint";
+
+export component ParamDialog inherits Rectangle {
+    background: Colors.modal-overlay;
+
+    in property <bool>       show: true;
+    in property <[ParamRow]> rows;
+    in property <bool>       all-valid: true;
+
+    callback value-changed(int, string);
+    callback type-changed(int, int);
+    callback confirm();
+    callback cancel();
+    callback exited();
+
+    changed show => {
+        if (!show) { root.exited(); }
+    }
+
+    VerticalLayout {
+        alignment: center;
+        HorizontalLayout {
+            alignment: center;
+
+            card := Rectangle {
+                width: 520px;
+                background: Colors.surface0;
+                border-radius: Layout.radius-lg;
+                border-width: 1px;
+                border-color: Colors.surface2;
+                drop-shadow-blur: 20px;
+                drop-shadow-color: Colors.shadow;
+
+                VerticalLayout {
+                    padding: Layout.padding-2xl;
+                    spacing: Layout.spacing-2xl;
+
+                    // Title
+                    Text {
+                        text: @tr("Query Parameters");
+                        color: Colors.text;
+                        font-size: Typography.size-xl;
+                        font-weight: 700;
+                    }
+
+                    // Scrollable rows
+                    Flickable {
+                        height: min(rows-layout.preferred-height, 300px);
+                        viewport-height: rows-layout.preferred-height;
+                        interactive: rows-layout.preferred-height > 300px;
+
+                        rows-layout := VerticalLayout {
+                            spacing: Layout.spacing-md;
+
+                            for row[i] in root.rows: HorizontalLayout {
+                                spacing: Layout.spacing-lg;
+                                height: Layout.height-row;
+
+                                // Param name label
+                                Rectangle {
+                                    width: 120px;
+                                    HorizontalLayout {
+                                        alignment: start;
+                                        padding-top: 6px;
+                                        Text {
+                                            text: ":" + row.name;
+                                            color: Colors.hl-param;
+                                            font-size: Typography.size-base;
+                                            font-family: Typography.font-mono;
+                                            overflow: elide;
+                                        }
+                                    }
+                                }
+
+                                // Type selector (4 small toggle buttons)
+                                HorizontalLayout {
+                                    spacing: 2px;
+                                    width: 148px;
+
+                                    for lbl[t] in [@tr("Str"), @tr("Num"), @tr("Date"), @tr("Bool")]:
+                                    Rectangle {
+                                        width: 34px;
+                                        height: Layout.height-row;
+                                        border-radius: Layout.radius-sm;
+                                        background: row.type-idx == t ? Colors.blue : Colors.surface1;
+
+                                        type-ta := TouchArea {
+                                            clicked => { root.type-changed(i, t); }
+                                        }
+                                        Text {
+                                            text: lbl;
+                                            color: row.type-idx == t ? Colors.base : Colors.subtext0;
+                                            font-size: Typography.size-sm;
+                                            horizontal-alignment: center;
+                                            vertical-alignment: center;
+                                        }
+                                        Rectangle {
+                                            border-radius: parent.border-radius;
+                                            background: Colors.hover-btn;
+                                            opacity: type-ta.has-hover ? 1.0 : 0.0;
+                                            animate opacity { duration: Animation.feedback; easing: Animation.enter-ease; }
+                                        }
+                                    }
+                                }
+
+                                // Value input
+                                input-rect := Rectangle {
+                                    border-radius: Layout.radius-md;
+                                    border-width: 1px;
+                                    border-color: row.is-valid ? Colors.surface2 : Colors.red;
+                                    background: Colors.surface1;
+                                    horizontal-stretch: 1;
+
+                                    TextInput {
+                                        x: Layout.padding-input;
+                                        width: parent.width - 2 * Layout.padding-input;
+                                        height: parent.height;
+                                        color: Colors.text;
+                                        font-size: Typography.size-base;
+                                        vertical-alignment: center;
+                                        single-line: true;
+
+                                        init => { self.text = row.value; }
+                                        edited => { root.value-changed(i, self.text); }
+                                    }
+                                }
+
+                                // Validation indicator dot
+                                if row.type-idx != 0 : Rectangle {
+                                    width: 8px;
+                                    height: 8px;
+                                    y: (parent.height - self.height) / 2;
+                                    border-radius: 4px;
+                                    background: row.is-valid ? Colors.green : Colors.red;
+                                }
+                            }
+                        }
+                    }
+
+                    // Footer buttons
+                    HorizontalLayout {
+                        spacing: Layout.spacing-lg;
+                        alignment: end;
+
+                        ActionButton {
+                            width: 90px;
+                            text: @tr("Cancel");
+                            clicked => { root.cancel(); }
+                        }
+
+                        ActionButton {
+                            width: 90px;
+                            text: @tr("Run");
+                            bg: root.all-valid ? Colors.blue : Colors.surface2;
+                            fg: root.all-valid ? Colors.base : Colors.subtext0;
+                            enabled: root.all-valid;
+                            clicked => { root.confirm(); }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/editor.slint
+++ b/app/src/ui/components/editor.slint
@@ -765,6 +765,7 @@ export component Editor inherits Rectangle {
                      : span.kind == 1 ? Colors.hl-string
                      : span.kind == 2 ? Colors.hl-comment
                      : span.kind == 3 ? Colors.hl-number
+                     : span.kind == 5 ? Colors.hl-param
                      : Colors.hl-identifier;
             }
         }

--- a/app/src/ui/event.rs
+++ b/app/src/ui/event.rs
@@ -19,6 +19,7 @@ use super::{
     config_connections_to_entries, groups_to_slint, with_sidebar, with_sidebar_mut, with_ui,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_event_handler(
     window: &crate::AppWindow,
     mut rx_event: mpsc::Receiver<Event>,
@@ -27,6 +28,7 @@ pub(super) fn spawn_event_handler(
     original_data: SharedOriginalData,
     snippet_repo: Arc<SnippetRepository>,
     fp_approval_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<bool>>>>,
+    param_pending_sql: Arc<Mutex<Option<String>>>,
 ) {
     let window_weak = window.as_weak();
     tokio::spawn(async move {
@@ -151,6 +153,35 @@ pub(super) fn spawn_event_handler(
                     state.clone(), // clone required: passed to spawned handler
                 ),
                 Event::HistoryLoaded(rows) => handle_history_loaded(rows, window_weak.clone()),
+                Event::ParamDialogRequired {
+                    sql,
+                    params,
+                    defaults,
+                } => {
+                    *param_pending_sql.lock().unwrap_or_else(|p| p.into_inner()) = Some(sql);
+                    let rows_data: Vec<crate::ParamRow> = params
+                        .iter()
+                        .map(|name| crate::ParamRow {
+                            name: name.as_str().into(),
+                            type_idx: 0,
+                            value: defaults
+                                .get(name.as_str())
+                                .map(|s| s.as_str())
+                                .unwrap_or("")
+                                .into(),
+                            is_valid: true,
+                        })
+                        .collect();
+                    let ww = window_weak.clone();
+                    let _ = slint::invoke_from_event_loop(move || {
+                        with_ui(&ww, |ui| {
+                            let model = Rc::new(slint::VecModel::from(rows_data));
+                            ui.set_param_dialog_rows(model.into());
+                            ui.set_params_all_valid(true);
+                            ui.set_show_param_dialog(true);
+                        });
+                    });
+                }
                 _ => {}
             }
         }

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -90,8 +90,15 @@ export struct CommandPaletteItem {
     shortcut: string,
 }
 
+export struct ParamRow {
+    name:     string,
+    type-idx: int,    // 0=String, 1=Number, 2=Date, 3=Bool
+    value:    string,
+    is-valid: bool,
+}
+
 /// One syntax-highlight span rendered as a colored Text element over the editor text.
-/// kind: 0=keyword, 1=string-literal, 2=comment, 3=number, 4=identifier (gap fill)
+/// kind: 0=keyword, 1=string-literal, 2=comment, 3=number, 4=identifier (gap fill), 5=parameter
 export struct HighlightSpan {
     line: int,
     col:  int,

--- a/app/src/ui/history.rs
+++ b/app/src/ui/history.rs
@@ -126,6 +126,7 @@ mod tests {
             error_message: None,
             timestamp: ts,
             connection_id: "c1".to_string(),
+            params_json: None,
         }
     }
 

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -520,6 +520,10 @@ impl UI {
         let fp_approval_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<bool>>>> =
             Arc::new(Mutex::new(None));
 
+        // Written by the async event handler when the controller detects :name placeholders;
+        // consumed by on_confirm_param_dialog on the Slint thread.
+        let param_pending_sql: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
         // Restore or create tab state. Track whether tabs were loaded from DB
         // so we can fall back to last_query on first launch.
         let handle = tokio::runtime::Handle::current();
@@ -555,6 +559,11 @@ impl UI {
             Arc::clone(&fp_approval_tx),
         );
         query::register_editor_callbacks(&window, tx_cmd.clone());
+        query::register_param_dialog_callbacks(
+            &window,
+            tx_cmd.clone(),
+            Arc::clone(&param_pending_sql),
+        );
         completion::register_completion_callbacks(&window, tx_cmd.clone());
         completion::register_completion_accept_callback(&window);
         let hl_model: Rc<slint::VecModel<crate::HighlightSpan>> =
@@ -752,6 +761,7 @@ impl UI {
             Arc::clone(&original_data),
             Arc::clone(&snippet_repo),
             Arc::clone(&fp_approval_tx),
+            Arc::clone(&param_pending_sql),
         );
 
         Ok(Self { window })

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -849,6 +849,9 @@ pub(super) fn register_param_dialog_callbacks(
             if let Some(mut row) = model.row_data(i as usize) {
                 row.value = v;
                 row.is_valid = is_valid;
+                // Single-row set_row_data (not a loop) is intentional here: replacing the
+                // whole VecModel would trigger Slint to re-run `init =>` on every TextInput,
+                // clearing focus while the user is still typing.
                 model.set_row_data(i as usize, row);
             }
             let all_valid = (0..model.row_count())
@@ -867,6 +870,7 @@ pub(super) fn register_param_dialog_callbacks(
                 let v = row.value.to_string();
                 row.type_idx = t;
                 row.is_valid = validate_param(t, &v);
+                // Same intentional single-row update as on_param_value_changed above.
                 model.set_row_data(i as usize, row);
             }
             let all_valid = (0..model.row_count())

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -1,11 +1,13 @@
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use chrono::NaiveDate;
 
 use slint::{ComponentHandle, Model as _};
 use tokio::sync::mpsc;
 
-use crate::app::command::{Command, ConfigUpdate};
+use crate::app::command::{Command, ConfigUpdate, ParamValue};
 use crate::state::SharedState;
 
 use super::appearance::{apply_highlight_spans, compute_highlight_spans};
@@ -816,6 +818,112 @@ pub(super) fn handle_table_data_loaded(
             ui.set_result_total_col_width(total_w);
         });
     });
+}
+
+fn validate_param(type_idx: i32, value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    match type_idx {
+        1 => value.parse::<f64>().is_ok(),
+        2 => NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok(),
+        3 => value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case("false"),
+        _ => true,
+    }
+}
+
+pub(super) fn register_param_dialog_callbacks(
+    window: &crate::AppWindow,
+    tx_cmd: mpsc::Sender<Command>,
+    param_pending_sql: Arc<Mutex<Option<String>>>,
+) {
+    let ww = window.as_weak();
+    window
+        .global::<crate::UiState>()
+        .on_param_value_changed(move |i, v| {
+            let Some(win) = ww.upgrade() else { return };
+            let ui = win.global::<crate::UiState>();
+            let model = ui.get_param_dialog_rows();
+            let type_idx = model.row_data(i as usize).map(|r| r.type_idx).unwrap_or(0);
+            let is_valid = validate_param(type_idx, &v);
+            if let Some(mut row) = model.row_data(i as usize) {
+                row.value = v;
+                row.is_valid = is_valid;
+                model.set_row_data(i as usize, row);
+            }
+            let all_valid = (0..model.row_count())
+                .all(|j| model.row_data(j).map(|r| r.is_valid).unwrap_or(true));
+            ui.set_params_all_valid(all_valid);
+        });
+
+    let ww = window.as_weak();
+    window
+        .global::<crate::UiState>()
+        .on_param_type_changed(move |i, t| {
+            let Some(win) = ww.upgrade() else { return };
+            let ui = win.global::<crate::UiState>();
+            let model = ui.get_param_dialog_rows();
+            if let Some(mut row) = model.row_data(i as usize) {
+                let v = row.value.to_string();
+                row.type_idx = t;
+                row.is_valid = validate_param(t, &v);
+                model.set_row_data(i as usize, row);
+            }
+            let all_valid = (0..model.row_count())
+                .all(|j| model.row_data(j).map(|r| r.is_valid).unwrap_or(true));
+            ui.set_params_all_valid(all_valid);
+        });
+
+    window
+        .global::<crate::UiState>()
+        .on_validate_param_number(|v| v.is_empty() || v.parse::<f64>().is_ok());
+    window
+        .global::<crate::UiState>()
+        .on_validate_param_date(|v| {
+            v.is_empty() || NaiveDate::parse_from_str(&v, "%Y-%m-%d").is_ok()
+        });
+    window
+        .global::<crate::UiState>()
+        .on_validate_param_bool(|v| {
+            v.is_empty() || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("false")
+        });
+
+    {
+        let ww = window.as_weak();
+        let pps = Arc::clone(&param_pending_sql); // clone required: closure needs owned pps
+        let tx = tx_cmd.clone(); // clone required: send_cmd closure needs owned tx
+        window
+            .global::<crate::UiState>()
+            .on_confirm_param_dialog(move || {
+                let Some(win) = ww.upgrade() else { return };
+                let sql = pps.lock().unwrap_or_else(|p| p.into_inner()).take();
+                let Some(sql) = sql else { return };
+                let ui = win.global::<crate::UiState>();
+                let model = ui.get_param_dialog_rows();
+                let params: Vec<ParamValue> = (0..model.row_count())
+                    .filter_map(|j| model.row_data(j))
+                    .map(|r| ParamValue {
+                        name: r.name.to_string(),
+                        type_idx: r.type_idx,
+                        value: r.value.to_string(),
+                    })
+                    .collect();
+                ui.set_show_param_dialog(false);
+                send_cmd(&tx, Command::RunQueryWithParams { sql, params });
+            });
+    }
+
+    {
+        let ww = window.as_weak();
+        let pps = Arc::clone(&param_pending_sql); // clone required: closure needs owned pps
+        window
+            .global::<crate::UiState>()
+            .on_cancel_param_dialog(move || {
+                let Some(win) = ww.upgrade() else { return };
+                *pps.lock().unwrap_or_else(|p| p.into_inner()) = None;
+                win.global::<crate::UiState>().set_show_param_dialog(false);
+            });
+    }
 }
 
 #[cfg(test)]

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -48,6 +48,7 @@ export global Colors {
     out property <color> hl-comment:    is-dark ? #57a64a : #6a9955;  // VS Code comment green
     out property <color> hl-number:     is-dark ? #b5cea8 : #098658;  // VS Code number green
     out property <color> hl-identifier: is-dark ? #9cdcfe : #0070a0;  // VS Code identifier cyan
+    out property <color> hl-param:      is-dark ? #c586c0 : #af00db;  // VS Code parameter purple
 }
 
 export global Typography {

--- a/crates/wf-db/src/models.rs
+++ b/crates/wf-db/src/models.rs
@@ -146,6 +146,9 @@ pub struct QueryExecution {
     /// Unix epoch seconds.
     pub timestamp: i64,
     pub connection_id: String,
+    /// JSON-encoded map of parameter name → raw value for parameterized queries.
+    /// `None` for non-parameterized queries.
+    pub params_json: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wf-history/Cargo.toml
+++ b/crates/wf-history/Cargo.toml
@@ -12,10 +12,11 @@ authors.workspace    = true
 license.workspace    = true
 
 [dependencies]
-wf-db     = { path = "../wf-db" }
-sqlx      = { workspace = true }
-tokio     = { workspace = true }
-anyhow    = { workspace = true }
-thiserror = { workspace = true }
-chrono    = { workspace = true }
-uuid      = { workspace = true }
+wf-db      = { path = "../wf-db" }
+sqlx       = { workspace = true }
+tokio      = { workspace = true }
+anyhow     = { workspace = true }
+thiserror  = { workspace = true }
+chrono     = { workspace = true }
+uuid       = { workspace = true }
+serde_json = "1.0.150"

--- a/crates/wf-history/Cargo.toml
+++ b/crates/wf-history/Cargo.toml
@@ -19,4 +19,5 @@ anyhow     = { workspace = true }
 thiserror  = { workspace = true }
 chrono     = { workspace = true }
 uuid       = { workspace = true }
-serde_json = "1.0.150"
+serde_json = { workspace = true }
+tracing    = { workspace = true }

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use sqlx::{Row as _, SqlitePool};
 use wf_db::models::QueryExecution;
 
@@ -25,7 +27,8 @@ const CREATE_TABLE: &str = "
         success       INTEGER NOT NULL,
         error_message TEXT,
         timestamp     INTEGER NOT NULL,
-        connection_id TEXT    NOT NULL
+        connection_id TEXT    NOT NULL,
+        params        TEXT
     )";
 
 const CREATE_INDEX: &str = "
@@ -56,8 +59,8 @@ impl HistoryService {
     pub async fn insert(&self, execution: &QueryExecution) -> Result<()> {
         sqlx::query(
             "INSERT INTO query_executions
-             (sql, duration_ms, success, error_message, timestamp, connection_id)
-             VALUES (?, ?, ?, ?, ?, ?)",
+             (sql, duration_ms, success, error_message, timestamp, connection_id, params)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&execution.sql)
         .bind(execution.duration_ms as i64)
@@ -65,9 +68,34 @@ impl HistoryService {
         .bind(&execution.error_message)
         .bind(execution.timestamp)
         .bind(&execution.connection_id)
+        .bind(&execution.params_json)
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Return the parameter values from the most recent successful execution of the same SQL.
+    ///
+    /// Returns `None` when no parameterized execution exists for that exact SQL.
+    pub async fn find_last_params(&self, sql: &str) -> Result<Option<HashMap<String, String>>> {
+        let row = sqlx::query(
+            "SELECT params FROM query_executions
+             WHERE sql = ? AND params IS NOT NULL
+             ORDER BY timestamp DESC
+             LIMIT 1",
+        )
+        .bind(sql)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            None => Ok(None),
+            Some(r) => {
+                let json: String = r.get("params");
+                let map: HashMap<String, String> = serde_json::from_str(&json).unwrap_or_default();
+                Ok(Some(map))
+            }
+        }
     }
 
     /// Return up to `limit` executions matching `keyword` in the SQL text,
@@ -82,7 +110,7 @@ impl HistoryService {
     ) -> Result<Vec<QueryExecution>> {
         let pattern = format!("%{keyword}%");
         let rows = sqlx::query(
-            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id
+            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id, params
              FROM query_executions
              WHERE sql LIKE ?
                AND connection_id = COALESCE(?, connection_id)
@@ -105,6 +133,7 @@ impl HistoryService {
                 error_message: row.get("error_message"),
                 timestamp: row.get("timestamp"),
                 connection_id: row.get("connection_id"),
+                params_json: row.get("params"),
             })
             .collect();
 
@@ -114,7 +143,7 @@ impl HistoryService {
     /// Return up to `limit` most recent executions, newest first (DESC timestamp).
     pub async fn recent(&self, limit: usize) -> Result<Vec<QueryExecution>> {
         let rows = sqlx::query(
-            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id
+            "SELECT id, sql, duration_ms, success, error_message, timestamp, connection_id, params
              FROM query_executions
              ORDER BY timestamp DESC
              LIMIT ?",
@@ -133,6 +162,7 @@ impl HistoryService {
                 error_message: row.get("error_message"),
                 timestamp: row.get("timestamp"),
                 connection_id: row.get("connection_id"),
+                params_json: row.get("params"),
             })
             .collect();
 
@@ -173,6 +203,20 @@ mod tests {
             error_message: err.map(|s| s.to_string()),
             timestamp: ts,
             connection_id: conn_id.to_string(),
+            params_json: None,
+        }
+    }
+
+    fn make_exec_with_params(sql: &str, ts: i64, params_json: &str) -> QueryExecution {
+        QueryExecution {
+            id: 0,
+            sql: sql.to_string(),
+            duration_ms: 5,
+            success: true,
+            error_message: None,
+            timestamp: ts,
+            connection_id: "c1".to_string(),
+            params_json: Some(params_json.to_string()),
         }
     }
 
@@ -303,5 +347,39 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].connection_id, "conn-a");
         assert!(rows[0].sql.contains("users"));
+    }
+
+    #[tokio::test]
+    async fn find_last_params_should_return_none_when_no_match() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        let result = svc.find_last_params("SELECT :id FROM t").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_last_params_should_return_most_recent_params_for_sql() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        svc.insert(&make_exec_with_params("SELECT :id", 1000, r#"{"id":"1"}"#))
+            .await
+            .unwrap();
+        svc.insert(&make_exec_with_params("SELECT :id", 2000, r#"{"id":"42"}"#))
+            .await
+            .unwrap();
+
+        let result = svc.find_last_params("SELECT :id").await.unwrap();
+        assert!(result.is_some());
+        let map = result.unwrap();
+        assert_eq!(map.get("id").map(|s| s.as_str()), Some("42"));
+    }
+
+    #[tokio::test]
+    async fn find_last_params_should_ignore_rows_without_params() {
+        let svc = HistoryService::open_memory().await.unwrap();
+        svc.insert(&make_exec("SELECT :id", 1000, true, None))
+            .await
+            .unwrap();
+
+        let result = svc.find_last_params("SELECT :id").await.unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/wf-history/src/service.rs
+++ b/crates/wf-history/src/service.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use sqlx::{Row as _, SqlitePool};
+use tracing::warn;
 use wf_db::models::QueryExecution;
 
 use crate::error::HistoryError;
@@ -92,8 +93,13 @@ impl HistoryService {
             None => Ok(None),
             Some(r) => {
                 let json: String = r.get("params");
-                let map: HashMap<String, String> = serde_json::from_str(&json).unwrap_or_default();
-                Ok(Some(map))
+                match serde_json::from_str::<HashMap<String, String>>(&json) {
+                    Ok(map) => Ok(Some(map)),
+                    Err(e) => {
+                        warn!("stored params JSON is invalid, ignoring defaults: {e}");
+                        Ok(None)
+                    }
+                }
             }
         }
     }

--- a/crates/wf-query/src/highlight.rs
+++ b/crates/wf-query/src/highlight.rs
@@ -7,6 +7,7 @@ pub enum TokenKind {
     StringLiteral = 1,
     Comment = 2,
     Number = 3,
+    Param = 5,
 }
 
 // ── Output type ───────────────────────────────────────────────────────────────
@@ -452,6 +453,27 @@ fn tokenize(sql: &str) -> Vec<RawToken> {
             continue;
         }
 
+        // ── Parameter placeholder :name ───────────────────────────────────────
+        // Reached only outside strings/comments (those are consumed above).
+        // Exclude :: (PostgreSQL cast operator).
+        if b == b':'
+            && i + 1 < len
+            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
+            && (i == 0 || bytes[i - 1] != b':')
+        {
+            let start = i;
+            i += 1;
+            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            tokens.push(RawToken {
+                start,
+                end: i,
+                kind: TokenKind::Param,
+            });
+            continue;
+        }
+
         i += 1;
     }
 
@@ -746,5 +768,37 @@ mod tests {
             .find(|s| s.kind == TokenKind::StringLiteral as i32);
         assert!(s.is_some());
         assert_eq!(s.unwrap().text, "'it''s'");
+    }
+
+    #[test]
+    fn highlight_should_detect_param_placeholder() {
+        let result = spans("SELECT :id FROM t");
+        let param = result.iter().find(|s| s.kind == TokenKind::Param as i32);
+        assert!(param.is_some());
+        assert_eq!(param.unwrap().text, ":id");
+    }
+
+    #[test]
+    fn highlight_should_not_detect_colon_in_string() {
+        let result = spans("SELECT ':name' FROM t");
+        assert!(result.iter().all(|s| s.kind != TokenKind::Param as i32));
+    }
+
+    #[test]
+    fn highlight_should_not_detect_colon_in_line_comment() {
+        let result = spans("SELECT 1 -- :param\nFROM t");
+        assert!(result.iter().all(|s| s.kind != TokenKind::Param as i32));
+    }
+
+    #[test]
+    fn highlight_should_detect_multiple_params() {
+        let result = spans("WHERE a = :foo AND b = :bar");
+        let params: Vec<_> = result
+            .iter()
+            .filter(|s| s.kind == TokenKind::Param as i32)
+            .collect();
+        assert_eq!(params.len(), 2);
+        assert!(params.iter().any(|s| s.text == ":foo"));
+        assert!(params.iter().any(|s| s.text == ":bar"));
     }
 }

--- a/crates/wf-query/src/lib.rs
+++ b/crates/wf-query/src/lib.rs
@@ -2,3 +2,4 @@ pub mod analyzer;
 pub mod export;
 pub mod formatter;
 pub mod highlight;
+pub mod params;

--- a/crates/wf-query/src/params.rs
+++ b/crates/wf-query/src/params.rs
@@ -1,0 +1,358 @@
+use std::collections::{HashMap, HashSet};
+
+/// Extract all distinct `:name` parameter placeholders from `sql`, in first-appearance order.
+///
+/// Colons inside string literals (single-quoted, double-quoted, backtick, dollar-quoted) and
+/// inside comments (`--` line comments, `/* */` block comments) are ignored.
+pub fn extract_params(sql: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut result: Vec<String> = Vec::new();
+
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+
+        // ── Line comment ──────────────────────────────────────────────────────
+        if b == b'-' && i + 1 < len && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // ── Block comment ─────────────────────────────────────────────────────
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
+
+        // ── Single-quoted string ──────────────────────────────────────────────
+        if b == b'\'' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\'' {
+                    i += 1;
+                    if i < len && bytes[i] == b'\'' {
+                        i += 1;
+                        continue;
+                    }
+                    break;
+                }
+                if bytes[i] == b'\\' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        // ── Double-quoted identifier / string ─────────────────────────────────
+        if b == b'"' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'"' {
+                    i += 1;
+                    if i < len && bytes[i] == b'"' {
+                        i += 1;
+                        continue;
+                    }
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        // ── Backtick-quoted identifier (MySQL) ────────────────────────────────
+        if b == b'`' {
+            i += 1;
+            while i < len && bytes[i] != b'`' {
+                i += 1;
+            }
+            if i < len {
+                i += 1;
+            }
+            continue;
+        }
+
+        // ── Dollar-quoted string (PostgreSQL) ─────────────────────────────────
+        if b == b'$'
+            && let Some(tag_end) = scan_dollar_tag(bytes, i)
+        {
+            let tag = &bytes[i..tag_end];
+            i = tag_end;
+            loop {
+                if i >= len {
+                    break;
+                }
+                if bytes[i] == b'$' && bytes[i..].starts_with(tag) {
+                    i += tag.len();
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        // ── Parameter placeholder :name ───────────────────────────────────────
+        // Exclude :: (PostgreSQL cast operator): if previous byte is also ':', skip.
+        if b == b':'
+            && i + 1 < len
+            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
+            && (i == 0 || bytes[i - 1] != b':')
+        {
+            i += 1;
+            let start = i;
+            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            let name = sql[start..i].to_string();
+            if seen.insert(name.clone()) {
+                result.push(name);
+            }
+            continue;
+        }
+
+        i += 1;
+    }
+
+    result
+}
+
+/// Replace every `:name` placeholder in `sql` with the corresponding value from `values`.
+///
+/// Placeholders inside string literals and comments are skipped, matching the same rules
+/// as [`extract_params`]. Replacements are applied back-to-front to preserve byte offsets.
+pub fn substitute_params(sql: &str, values: &HashMap<String, String>) -> String {
+    let mut replacements: Vec<(usize, usize, &str)> = Vec::new();
+
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+
+        if b == b'-' && i + 1 < len && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
+
+        if b == b'\'' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\'' {
+                    i += 1;
+                    if i < len && bytes[i] == b'\'' {
+                        i += 1;
+                        continue;
+                    }
+                    break;
+                }
+                if bytes[i] == b'\\' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b'"' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'"' {
+                    i += 1;
+                    if i < len && bytes[i] == b'"' {
+                        i += 1;
+                        continue;
+                    }
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b'`' {
+            i += 1;
+            while i < len && bytes[i] != b'`' {
+                i += 1;
+            }
+            if i < len {
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b'$'
+            && let Some(tag_end) = scan_dollar_tag(bytes, i)
+        {
+            let tag = &bytes[i..tag_end];
+            i = tag_end;
+            loop {
+                if i >= len {
+                    break;
+                }
+                if bytes[i] == b'$' && bytes[i..].starts_with(tag) {
+                    i += tag.len();
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if b == b':'
+            && i + 1 < len
+            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
+            && (i == 0 || bytes[i - 1] != b':')
+        {
+            let colon_pos = i;
+            i += 1;
+            let start = i;
+            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            let name = &sql[start..i];
+            if let Some(replacement) = values.get(name) {
+                replacements.push((colon_pos, i, replacement.as_str()));
+            }
+            continue;
+        }
+
+        i += 1;
+    }
+
+    // Apply replacements from end to start to preserve earlier offsets.
+    let mut result = sql.to_string();
+    for (start, end, replacement) in replacements.into_iter().rev() {
+        result.replace_range(start..end, replacement);
+    }
+    result
+}
+
+fn scan_dollar_tag(bytes: &[u8], pos: usize) -> Option<usize> {
+    let mut i = pos + 1;
+    let len = bytes.len();
+    while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    if i < len && bytes[i] == b'$' {
+        Some(i + 1)
+    } else {
+        None
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_params_should_find_basic_placeholders() {
+        let params = extract_params("SELECT :id, :name FROM users");
+        assert_eq!(params, vec!["id", "name"]);
+    }
+
+    #[test]
+    fn extract_params_should_ignore_colons_in_single_quoted_strings() {
+        let params = extract_params("SELECT ':name' FROM t");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn extract_params_should_ignore_colons_in_line_comments() {
+        let params = extract_params("SELECT 1 -- :name\nFROM t");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn extract_params_should_ignore_colons_in_block_comments() {
+        let params = extract_params("SELECT /* :name */ 1");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn extract_params_should_deduplicate_param_names() {
+        let params = extract_params("WHERE a = :id AND b = :id");
+        assert_eq!(params, vec!["id"]);
+    }
+
+    #[test]
+    fn extract_params_should_handle_empty_sql() {
+        assert!(extract_params("").is_empty());
+    }
+
+    #[test]
+    fn extract_params_should_preserve_first_occurrence_order() {
+        let params = extract_params("SELECT :b, :a, :b");
+        assert_eq!(params, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn extract_params_should_ignore_bare_colon_not_followed_by_ident() {
+        let params = extract_params("a::text");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn extract_params_should_ignore_colons_in_dollar_quoted_strings() {
+        let params = extract_params("$$ :name $$");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn substitute_params_should_replace_named_placeholder() {
+        let mut values = HashMap::new();
+        values.insert("id".to_string(), "42".to_string());
+        let result = substitute_params("SELECT :id", &values);
+        assert_eq!(result, "SELECT 42");
+    }
+
+    #[test]
+    fn substitute_params_should_replace_multiple_placeholders() {
+        let mut values = HashMap::new();
+        values.insert("id".to_string(), "1".to_string());
+        values.insert("name".to_string(), "'alice'".to_string());
+        let result = substitute_params("WHERE id = :id AND name = :name", &values);
+        assert_eq!(result, "WHERE id = 1 AND name = 'alice'");
+    }
+
+    #[test]
+    fn substitute_params_should_not_replace_inside_string_literals() {
+        let mut values = HashMap::new();
+        values.insert("name".to_string(), "replaced".to_string());
+        let result = substitute_params("SELECT ':name'", &values);
+        assert_eq!(result, "SELECT ':name'");
+    }
+
+    #[test]
+    fn substitute_params_should_replace_duplicate_occurrences() {
+        let mut values = HashMap::new();
+        values.insert("id".to_string(), "7".to_string());
+        let result = substitute_params("WHERE a = :id OR b = :id", &values);
+        assert_eq!(result, "WHERE a = 7 OR b = 7");
+    }
+}


### PR DESCRIPTION
## Summary

Implements T103 — parameterized query support with `:name` placeholder detection. When the active SQL contains `:name` placeholders, the app intercepts the Run command, shows a `ParamDialog` modal for the user to supply typed values (Str / Num / Date / Bool), validates them, then substitutes the values and executes the resolved SQL. Previously-used param values for the same SQL are loaded from history as defaults.

## Changes

- **`crates/wf-query/src/params.rs`** (new): `extract_params()` — scans SQL bytes for `:name` placeholders, skipping string literals, comments, and `::` cast operators; `substitute_params()` — back-to-front replacement to preserve byte offsets; full unit test suite (13 tests)
- **`crates/wf-query/src/highlight.rs`**: Added `TokenKind::Param` and highlighting pass for `:name` tokens, emitting `Colors.hl-param` spans
- **`app/src/ui/components/dialogs/param_dialog.slint`** (new): `ParamDialog` component — scrollable list of param rows each with name label, 4-button type selector (Str/Num/Date/Bool), value `TextInput`, validation dot; Cancel + Run footer (Run disabled while any row is invalid)
- **`app/src/ui/globals.slint`**: Added `ParamRow` struct and `UiState` properties (`param-dialog-rows`, `params-all-valid`, `show-param-dialog`)
- **`app/src/app/command.rs`**: Added `RunQueryWithParams { sql, params }` command variant
- **`app/src/app/event.rs`**: Added `ParamDialogRequired { sql, params, defaults }` event variant
- **`app/src/app/controller/query.rs`**: Pre-run param extraction; if params found, emits `ParamDialogRequired`; `handle_run_query_with_params()` formats values by type and executes
- **`crates/wf-history/src/service.rs`**: Added `find_last_params(sql)` — returns most-recent param JSON for a given SQL template (for pre-filling defaults); new tests
- **`app/src/ui/event.rs`**: Handles `ParamDialogRequired` — populates `param_pending_sql`, builds `ParamRow` VecModel with defaults, shows dialog
- **`app/src/ui/query.rs`**: `register_param_dialog_callbacks()` — wires `on_param_value_changed`, `on_param_type_changed`, `on_param_confirm`, `on_param_cancel`

## Related Issues

Closes #209

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes