### PR TITLE
feat(ui): form view for single-record vertical layout in result table

### DIFF
--- a/app/assets/icons/chevron-left.svg
+++ b/app/assets/icons/chevron-left.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg fill="#000000" width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g transform="translate(24,0) scale(-1,1)"><path d="M9.64,6.231A1,1,0,0,0,8,7V17a1,1,0,0,0,.576.905A.989.989,0,0,0,9,18a1,1,0,0,0,.64-.231l6-5a1,1,0,0,0,0-1.538ZM10,14.865V9.135L13.438,12Z"/></g></svg>

--- a/app/lang/en/LC_MESSAGES/wellfeather.po
+++ b/app/lang/en/LC_MESSAGES/wellfeather.po
@@ -664,3 +664,19 @@ msgstr "Rename"
 msgctxt "Sidebar"
 msgid "Delete"
 msgstr "Delete"
+
+msgctxt "ResultTableToolbar"
+msgid "Form"
+msgstr "Form"
+
+msgctxt "FormView"
+msgid "No rows"
+msgstr "No rows"
+
+msgctxt "FormView"
+msgid "{0} / {1}"
+msgstr "{0} / {1}"
+
+msgctxt "FormView"
+msgid "Grid"
+msgstr "Grid"

--- a/app/lang/ja/LC_MESSAGES/wellfeather.po
+++ b/app/lang/ja/LC_MESSAGES/wellfeather.po
@@ -664,3 +664,19 @@ msgstr "名前変更"
 msgctxt "Sidebar"
 msgid "Delete"
 msgstr "削除"
+
+msgctxt "ResultTableToolbar"
+msgid "Form"
+msgstr "フォーム"
+
+msgctxt "FormView"
+msgid "No rows"
+msgstr "行なし"
+
+msgctxt "FormView"
+msgid "{0} / {1}"
+msgstr "{0} / {1}"
+
+msgctxt "FormView"
+msgid "Grid"
+msgstr "グリッド"

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -36,6 +36,7 @@ import { EditorPrefsDialog }     from "components/dialogs/editor_prefs_dialog.sl
 import { FingerprintDialog }    from "components/dialogs/fingerprint_dialog.slint";
 import { ParamDialog }          from "components/dialogs/param_dialog.slint";
 import { TreeViewer }           from "components/tree_viewer.slint";
+import { FormView }             from "components/form_view.slint";
 
 // UiState is defined here (root file) so that Slint generates Rust bindings for it.
 // Sub-components that need global state receive properties bound from UiState below.
@@ -497,6 +498,10 @@ export global UiState {
     callback sidebar-undo();
     /// Fired when Ctrl+Shift+Z is pressed while the sidebar has focus.
     callback sidebar-redo();
+
+    // ── Form view ─────────────────────────────────────────────────────────────
+    in-out property <bool> form-view-active:       false;
+    in-out property <int>  form-view-record-index: 0;
 }
 
 export component AppWindow inherits Window {
@@ -520,6 +525,10 @@ export component AppWindow inherits Window {
     property <bool> _reduce-motion-sync: UiState.reduce-motion;
     changed _reduce-motion-sync => { Animation.reduce-motion = UiState.reduce-motion; }
 
+    // Reset record index when query results change.
+    property <int> _form-row-count: UiState.result-rows.length;
+    changed _form-row-count => { UiState.form-view-record-index = 0; }
+
     // ── Layout geometry helpers ───────────────────────────────────────────────
     property <length> menu-bar-height:   Layout.height-bar;
     property <length> tab-bar-height:    Layout.height-tab-bar;
@@ -530,8 +539,9 @@ export component AppWindow inherits Window {
     // Width of the shared line-number gutter column.
     // Must match the gutter rectangle width defined in the container below.
     property <length> gutter-col-width:  48px;
-    // Preview strip height: taller in tree-view mode to accommodate expandable nodes.
-    property <length> preview-strip-h: UiState.cell-preview-mode != 0 ? 220px : 60px;
+    // Preview strip height: 0 in form view, taller in tree-view mode for expandable nodes.
+    property <length> preview-strip-h: UiState.form-view-active ? 0px
+        : (UiState.cell-preview-mode != 0 ? 220px : 60px);
 
     // ── Overlay panel geometry ────────────────────────────────────────────────
     // The result/error panel overlays the editor from the bottom (VSCode style).
@@ -1098,6 +1108,7 @@ export component AppWindow inherits Window {
 
                 // ── Result table content ──────────────────────────────────────
                 result-table-inst := ResultTable {
+                    visible: !UiState.form-view-active;
                     x: 0;
                     y: root.panel-header-height;
                     width:  parent.width;
@@ -1134,6 +1145,20 @@ export component AppWindow inherits Window {
                             UiState.update-page-size(n);
                         }
                     }
+                    form-view-active: UiState.form-view-active;
+                    toggle-form-view => { UiState.form-view-active = !UiState.form-view-active; }
+                }
+
+                // ── Form view ─────────────────────────────────────────────────
+                if UiState.form-view-active: FormView {
+                    x: 0;
+                    y: root.panel-header-height;
+                    width:  parent.width;
+                    height: root.panel-height - root.panel-header-height;
+                    columns: UiState.result-columns;
+                    rows:    UiState.result-rows;
+                    current-index <=> UiState.form-view-record-index;
+                    toggle-form-view => { UiState.form-view-active = false; }
                 }
 
                 // ── Cell-value preview strip ──────────────────────────────────

--- a/app/src/ui/components/form_view.slint
+++ b/app/src/ui/components/form_view.slint
@@ -1,0 +1,208 @@
+import { Colors, Typography, Layout, Icons } from "../theme.slint";
+import { RowData } from "../globals.slint";
+import { ToolbarButton } from "common.slint";
+
+export component FormView inherits Rectangle {
+    background: Colors.base;
+    clip: true;
+
+    in property <[string]>  columns:       [];
+    in property <[RowData]> rows:          [];
+    in-out property <int>   current-index: 0;
+
+    out property <bool> form-focused: form-scope.has-focus;
+    callback toggle-form-view();
+    public function grab-focus() { form-scope.focus(); }
+
+    header := Rectangle {
+        x: 0; y: 0;
+        width: parent.width;
+        height: Layout.height-bar;
+        background: Colors.mantle;
+
+        Rectangle {
+            x: 0; y: parent.height - 1px;
+            width: parent.width; height: 1px;
+            background: Colors.surface0;
+        }
+
+        HorizontalLayout {
+            x: 8px;
+            y: (parent.height - self.height) / 2;
+            width: parent.width - 16px;
+            height: Layout.height-btn-sm;
+            spacing: 4px;
+            alignment: start;
+
+            Rectangle {
+                width: 22px;
+                height: 22px;
+                border-radius: Layout.radius-sm;
+                background: prev-ta.has-hover && root.current-index > 0
+                    ? Colors.surface1 : transparent;
+
+                Image {
+                    width: 10px; height: 10px;
+                    x: (parent.width - self.width) / 2;
+                    y: (parent.height - self.height) / 2;
+                    source: Icons.chevron-left;
+                    colorize: root.current-index > 0 ? Colors.overlay2 : Colors.surface2;
+                    image-fit: contain;
+                }
+
+                prev-ta := TouchArea {
+                    clicked => {
+                        form-scope.focus();
+                        if (root.current-index > 0) { root.current-index -= 1; }
+                    }
+                }
+            }
+
+            Text {
+                text: root.rows.length == 0
+                    ? @tr("No rows")
+                    : @tr("{0} / {1}", root.current-index + 1, root.rows.length);
+                color: Colors.subtext1;
+                font-size: Typography.size-sm;
+                vertical-alignment: center;
+                min-width: 60px;
+            }
+
+            Rectangle {
+                width: 22px;
+                height: 22px;
+                border-radius: Layout.radius-sm;
+                background: next-ta.has-hover
+                        && root.current-index < root.rows.length - 1
+                    ? Colors.surface1 : transparent;
+
+                Image {
+                    width: 10px; height: 10px;
+                    x: (parent.width - self.width) / 2;
+                    y: (parent.height - self.height) / 2;
+                    source: Icons.chevron-right;
+                    colorize: root.current-index < root.rows.length - 1
+                        ? Colors.overlay2 : Colors.surface2;
+                    image-fit: contain;
+                }
+
+                next-ta := TouchArea {
+                    clicked => {
+                        form-scope.focus();
+                        if (root.current-index < root.rows.length - 1) {
+                            root.current-index += 1;
+                        }
+                    }
+                }
+            }
+
+            Rectangle { horizontal-stretch: 1; }
+
+            ToolbarButton {
+                width: 80px;
+                text: @tr("Grid");
+                clicked => { root.toggle-form-view(); }
+            }
+        }
+    }
+
+    form-scope := FocusScope {
+        x: 0;
+        y: header.height;
+        width: parent.width;
+        height: parent.height - header.height;
+
+        capture-key-pressed(event) => {
+            if (event.modifiers.alt && event.text == Key.UpArrow) {
+                if (root.current-index > 0) { root.current-index -= 1; }
+                return EventResult.accept;
+            }
+            if (event.modifiers.alt && event.text == Key.DownArrow) {
+                if (root.current-index < root.rows.length - 1) {
+                    root.current-index += 1;
+                }
+                return EventResult.accept;
+            }
+            EventResult.reject
+        }
+
+        flick := Flickable {
+            x: 0; y: 0;
+            width: parent.width;
+            height: parent.height;
+            viewport-height: body.preferred-height;
+
+            body := VerticalLayout {
+                spacing: 0;
+                alignment: start;
+
+                for col-name[i] in root.columns: Rectangle {
+                    property <string> cell-value:
+                        (root.rows.length > 0
+                            && root.current-index >= 0
+                            && root.current-index < root.rows.length)
+                        ? root.rows[root.current-index].cells[i].value
+                        : "";
+                    property <bool> cell-is-null:
+                        (root.rows.length > 0
+                            && root.current-index >= 0
+                            && root.current-index < root.rows.length)
+                        ? root.rows[root.current-index].cells[i].is-null
+                        : false;
+
+                    height: max(32px, val-text.preferred-height + 8px);
+
+                    Rectangle {
+                        x: 0; y: parent.height - 1px;
+                        width: parent.width; height: 1px;
+                        background: Colors.surface0;
+                    }
+
+                    HorizontalLayout {
+                        x: 0; y: 0;
+                        width: parent.width;
+                        height: parent.height;
+                        spacing: 0;
+
+                        Rectangle {
+                            width: 160px;
+                            height: parent.height;
+                            background: Colors.mantle;
+
+                            Text {
+                                x: 8px;
+                                y: (parent.height - self.preferred-height) / 2;
+                                width: parent.width - 16px;
+                                text: col-name;
+                                color: Colors.subtext1;
+                                font-size: Typography.size-sm;
+                                wrap: no-wrap;
+                                overflow: elide;
+                            }
+
+                            Rectangle {
+                                x: parent.width - 1px; y: 0;
+                                width: 1px; height: parent.height;
+                                background: Colors.surface0;
+                            }
+                        }
+
+                        Rectangle {
+                            height: parent.height;
+
+                            val-text := Text {
+                                x: 8px;
+                                y: 4px;
+                                width: parent.width - 16px;
+                                text: cell-is-null ? "NULL" : cell-value;
+                                color: cell-is-null ? Colors.overlay1 : Colors.text;
+                                font-size: Typography.size-sm;
+                                wrap: word-wrap;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/ui/components/result_table.slint
+++ b/app/src/ui/components/result_table.slint
@@ -25,6 +25,8 @@ export component ResultTable inherits Rectangle {
     in property <bool>      sort-asc:        true;
     in property <string>    font-family:     "JetBrains Mono";
     in property <int>       font-size-px:    12;
+    in property <bool> form-view-active: false;
+    callback toggle-form-view();
     callback resize-column(int, float);
     callback filter-rows(string);
     callback clear-filter();
@@ -60,14 +62,16 @@ export component ResultTable inherits Rectangle {
         height: root.height - root.bottom-total;
 
         toolbar-inst := ResultTableToolbar {
-            col-count:  root.columns.length;
-            row-count:  root.row-count;
-            total-rows: root.total-rows;
-            page-size:  root.page-size;
+            col-count:       root.columns.length;
+            row-count:       root.row-count;
+            total-rows:      root.total-rows;
+            page-size:       root.page-size;
+            form-view-active: root.form-view-active;
             change-page-size(n) => { root.change-page-size(n); }
             export-csv        => { root.export-csv(); }
             export-json       => { root.export-json(); }
             export-insert-sql => { root.export-insert-sql(); }
+            toggle-form-view  => { root.toggle-form-view(); }
         }
 
         header-inst := ResultTableHeader {

--- a/app/src/ui/components/result_table_toolbar.slint
+++ b/app/src/ui/components/result_table_toolbar.slint
@@ -7,15 +7,17 @@ export component ResultTableToolbar inherits Rectangle {
     background: Colors.mantle;
     clip: true;
 
-    in property <int> col-count:  0;
-    in property <int> row-count:  0;
-    in property <int> total-rows: 0;
-    in property <int> page-size:  500;
+    in property <int>  col-count:       0;
+    in property <int>  row-count:       0;
+    in property <int>  total-rows:      0;
+    in property <int>  page-size:       500;
+    in property <bool> form-view-active: false;
 
     callback change-page-size(int);
     callback export-csv();
     callback export-json();
     callback export-insert-sql();
+    callback toggle-form-view();
 
     Rectangle {
         x: 0; y: parent.height - 1px;
@@ -31,6 +33,14 @@ export component ResultTableToolbar inherits Rectangle {
             : @tr("{0} rows", root.row-count);
         color: Colors.surface2;
         font-size: Typography.size-md;
+    }
+
+    if root.col-count > 0: ToolbarButton {
+        x: parent.width - 356px;
+        y: (parent.height - self.height) / 2;
+        width: 80px;
+        text: @tr("Form");
+        clicked => { root.toggle-form-view(); }
     }
 
     if root.col-count > 0: ToolbarButton {

--- a/app/src/ui/query.rs
+++ b/app/src/ui/query.rs
@@ -490,6 +490,7 @@ pub(super) fn register_result_callbacks(
                 let rows: Vec<crate::RowData> =
                     filtered.into_iter().map(|r| rows_to_ui(r)).collect();
                 ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+                ui.set_form_view_record_index(0);
                 ui.set_result_row_count(row_count);
                 ui.set_result_active_filter(query);
             });
@@ -515,6 +516,7 @@ pub(super) fn register_result_callbacks(
                 let ui_rows: Vec<crate::RowData> =
                     rows.into_iter().map(|r| rows_to_ui(r)).collect();
                 ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
+                ui.set_form_view_record_index(0);
                 ui.set_result_row_count(row_count);
                 ui.set_result_active_filter("".into());
             });
@@ -726,6 +728,7 @@ pub(super) fn register_result_callbacks(
                     (new_col, new_asc, row_count, ui_rows)
                 };
                 ui.set_result_rows(Rc::new(slint::VecModel::from(ui_rows)).into());
+                ui.set_form_view_record_index(0);
                 ui.set_result_row_count(row_count);
                 ui.set_result_sort_col(new_col.map(|c| c as i32).unwrap_or(-1));
                 ui.set_result_sort_asc(new_asc);
@@ -766,6 +769,7 @@ pub(super) fn handle_query_finished(
             ui.set_result_columns(col_model.into());
             let rows: Vec<crate::RowData> = raw_rows.iter().map(|r| rows_to_ui(r)).collect();
             ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+            ui.set_form_view_record_index(0);
             ui.set_result_row_count(row_count);
             ui.set_result_total_rows(row_count);
             let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
@@ -811,6 +815,7 @@ pub(super) fn handle_table_data_loaded(
             ui.set_result_columns(col_model.into());
             let rows: Vec<crate::RowData> = raw_rows.iter().map(|r| rows_to_ui(r)).collect();
             ui.set_result_rows(Rc::new(slint::VecModel::from(rows)).into());
+            ui.set_form_view_record_index(0);
             ui.set_result_row_count(row_count);
             let widths: Vec<f32> = vec![DEFAULT_COLUMN_WIDTH; col_count];
             let total_w = col_count as f32 * DEFAULT_COLUMN_WIDTH;

--- a/app/src/ui/theme.slint
+++ b/app/src/ui/theme.slint
@@ -146,6 +146,7 @@ export global Icons {
     out property <image> brand-postgresql: @image-url("../../assets/icons/brand-postgresql.svg");
     out property <image> brand-sqlite:     @image-url("../../assets/icons/brand-sqlite.svg");
     out property <image> chevron-down:     @image-url("../../assets/icons/chevron-down.svg");
+    out property <image> chevron-left:     @image-url("../../assets/icons/chevron-left.svg");
     out property <image> chevron-right:    @image-url("../../assets/icons/chevron-right.svg");
     out property <image> folder:           @image-url("../../assets/icons/folder.svg");
     out property <image> close:            @image-url("../../assets/icons/close.svg");


### PR DESCRIPTION
## Summary

Adds a form view to the result table that displays one record at a time as column/value pairs, useful for wide tables or inspecting individual rows. Users can navigate between records using ← → buttons or Alt+↑/↓ keyboard shortcuts. The implementation is purely Slint UI state with no Rust changes to the service layer.

## Changes

- `app/src/ui/components/form_view.slint` (new): FormView component with header bar (← N/M → navigation, Grid toggle button), FocusScope with `capture-key-pressed` for Alt+↑/↓, and a Flickable body rendering column/value rows
- `app/assets/icons/chevron-left.svg` (new): horizontally mirrored chevron-right for the prev-record button
- `app/src/ui/theme.slint`: added `chevron-left` icon
- `app/src/ui/components/result_table_toolbar.slint`: added Form toggle button; toolbar is hidden while form view is active
- `app/src/ui/components/result_table.slint`: pass-through `form-view-active` and `toggle-form-view` callback
- `app/src/ui/app.slint`: `form-view-active` and `form-view-record-index` in UiState; `if` conditional for FormView instance; `preview-strip-h` collapses to 0px in form view; `_form-row-count` binding resets record index on new results
- `app/src/ui/query.rs`: explicit `set_form_view_record_index(0)` alongside every `set_result_rows` call (filter, clear-filter, sort, QueryFinished, table-data-loaded)
- `app/lang/en/` and `app/lang/ja/`: added `FormView/{0} / {1}` and `ResultTableToolbar/Form` i18n entries

## Related Issues

Closes #211

## Test Plan

- [x] `just ci` passes (fmt-check, clippy, build, test)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes