### PR TITLE
feat(ui): add JSON/XML tree viewer in cell-value preview strip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5175,6 +5175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7895,7 +7905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.3",
  "quote",
 ]
 
@@ -7981,6 +7991,7 @@ dependencies = [
  "directories",
  "fuzzy-matcher",
  "icu_provider",
+ "quick-xml 0.40.1",
  "regex",
  "rfd",
  "rust-i18n",
@@ -8971,7 +8982,7 @@ version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.39.3",
  "serde",
  "zbus_names",
  "zvariant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing       = "0.1.44"
 sqlx          = { version = "0.8.6", features = ["postgres", "mysql", "sqlite", "runtime-tokio", "macros", "chrono", "uuid", "tls-rustls-ring"] }
 uuid          = { version = "1.23.0", features = ["v4"] }
 chrono        = { version = "0.4.44", features = ["serde"] }
+quick-xml     = { version = "0.40.1", features = ["serialize"] }
 
 [profile.release]
 opt-level     = 3

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -31,6 +31,7 @@ fuzzy-matcher      = "0.3.7"
 directories        = "6.0.0"
 thiserror          = { workspace = true }
 serde_json         = { workspace = true }
+quick-xml          = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_UI_HiDpi"] }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -7,7 +7,7 @@ import "../../assets/fonts/NotoSansJP-Bold.ttf";
 import "../../assets/fonts/JetBrainsMono-Regular.ttf";
 import "../../assets/fonts/JetBrainsMono-Bold.ttf";
 
-import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem, HistoryEntry, ParamRow } from "globals.slint";
+import { ConnectionEntry, RowData, SidebarNode, GroupEntry, CompletionRow, TabEntry, ColumnData, SnippetEntry, MetadataSearchResult, HighlightSpan, CommandPaletteItem, HistoryEntry, ParamRow, TreeNode } from "globals.slint";
 import { Colors, Typography, Layout, Icons, Animation } from "theme.slint";
 import { CompletionPopup } from "components/completion_popup.slint";
 import { ConnectionForm }  from "components/connection_form.slint";
@@ -35,6 +35,7 @@ import { SnippetPalette }        from "components/snippet_palette.slint";
 import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.slint";
 import { FingerprintDialog }    from "components/dialogs/fingerprint_dialog.slint";
 import { ParamDialog }          from "components/dialogs/param_dialog.slint";
+import { TreeViewer }           from "components/tree_viewer.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -476,6 +477,21 @@ export global UiState {
     /// Fired on every user text edit; Rust uses this to drive the debounce snapshot.
     callback text-changed(string);
 
+    // ── Cell-value tree viewer ────────────────────────────────────────────────
+    /// Flat visible-node list for the JSON / XML tree viewer; rebuilt by Rust
+    /// on cell selection and on each expand/collapse toggle.
+    in-out property <[TreeNode]> cell-tree-nodes:   [];
+    /// 0 = plain-text preview, 1 = JSON tree, 2 = XML tree.
+    in-out property <int>        cell-preview-mode: 0;
+    /// Fired when a result cell is selected; Rust parses JSON/XML and updates tree nodes.
+    callback cell-value-selected(string);
+    /// Fired when a tree node is clicked to toggle expand/collapse; arg is node path.
+    callback cell-tree-node-toggle(string);
+    /// Copy a tree node path to the clipboard.
+    callback cell-copy-path(string);
+    /// Copy a tree node value to the clipboard.
+    callback cell-copy-node-value(string);
+
     // ── Sidebar action undo / redo ────────────────────────────────────────────
     /// Fired when Ctrl+Z is pressed while the sidebar has focus.
     callback sidebar-undo();
@@ -514,8 +530,8 @@ export component AppWindow inherits Window {
     // Width of the shared line-number gutter column.
     // Must match the gutter rectangle width defined in the container below.
     property <length> gutter-col-width:  48px;
-    // Fixed-height preview strip shown above the result panel.
-    property <length> preview-strip-h:   60px;
+    // Preview strip height: taller in tree-view mode to accommodate expandable nodes.
+    property <length> preview-strip-h: UiState.cell-preview-mode != 0 ? 220px : 60px;
 
     // ── Overlay panel geometry ────────────────────────────────────────────────
     // The result/error panel overlays the editor from the bottom (VSCode style).
@@ -552,6 +568,13 @@ export component AppWindow inherits Window {
     property <bool> _result-active: result-table-inst.result-focused;
     changed _result-active => {
         if (root._result-active) { root.focused-pane = 2; }
+    }
+
+    // Fire cell-value-selected whenever the selected result cell changes so Rust
+    // can attempt JSON / XML parsing and update cell-preview-mode + cell-tree-nodes.
+    property <string> _cell-value-alias: result-table-inst.selected-cell-value;
+    changed _cell-value-alias => {
+        UiState.cell-value-selected(result-table-inst.selected-cell-value);
     }
 
     // When switching to a Table View tab, give it focus so keyboard shortcuts work.
@@ -1129,8 +1152,64 @@ export component AppWindow inherits Window {
                         background: Colors.surface1;
                     }
 
+                    // ── Tree mode (JSON or XML) ───────────────────────────────
+                    if UiState.cell-preview-mode != 0: VerticalLayout {
+                        x: 0; y: 1px;
+                        width:  parent.width;
+                        height: parent.height - 1px;
+                        spacing: 0;
+
+                        // Header bar: label + "View as Text" button
+                        HorizontalLayout {
+                            height: 22px;
+                            padding-left: 6px;
+                            padding-right: 4px;
+                            spacing: 4px;
+                            alignment: start;
+                            Text {
+                                vertical-alignment: center;
+                                font-size: Typography.size-sm;
+                                color: Colors.overlay2;
+                                text: UiState.cell-preview-mode == 1
+                                    ? @tr("JSON")
+                                    : @tr("XML");
+                            }
+                            Rectangle { horizontal-stretch: 1; }
+                            // "View as Text" button
+                            TouchArea {
+                                width: view-as-text-label.preferred-width + 12px;
+                                height: 18px;
+                                y: 2px;
+                                clicked => { UiState.cell-preview-mode = 0; }
+                                Rectangle {
+                                    border-radius: 3px;
+                                    background: parent.has-hover
+                                        ? Colors.hover-btn
+                                        : transparent;
+                                    view-as-text-label := Text {
+                                        x: 6px;
+                                        text: @tr("View as Text");
+                                        font-size: Typography.size-sm;
+                                        color: Colors.overlay2;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+
+                        TreeViewer {
+                            vertical-stretch: 1;
+                            nodes: UiState.cell-tree-nodes;
+                            toggle(path)      => { UiState.cell-tree-node-toggle(path); }
+                            copy-path(path)   => { UiState.cell-copy-path(path); }
+                            copy-value(value) => { UiState.cell-copy-node-value(value); }
+                        }
+                    }
+
+                    // ── Text mode (plain preview) ────────────────────────────
                     // Placeholder — nothing selected or row-only selection
-                    if !result-table-inst.selected-cell-is-null
+                    if UiState.cell-preview-mode == 0
+                            && !result-table-inst.selected-cell-is-null
                             && result-table-inst.selected-cell-value == "": Text {
                         x: 10px; y: 8px;
                         color: Colors.surface1;
@@ -1139,7 +1218,8 @@ export component AppWindow inherits Window {
                     }
 
                     // NULL indicator
-                    if result-table-inst.selected-cell-is-null: Text {
+                    if UiState.cell-preview-mode == 0
+                            && result-table-inst.selected-cell-is-null: Text {
                         x: 10px; y: 8px;
                         color: Colors.overlay2;
                         font-size: Typography.size-base;
@@ -1147,7 +1227,8 @@ export component AppWindow inherits Window {
                     }
 
                     // Cell value — word-wrapped, vertically scrollable
-                    if !result-table-inst.selected-cell-is-null
+                    if UiState.cell-preview-mode == 0
+                            && !result-table-inst.selected-cell-is-null
                             && result-table-inst.selected-cell-value != "": Flickable {
                         x: 0; y: 4px;
                         width:  parent.width;

--- a/app/src/ui/components/tree_viewer.slint
+++ b/app/src/ui/components/tree_viewer.slint
@@ -1,0 +1,198 @@
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { TreeNode } from "../globals.slint";
+import { MenuItem } from "common.slint";
+
+// Scrollable JSON / XML tree shown in the cell-value preview strip.
+// Nodes are supplied as a pre-flattened visible list by the Rust side.
+export component TreeViewer inherits Rectangle {
+    background: Colors.mantle;
+    clip: true;
+
+    in property <[TreeNode]> nodes: [];
+    callback toggle(string);           // path of node to expand/collapse
+    callback copy-path(string);        // copy path to clipboard
+    callback copy-value(string);       // copy value to clipboard
+
+    private property <length> ctx-menu-x: 0;
+    private property <length> ctx-menu-y: 0;
+    private property <string> ctx-path:   "";
+    private property <string> ctx-value:  "";
+
+    ctx-popup := PopupWindow {
+        x: root.ctx-menu-x;
+        y: root.ctx-menu-y;
+        width:  160px;
+        height: 2 * Layout.height-menu-item;
+        close-policy: PopupClosePolicy.close-on-click;
+
+        Rectangle {
+            width: 160px;
+            height: 2 * Layout.height-menu-item;
+            background: Colors.surface0;
+            border-radius: Layout.radius-md;
+            border-width: 1px;
+            border-color: Colors.surface2;
+            drop-shadow-blur: 8px;
+            drop-shadow-color: Colors.shadow;
+            clip: true;
+
+            VerticalLayout {
+                spacing: 0;
+                MenuItem {
+                    text: @tr("Copy Path");
+                    clicked => { root.copy-path(root.ctx-path); }
+                }
+                MenuItem {
+                    text: @tr("Copy Value");
+                    clicked => { root.copy-value(root.ctx-value); }
+                }
+            }
+        }
+    }
+
+    flick := Flickable {
+        x: 0; y: 0;
+        width:  parent.width;
+        height: parent.height;
+        viewport-height: node-list.preferred-height;
+
+        node-list := VerticalLayout {
+            spacing: 0;
+            alignment: start;
+
+            for node[i] in root.nodes: Rectangle {
+                height: 22px;
+                background: row-touch.has-hover ? Colors.hover-subtle : transparent;
+
+                HorizontalLayout {
+                    x: node.depth * 14px + 4px;
+                    width: parent.width - self.x;
+                    height: parent.height;
+                    spacing: 2px;
+                    alignment: start;
+
+                    // Expand/collapse chevron — click handled by row-touch below
+                    if node.has-children: Rectangle {
+                        width: 14px;
+                        Image {
+                            width: 10px;
+                            height: 10px;
+                            x: (parent.width - self.width) / 2;
+                            y: (parent.height - self.height) / 2;
+                            source: node.is-expanded ? Icons.chevron-down : Icons.chevron-right;
+                            colorize: Colors.overlay2;
+                            image-fit: contain;
+                        }
+                    }
+                    if !node.has-children: Rectangle { width: 14px; }
+
+                    // Key label
+                    if node.key != "": Text {
+                        text: node.key + ": ";
+                        color: Colors.subtext1;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+
+                    // JSON string (green)
+                    if node.node-kind == 2: Text {
+                        text: "\"" + node.value + "\"";
+                        color: Colors.green;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+
+                    // JSON number (blue)
+                    if node.node-kind == 3: Text {
+                        text: node.value;
+                        color: Colors.blue;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                    }
+
+                    // JSON boolean (yellow)
+                    if node.node-kind == 4: Text {
+                        text: node.value;
+                        color: Colors.yellow;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                    }
+
+                    // JSON null (grey)
+                    if node.node-kind == 5: Text {
+                        text: "null";
+                        color: Colors.overlay2;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                    }
+
+                    // JSON object/array — collapsed summary
+                    if (node.node-kind == 0 || node.node-kind == 1) && !node.is-expanded: Text {
+                        text: node.node-kind == 0
+                            ? "{ " + node.child-count + " }"
+                            : "[ " + node.child-count + " ]";
+                        color: Colors.overlay1;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                    }
+
+                    // XML element tag (<name>)
+                    if node.node-kind == 6: Text {
+                        text: "<" + node.value + ">";
+                        color: Colors.blue;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+
+                    // XML attribute (@key = "value")
+                    if node.node-kind == 7: Text {
+                        text: "= \"" + node.value + "\"";
+                        color: Colors.hl-param;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+
+                    // XML text node
+                    if node.node-kind == 8: Text {
+                        text: node.value;
+                        color: Colors.subtext0;
+                        font-size: Typography.size-sm;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
+
+                row-touch := TouchArea {
+                    x: 0; y: 0;
+                    width: parent.width;
+                    height: parent.height;
+                    clicked => {
+                        if (node.has-children) { root.toggle(node.path); }
+                    }
+                    pointer-event(event) => {
+                        if (event.button == PointerEventButton.right
+                                && event.kind == PointerEventKind.down) {
+                            root.ctx-path  = node.path;
+                            root.ctx-value = node.value;
+                            root.ctx-menu-x = clamp(
+                                self.mouse-x,
+                                0,
+                                root.width - 164px
+                            );
+                            root.ctx-menu-y = clamp(
+                                i * 22px - flick.viewport-y + self.mouse-y,
+                                0,
+                                root.height - 2 * Layout.height-menu-item
+                            );
+                            ctx-popup.show();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/globals.slint
+++ b/app/src/ui/globals.slint
@@ -115,3 +115,17 @@ export struct HistoryEntry {
     success:        bool,
     connection-id:  string,
 }
+
+/// One visible node in the cell-value tree viewer.
+/// node-kind: 0=json-object, 1=json-array, 2=json-string, 3=json-number,
+///            4=json-bool, 5=json-null, 6=xml-element, 7=xml-attr, 8=xml-text
+export struct TreeNode {
+    depth:        int,
+    key:          string,
+    value:        string,
+    node-kind:    int,
+    has-children: bool,
+    is-expanded:  bool,
+    child-count:  int,
+    path:         string,
+}

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -10,6 +10,7 @@ mod query;
 mod snippet;
 mod tabs;
 mod tabs_state;
+mod tree_viewer;
 mod undo;
 
 use std::cell::RefCell;
@@ -693,6 +694,7 @@ impl UI {
             Rc::clone(&tabs_state),
             Rc::clone(&undo_state),
         );
+        tree_viewer::register_callbacks(&window);
         metadata_search::register_metadata_search_callbacks(&window, Arc::clone(&sidebar_state));
         palette::register_command_palette_callbacks(
             &window,

--- a/app/src/ui/tree_viewer.rs
+++ b/app/src/ui/tree_viewer.rs
@@ -1,0 +1,473 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use slint::ComponentHandle;
+
+// ---------------------------------------------------------------------------
+// Internal tree representation
+// ---------------------------------------------------------------------------
+
+struct InternalNode {
+    key: String,
+    path: String,
+    kind: NodeKind,
+}
+
+enum NodeKind {
+    JsonObject(Vec<InternalNode>),
+    JsonArray(Vec<InternalNode>),
+    JsonString(String),
+    JsonNumber(String),
+    JsonBool(bool),
+    JsonNull,
+    XmlElement(Vec<InternalNode>),
+    XmlAttr(String),
+    XmlText(String),
+}
+
+struct TreeViewerState {
+    roots: Vec<InternalNode>,
+    collapsed: HashSet<String>,
+    mode: i32, // 1=json, 2=xml
+}
+
+// ---------------------------------------------------------------------------
+// JSON parsing
+// ---------------------------------------------------------------------------
+
+fn json_value_to_node(v: &serde_json::Value, key: String, path: String) -> InternalNode {
+    match v {
+        serde_json::Value::Object(map) => {
+            let children = map
+                .iter()
+                .map(|(k, child)| {
+                    let child_path = format!("{}.{}", path, k);
+                    json_value_to_node(child, k.clone(), child_path)
+                })
+                .collect();
+            InternalNode {
+                key,
+                path,
+                kind: NodeKind::JsonObject(children),
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            let children = arr
+                .iter()
+                .enumerate()
+                .map(|(i, child)| {
+                    let child_key = format!("[{i}]");
+                    let child_path = format!("{path}[{i}]");
+                    json_value_to_node(child, child_key, child_path)
+                })
+                .collect();
+            InternalNode {
+                key,
+                path,
+                kind: NodeKind::JsonArray(children),
+            }
+        }
+        serde_json::Value::String(s) => InternalNode {
+            key,
+            path,
+            kind: NodeKind::JsonString(s.clone()),
+        },
+        serde_json::Value::Number(n) => InternalNode {
+            key,
+            path,
+            kind: NodeKind::JsonNumber(n.to_string()),
+        },
+        serde_json::Value::Bool(b) => InternalNode {
+            key,
+            path,
+            kind: NodeKind::JsonBool(*b),
+        },
+        serde_json::Value::Null => InternalNode {
+            key,
+            path,
+            kind: NodeKind::JsonNull,
+        },
+    }
+}
+
+fn parse_json(text: &str) -> Option<TreeViewerState> {
+    let v: serde_json::Value = serde_json::from_str(text).ok()?;
+    // Only treat top-level objects/arrays as tree-viewable; primitives fall back to text.
+    match &v {
+        serde_json::Value::Object(_) | serde_json::Value::Array(_) => {}
+        _ => return None,
+    }
+    let root = json_value_to_node(&v, String::new(), String::new());
+    Some(TreeViewerState {
+        roots: vec![root],
+        collapsed: HashSet::new(),
+        mode: 1,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// XML parsing
+// ---------------------------------------------------------------------------
+
+fn parse_xml(text: &str) -> Option<TreeViewerState> {
+    use quick_xml::Reader;
+    use quick_xml::events::Event as XmlEvent;
+
+    let mut reader = Reader::from_str(text.trim());
+    reader.config_mut().trim_text(true);
+
+    // Stack: (tag_name, path, accumulated_children)
+    let mut stack: Vec<(String, String, Vec<InternalNode>)> = Vec::new();
+    // Counts siblings of the same tag name under a given parent path
+    let mut sibling_counts: std::collections::HashMap<String, usize> = Default::default();
+
+    loop {
+        match reader.read_event() {
+            Ok(XmlEvent::Start(e)) => {
+                let tag = std::str::from_utf8(e.name().as_ref()).ok()?.to_string();
+                let parent_path = stack.last().map(|(_, p, _)| p.as_str()).unwrap_or("");
+                let key = format!("{}/{}", parent_path, tag);
+                let idx = *sibling_counts.entry(key.clone()).or_insert(0);
+                sibling_counts.insert(key.clone(), idx + 1);
+                let path = format!("{}[{}]", key, idx);
+
+                let mut attr_nodes = Vec::new();
+                for attr in e.attributes().flatten() {
+                    let k = std::str::from_utf8(attr.key.as_ref()).ok()?.to_string();
+                    let v = std::str::from_utf8(&attr.value).ok()?.to_string();
+                    let attr_path = format!("{}/@{}", path, k);
+                    attr_nodes.push(InternalNode {
+                        key: format!("@{k}"),
+                        path: attr_path,
+                        kind: NodeKind::XmlAttr(v),
+                    });
+                }
+                stack.push((tag, path, attr_nodes));
+            }
+            // Self-closing tags like <item/> — emit as element with no children
+            Ok(XmlEvent::Empty(e)) => {
+                let tag = std::str::from_utf8(e.name().as_ref()).ok()?.to_string();
+                let parent_path = stack.last().map(|(_, p, _)| p.as_str()).unwrap_or("");
+                let key = format!("{}/{}", parent_path, tag);
+                let idx = *sibling_counts.entry(key.clone()).or_insert(0);
+                sibling_counts.insert(key.clone(), idx + 1);
+                let path = format!("{}[{}]", key, idx);
+
+                let mut attr_nodes = Vec::new();
+                for attr in e.attributes().flatten() {
+                    let k = std::str::from_utf8(attr.key.as_ref()).ok()?.to_string();
+                    let v = std::str::from_utf8(&attr.value).ok()?.to_string();
+                    let attr_path = format!("{}/@{}", path, k);
+                    attr_nodes.push(InternalNode {
+                        key: format!("@{k}"),
+                        path: attr_path,
+                        kind: NodeKind::XmlAttr(v),
+                    });
+                }
+                let node = InternalNode {
+                    key: tag,
+                    path: path.clone(),
+                    kind: NodeKind::XmlElement(attr_nodes),
+                };
+                if let Some((_, _, parent_children)) = stack.last_mut() {
+                    parent_children.push(node);
+                } else {
+                    // Root is a self-closing element
+                    return Some(TreeViewerState {
+                        roots: vec![node],
+                        collapsed: HashSet::new(),
+                        mode: 2,
+                    });
+                }
+            }
+            Ok(XmlEvent::End(_)) => {
+                let (tag, path, children) = stack.pop()?;
+                let node = InternalNode {
+                    key: tag,
+                    path: path.clone(),
+                    kind: NodeKind::XmlElement(children),
+                };
+                if let Some((_, _, parent_children)) = stack.last_mut() {
+                    parent_children.push(node);
+                } else {
+                    return Some(TreeViewerState {
+                        roots: vec![node],
+                        collapsed: HashSet::new(),
+                        mode: 2,
+                    });
+                }
+            }
+            Ok(XmlEvent::Text(e)) => {
+                // XML entities (e.g. &amp;) are not decoded — quick-xml 0.40 removed unescape()
+                let trimmed = String::from_utf8_lossy(e.as_ref()).trim().to_string();
+                if !trimmed.is_empty()
+                    && let Some((_, parent_path, children)) = stack.last_mut()
+                {
+                    let text_path = format!("{}/text()", parent_path);
+                    children.push(InternalNode {
+                        key: String::new(),
+                        path: text_path,
+                        kind: NodeKind::XmlText(trimmed),
+                    });
+                }
+            }
+            Ok(XmlEvent::Eof) | Err(_) => break,
+            _ => {}
+        }
+    }
+    // Malformed XML (unclosed tags) or no root element found
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Flatten tree → visible Slint nodes
+// ---------------------------------------------------------------------------
+
+fn flatten(
+    nodes: &[InternalNode],
+    collapsed: &HashSet<String>,
+    depth: i32,
+    result: &mut Vec<crate::TreeNode>,
+) {
+    for node in nodes {
+        let (node_kind, value, has_children, child_count, children_ref) = match &node.kind {
+            NodeKind::JsonObject(ch) => (
+                0i32,
+                String::new(),
+                !ch.is_empty(),
+                ch.len() as i32,
+                Some(ch.as_slice()),
+            ),
+            NodeKind::JsonArray(ch) => (
+                1i32,
+                String::new(),
+                !ch.is_empty(),
+                ch.len() as i32,
+                Some(ch.as_slice()),
+            ),
+            NodeKind::JsonString(s) => (2i32, s.clone(), false, 0, None),
+            NodeKind::JsonNumber(n) => (3i32, n.clone(), false, 0, None),
+            NodeKind::JsonBool(b) => (4i32, b.to_string(), false, 0, None),
+            NodeKind::JsonNull => (5i32, String::new(), false, 0, None),
+            NodeKind::XmlElement(ch) => (
+                6i32,
+                node.key.clone(),
+                !ch.is_empty(),
+                ch.len() as i32,
+                Some(ch.as_slice()),
+            ),
+            NodeKind::XmlAttr(v) => (7i32, v.clone(), false, 0, None),
+            NodeKind::XmlText(v) => (8i32, v.clone(), false, 0, None),
+        };
+
+        let is_expanded = !collapsed.contains(&node.path);
+
+        result.push(crate::TreeNode {
+            depth,
+            key: node.key.clone().into(),
+            value: value.into(),
+            node_kind,
+            has_children,
+            is_expanded: !has_children || is_expanded,
+            child_count,
+            path: node.path.clone().into(),
+        });
+
+        if has_children
+            && is_expanded
+            && let Some(ch) = children_ref
+        {
+            flatten(ch, collapsed, depth + 1, result);
+        }
+    }
+}
+
+fn build_flat_list(state: &TreeViewerState) -> Vec<crate::TreeNode> {
+    let mut result = Vec::new();
+    flatten(&state.roots, &state.collapsed, 0, &mut result);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Callback registration
+// ---------------------------------------------------------------------------
+
+pub(super) fn register_callbacks(window: &crate::AppWindow) {
+    let tree_state: Rc<RefCell<Option<TreeViewerState>>> = Rc::new(RefCell::new(None));
+
+    // ── cell-value-selected ─────────────────────────────────────────────────
+    {
+        let ww = window.as_weak(); // clone required: moved into callback closure
+        let state_ref = Rc::clone(&tree_state); // clone required: shared across callbacks
+        window
+            .global::<crate::UiState>()
+            .on_cell_value_selected(move |value| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let text = value.as_str();
+
+                let parsed = if text.is_empty() {
+                    None
+                } else {
+                    parse_json(text).or_else(|| parse_xml(text))
+                };
+
+                match parsed {
+                    Some(state) => {
+                        let flat = build_flat_list(&state);
+                        let mode = state.mode;
+                        *state_ref.borrow_mut() = Some(state);
+                        ui.set_cell_tree_nodes(Rc::new(slint::VecModel::from(flat)).into());
+                        ui.set_cell_preview_mode(mode);
+                    }
+                    None => {
+                        *state_ref.borrow_mut() = None;
+                        ui.set_cell_preview_mode(0);
+                    }
+                }
+            });
+    }
+
+    // ── cell-tree-node-toggle ───────────────────────────────────────────────
+    {
+        let ww = window.as_weak(); // clone required: moved into callback closure
+        let state_ref = Rc::clone(&tree_state); // clone required: shared across callbacks
+        window
+            .global::<crate::UiState>()
+            .on_cell_tree_node_toggle(move |path| {
+                let Some(w) = ww.upgrade() else { return };
+                let ui = w.global::<crate::UiState>();
+                let mut borrow = state_ref.borrow_mut();
+                let Some(state) = borrow.as_mut() else { return };
+
+                let path_str = path.to_string();
+                if state.collapsed.contains(&path_str) {
+                    state.collapsed.remove(&path_str);
+                } else {
+                    state.collapsed.insert(path_str);
+                }
+                let flat = build_flat_list(state);
+                ui.set_cell_tree_nodes(Rc::new(slint::VecModel::from(flat)).into());
+            });
+    }
+
+    // ── cell-copy-path ──────────────────────────────────────────────────────
+    {
+        let ww = window.as_weak(); // clone required: moved into callback closure
+        window
+            .global::<crate::UiState>()
+            .on_cell_copy_path(move |path| {
+                let Some(w) = ww.upgrade() else { return };
+                w.global::<crate::UiState>().invoke_copy_result_cell(path);
+            });
+    }
+
+    // ── cell-copy-node-value ────────────────────────────────────────────────
+    {
+        let ww = window.as_weak(); // clone required: moved into callback closure
+        window
+            .global::<crate::UiState>()
+            .on_cell_copy_node_value(move |value| {
+                let Some(w) = ww.upgrade() else { return };
+                w.global::<crate::UiState>().invoke_copy_result_cell(value);
+            });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_json_should_return_none_for_primitive_string() {
+        assert!(parse_json(r#""hello""#).is_none());
+    }
+
+    #[test]
+    fn parse_json_should_return_none_for_invalid_json() {
+        assert!(parse_json("{not json}").is_none());
+    }
+
+    #[test]
+    fn parse_json_should_parse_object() {
+        let state = parse_json(r#"{"name":"Alice","age":30}"#).unwrap();
+        assert_eq!(state.mode, 1);
+        assert_eq!(state.roots.len(), 1);
+        let NodeKind::JsonObject(children) = &state.roots[0].kind else {
+            panic!("not object")
+        };
+        assert_eq!(children.len(), 2);
+    }
+
+    #[test]
+    fn parse_json_should_parse_array() {
+        let state = parse_json(r#"[1,2,3]"#).unwrap();
+        assert_eq!(state.mode, 1);
+        let NodeKind::JsonArray(children) = &state.roots[0].kind else {
+            panic!("not array")
+        };
+        assert_eq!(children.len(), 3);
+    }
+
+    #[test]
+    fn flatten_should_produce_object_then_leaves() {
+        let state = parse_json(r#"{"x":1,"y":true}"#).unwrap();
+        let flat = build_flat_list(&state);
+        assert_eq!(flat.len(), 3); // root object + 2 leaves
+        assert_eq!(flat[0].node_kind, 0); // JsonObject
+        assert!(flat[0].has_children);
+        assert_eq!(flat[1].node_kind, 3); // JsonNumber
+        assert_eq!(flat[2].node_kind, 4); // JsonBool
+    }
+
+    #[test]
+    fn flatten_should_hide_children_when_collapsed() {
+        let mut state = parse_json(r#"{"x":1}"#).unwrap();
+        state.collapsed.insert(state.roots[0].path.clone());
+        let flat = build_flat_list(&state);
+        assert_eq!(flat.len(), 1); // only the root object (collapsed)
+        assert!(!flat[0].is_expanded);
+    }
+
+    #[test]
+    fn parse_xml_should_return_none_for_invalid_xml() {
+        assert!(parse_xml("<unclosed").is_none());
+    }
+
+    #[test]
+    fn parse_xml_should_parse_simple_element() {
+        let state = parse_xml("<root><child>text</child></root>").unwrap();
+        assert_eq!(state.mode, 2);
+        let flat = build_flat_list(&state);
+        // root element + child element + text node
+        assert_eq!(flat.len(), 3);
+        assert_eq!(flat[0].node_kind, 6); // XmlElement root
+        assert_eq!(flat[1].node_kind, 6); // XmlElement child
+        assert_eq!(flat[2].node_kind, 8); // XmlText
+    }
+
+    #[test]
+    fn parse_xml_should_include_attributes() {
+        let state = parse_xml(r#"<item id="1" name="foo"/>"#).unwrap();
+        let flat = build_flat_list(&state);
+        // element + 2 attrs
+        assert_eq!(flat.len(), 3);
+        assert_eq!(flat[1].node_kind, 7); // XmlAttr
+        assert_eq!(flat[2].node_kind, 7);
+    }
+
+    #[test]
+    fn path_should_use_dot_bracket_notation_for_json() {
+        let state = parse_json(r#"{"users":[{"id":1}]}"#).unwrap();
+        let flat = build_flat_list(&state);
+        // paths: "" (root obj) → ".users" (array) → ".users[0]" (obj) → ".users[0].id" (num)
+        assert_eq!(flat[1].path.as_str(), ".users");
+        assert_eq!(flat[2].path.as_str(), ".users[0]");
+        assert_eq!(flat[3].path.as_str(), ".users[0].id");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the JSON/XML tree viewer for the cell-value preview strip (bottom pane), addressing Issue #210. When a cell containing a JSON object/array or XML document is selected, the bottom pane switches from plain-text display to an interactive collapsible tree. Non-JSON/XML values continue to show the existing text preview unchanged.

## Changes

- `app/src/ui/components/tree_viewer.slint` — new `TreeViewer` component: scrollable flat-list tree with per-row expand/collapse and right-click context menu (Copy Path / Copy Value)
- `app/src/ui/tree_viewer.rs` — new module: JSON parse via `serde_json`, XML parse via `quick-xml` (stack-based, handles self-closing tags), `flatten()` to produce visible-node lists, four callback registrations
- `app/src/ui/globals.slint` — added `TreeNode` struct (depth, key, value, node-kind, has-children, is-expanded, child-count, path)
- `app/src/ui/app.slint` — UiState properties (`cell-tree-nodes`, `cell-preview-mode`, four callbacks), `_cell-value-alias` changed-handler to wire `ResultTable.selected-cell-value` → `UiState.cell-value-selected`, dynamic `preview-strip-h` (60 px text / 220 px tree), tree header bar with mode label and "View as Text" button
- `app/src/ui/mod.rs` — registered `tree_viewer::register_callbacks`
- `Cargo.toml` / `app/Cargo.toml` — added `quick-xml 0.40.1` workspace dependency
- 10 unit tests covering JSON/XML parse, flatten, collapse, and path notation

## Related Issues

Closes #210

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes